### PR TITLE
fix: resolve "browser" field when "exports" is present

### DIFF
--- a/fixtures/enhanced_resolve/test/fixtures/browser-module/package.json
+++ b/fixtures/enhanced_resolve/test/fixtures/browser-module/package.json
@@ -1,4 +1,6 @@
 {
+  "exports": {
+  },
   "browser": {
     "./lib/ignore.js": false,
     "./lib/replaced.js": "./lib/browser",

--- a/fixtures/pnpm8/package.json
+++ b/fixtures/pnpm8/package.json
@@ -8,6 +8,7 @@
   "packageManager": "pnpm@8.10.5",
   "devDependencies": {
     "axios": "1.6.2",
-    "styled-components": "6.1.1"
+    "styled-components": "6.1.1",
+    "postcss": "8.4.33"
   }
 }

--- a/fixtures/pnpm8/pnpm-lock.yaml
+++ b/fixtures/pnpm8/pnpm-lock.yaml
@@ -8,6 +8,9 @@ devDependencies:
   axios:
     specifier: 1.6.2
     version: 1.6.2
+  postcss:
+    specifier: 8.4.33
+    version: 8.4.33
   styled-components:
     specifier: 6.1.1
     version: 6.1.1(react-dom@18.2.0)(react@18.2.0)
@@ -135,8 +138,8 @@ packages:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
-  /postcss@8.4.32:
-    resolution: {integrity: sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==}
+  /postcss@8.4.33:
+    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7
@@ -192,7 +195,7 @@ packages:
       '@types/stylis': 4.2.4
       css-to-react-native: 3.2.0
       csstype: 3.1.2
-      postcss: 8.4.32
+      postcss: 8.4.33
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       shallowequal: 1.1.0

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -9,7 +9,7 @@ test       = false
 doctest    = false
 
 [dependencies]
-oxc_resolver = { path = "../../oxc_resolver" }
+oxc_resolver = { path = ".." }
 napi         = { version = "2", default-features = false, features = ["napi3", "serde-json"] }
 napi-derive  = { version = "2" }
 


### PR DESCRIPTION
closes #58

Failed to resolve `path` in browser mode for `postcss` when

```
"exports": {
  ...
}

"browser": {
    "./lib/terminal-highlight": false,
    "source-map-js": false,
    "path": false,
    "url": false,
    "fs": false
  },
```

Are both present

There are no such test cases for this type of combination in enhanced_resolve.