### PR TITLE
feat: add more builder functions for options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm
       - uses: ./.github/actions/rustup
-      - run:
+      - run: |
           cargo test --all-features
           cargo test --doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm
       - uses: ./.github/actions/rustup
-      - run: 
+      - run:
           cargo test --all-features
-          cargo t --doc
+          cargo test --doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,4 +217,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm
       - uses: ./.github/actions/rustup
-      - run: cargo test --all-features
+      - run: 
+          cargo test --all-features
+          cargo t --doc

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -60,7 +60,7 @@ fn data() -> Vec<(PathBuf, &'static str)> {
 
 fn oxc_resolver() -> oxc_resolver::Resolver {
     use oxc_resolver::{AliasValue, ResolveOptions, Resolver};
-    let alias_value = AliasValue::Path("./".into());
+    let alias_value = AliasValue::from("./");
     Resolver::new(ResolveOptions {
         extensions: vec![".ts".into(), ".js".into()],
         condition_names: vec!["webpack".into()],

--- a/examples/resolver.rs
+++ b/examples/resolver.rs
@@ -13,7 +13,7 @@ fn main() {
 
     let options = ResolveOptions {
         alias_fields: vec![vec!["browser".into()]],
-        alias: vec![("asdf".into(), vec![AliasValue::Path("./test.js".into())])],
+        alias: vec![("asdf".into(), vec![AliasValue::from("./test.js")])],
         ..ResolveOptions::default()
     };
 

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -86,7 +86,7 @@ impl ResolverFactory {
                             let v = v
                                 .into_iter()
                                 .map(|item| match item {
-                                    Some(path) => oxc_resolver::AliasValue::Path(path),
+                                    Some(path) => oxc_resolver::AliasValue::from(path),
                                     None => oxc_resolver::AliasValue::Ignore,
                                 })
                                 .collect();
@@ -123,7 +123,7 @@ impl ResolverFactory {
                             let v = v
                                 .into_iter()
                                 .map(|item| match item {
-                                    Some(path) => oxc_resolver::AliasValue::Path(path),
+                                    Some(path) => oxc_resolver::AliasValue::from(path),
                                     None => oxc_resolver::AliasValue::Ignore,
                                 })
                                 .collect();

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -165,10 +165,7 @@ fn absolute_path() {
 fn system_path() {
     let f = super::fixture();
     let resolver = Resolver::new(ResolveOptions {
-        alias: vec![(
-            "@app".into(),
-            vec![AliasValue::from(f.join("alias").to_string_lossy())],
-        )],
+        alias: vec![("@app".into(), vec![AliasValue::from(f.join("alias").to_string_lossy())])],
         ..ResolveOptions::default()
     });
 

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -35,30 +35,30 @@ fn alias() {
         file_system,
         ResolveOptions {
             alias: vec![
-                ("aliasA".into(), vec![AliasValue::Path("a".into())]),
-                ("b$".into(), vec![AliasValue::Path("a/index".into())]),
-                ("c$".into(), vec![AliasValue::Path("/a/index".into())]),
+                ("aliasA".into(), vec![AliasValue::from("a")]),
+                ("b$".into(), vec![AliasValue::from("a/index")]),
+                ("c$".into(), vec![AliasValue::from("/a/index")]),
                 (
                     "multiAlias".into(),
                     vec![
-                        AliasValue::Path("b".into()),
-                        AliasValue::Path("c".into()),
-                        AliasValue::Path("d".into()),
-                        AliasValue::Path("e".into()),
-                        AliasValue::Path("a".into()),
+                        AliasValue::from("b"),
+                        AliasValue::from("c"),
+                        AliasValue::from("d"),
+                        AliasValue::from("e"),
+                        AliasValue::from("a"),
                     ],
                 ),
-                ("recursive".into(), vec![AliasValue::Path("recursive/dir".into())]),
-                ("/d/dir".into(), vec![AliasValue::Path("/c/dir".into())]),
-                ("/d/index.js".into(), vec![AliasValue::Path("/c/index".into())]),
-                ("#".into(), vec![AliasValue::Path("/c/dir".into())]),
-                ("@".into(), vec![AliasValue::Path("/c/dir".into())]),
+                ("recursive".into(), vec![AliasValue::from("recursive/dir")]),
+                ("/d/dir".into(), vec![AliasValue::from("/c/dir")]),
+                ("/d/index.js".into(), vec![AliasValue::from("/c/index")]),
+                ("#".into(), vec![AliasValue::from("/c/dir")]),
+                ("@".into(), vec![AliasValue::from("/c/dir")]),
                 ("ignored".into(), vec![AliasValue::Ignore]),
                 // not part of enhanced-resolve, added to make sure query in alias value works
-                ("alias_query".into(), vec![AliasValue::Path("a?query_after".into())]),
-                ("alias_fragment".into(), vec![AliasValue::Path("a#fragment_after".into())]),
+                ("alias_query".into(), vec![AliasValue::from("a?query_after")]),
+                ("alias_fragment".into(), vec![AliasValue::from("a#fragment_after")]),
                 ("dash".into(), vec![AliasValue::Ignore]),
-                ("@scope/package-name/file$".into(), vec![AliasValue::Path("/c/dir".into())]),
+                ("@scope/package-name/file$".into(), vec![AliasValue::from("/c/dir")]),
             ],
             modules: vec!["/".into()],
             ..ResolveOptions::default()
@@ -126,8 +126,8 @@ fn infinite_recursion() {
     let f = super::fixture();
     let resolver = Resolver::new(ResolveOptions {
         alias: vec![
-            ("./a".into(), vec![AliasValue::Path("./b".into())]),
-            ("./b".into(), vec![AliasValue::Path("./a".into())]),
+            ("./a".into(), vec![AliasValue::from("./b")]),
+            ("./b".into(), vec![AliasValue::from("./a")]),
         ],
         ..ResolveOptions::default()
     });
@@ -167,7 +167,7 @@ fn system_path() {
     let resolver = Resolver::new(ResolveOptions {
         alias: vec![(
             "@app".into(),
-            vec![AliasValue::Path(f.join("alias").to_string_lossy().to_string())],
+            vec![AliasValue::from(f.join("alias").to_string_lossy())],
         )],
         ..ResolveOptions::default()
     });

--- a/src/tests/browser_field.rs
+++ b/src/tests/browser_field.rs
@@ -122,7 +122,7 @@ fn crypto_js() {
         alias_fields: vec![vec!["browser".into()]],
         fallback: vec![(
             "crypto".into(),
-            vec![AliasValue::Path(f.join("lib.js").to_string_lossy().to_string())],
+            vec![AliasValue::from(f.join("lib.js").to_string_lossy())],
         )],
         ..ResolveOptions::default()
     });

--- a/src/tests/full_specified.rs
+++ b/src/tests/full_specified.rs
@@ -33,8 +33,8 @@ mod windows {
             file_system,
             ResolveOptions {
                 alias: vec![
-                    ("alias1".into(), vec![AliasValue::Path("/a/abc".into())]),
-                    ("alias2".into(), vec![AliasValue::Path("/a".into())]),
+                    ("alias1".into(), vec![AliasValue::from("/a/abc")]),
+                    ("alias2".into(), vec![AliasValue::from("/a")]),
                 ],
                 alias_fields: vec![vec!["browser".into()]],
                 fully_specified: true,
@@ -84,8 +84,8 @@ mod windows {
             file_system,
             ResolveOptions {
                 alias: vec![
-                    ("alias1".into(), vec![AliasValue::Path("/a/abc".into())]),
-                    ("alias2".into(), vec![AliasValue::Path("/a".into())]),
+                    ("alias1".into(), vec![AliasValue::from("/a/abc")]),
+                    ("alias2".into(), vec![AliasValue::from("/a")]),
                 ],
                 alias_fields: vec![vec!["browser".into()]],
                 fully_specified: true,

--- a/src/tests/roots.rs
+++ b/src/tests/roots.rs
@@ -14,7 +14,7 @@ fn roots() {
 
     let resolver = Resolver::new(ResolveOptions {
         extensions: vec![".js".into()],
-        alias: vec![("foo".into(), vec![AliasValue::Path("/fixtures".into())])],
+        alias: vec![("foo".into(), vec![AliasValue::from("/fixtures")])],
         roots: vec![dirname(), f.clone()],
         ..ResolveOptions::default()
     });
@@ -62,7 +62,7 @@ fn prefer_absolute() {
     let f = super::fixture();
     let resolver = Resolver::new(ResolveOptions {
         extensions: vec![".js".into()],
-        alias: vec![("foo".into(), vec![AliasValue::Path("/fixtures".into())])],
+        alias: vec![("foo".into(), vec![AliasValue::from("/fixtures")])],
         roots: vec![dirname(), f.clone()],
         prefer_absolute: true,
         ..ResolveOptions::default()


### PR DESCRIPTION
## Changes

- moved `sanitize` in the first `impl` block, so we don't have two `impl` of the same struct
- we have doctects which didn't run in the CI, this PR changes the workflow to add `cargo t --doc`. By default `cargo test` doesn't run doctests
- added three new builder functions for `ResolverOptions`
- made functions of `EnforceExtension` const functions
- implemented `From` for `AliasValue` and updated its usage in the tests. Less typing :)

## Test plan

Added some doc tests, which pass locally. CI should pass