### PR TITLE
Update README.md passing "require" instead of "import" to CJS resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ const esmResolver = ResolverFactory({
 });
 
 const cjsResolver = esmResolver.cloneWithOptions({
-  conditionNames: ["node", "import"]
+  conditionNames: ["node", "require"]
 });
 ```
 


### PR DESCRIPTION
Going over the readme, I discovered what I suspect is a simple copy-paste error.