### PR TITLE
refactor: selectively parse package_json fields instead of parsing everything

### DIFF
--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -157,7 +157,6 @@ impl ResolverFactory {
                 .unwrap_or(default.roots),
             symlinks: op.symlinks.unwrap_or(default.symlinks),
             builtin_modules: op.builtin_modules.unwrap_or(default.builtin_modules),
-            remove_unused_fields: op.remove_unused_fields.unwrap_or(default.remove_unused_fields),
         }
     }
 }

--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -141,10 +141,6 @@ pub struct NapiResolveOptions {
     ///
     /// Default `false`
     pub builtin_modules: Option<bool>,
-
-    /// When enabled, will attempt to reduce memory usage by clearing data and fields
-    /// that are not relevant to the current process, and should not be held in memory.
-    pub remove_unused_fields: Option<bool>,
 }
 
 #[napi]

--- a/src/options.rs
+++ b/src/options.rs
@@ -133,10 +133,6 @@ pub struct ResolveOptions {
     ///
     /// Default `false`
     pub builtin_modules: bool,
-
-    /// When enabled, will attempt to reduce memory usage by clearing data and fields
-    /// that are not relevant to the current process, and should not be held in memory.
-    pub remove_unused_fields: bool,
 }
 
 impl ResolveOptions {
@@ -377,7 +373,6 @@ impl Default for ResolveOptions {
             roots: vec![],
             symlinks: true,
             builtin_modules: false,
-            remove_unused_fields: true,
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -35,11 +35,9 @@ fn eq() {
 #[test]
 fn package_json() {
     let resolution = resolve("./tests/package.json");
-    assert!(resolution.package_json().is_some_and(|json| json
-        .data
-        .name
-        .as_ref()
-        .is_some_and(|name| name == "name")));
+    assert!(resolution
+        .package_json()
+        .is_some_and(|json| json.name.as_ref().is_some_and(|name| name == "name")));
 }
 
 #[test]


### PR DESCRIPTION
so we don't end up parsing unwanted fields and produce errors we don't
care about.