### PR TITLE
feat: allow `Resolver<Box<dyn FileSystem>>` by removing unnecessary `Default` constraint

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -26,7 +26,7 @@ pub struct Cache<Fs> {
 
 impl<Fs: FileSystem> Cache<Fs> {
     pub fn new(fs: Fs) -> Self {
-        Self { fs, paths: Default::default(), tsconfigs: Default::default()}
+        Self { fs, paths: DashSet::default(), tsconfigs: DashMap::default() }
     }
 
     pub fn clear(&self) {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -24,9 +24,9 @@ pub struct Cache<Fs> {
     tsconfigs: DashMap<PathBuf, Arc<TsConfig>, BuildHasherDefault<FxHasher>>,
 }
 
-impl<Fs: FileSystem + Default> Cache<Fs> {
+impl<Fs: FileSystem> Cache<Fs> {
     pub fn new(fs: Fs) -> Self {
-        Self { fs, ..Self::default() }
+        Self { fs, paths: Default::default(), tsconfigs: Default::default()}
     }
 
     pub fn clear(&self) {
@@ -220,7 +220,7 @@ impl CachedPathImpl {
             .map(|r| r.unwrap_or_else(|| self.path.clone().to_path_buf()))
     }
 
-    pub fn module_directory<Fs: FileSystem + Default>(
+    pub fn module_directory<Fs: FileSystem>(
         &self,
         module_name: &str,
         cache: &Cache<Fs>,
@@ -230,7 +230,7 @@ impl CachedPathImpl {
         cached_path.is_dir(&cache.fs, ctx).then(|| cached_path)
     }
 
-    pub fn cached_node_modules<Fs: FileSystem + Default>(
+    pub fn cached_node_modules<Fs: FileSystem>(
         &self,
         cache: &Cache<Fs>,
         ctx: &mut Ctx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
 
 impl<Fs: FileSystem> ResolverGeneric<Fs> {
     pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
-        Self { cache: Arc::new(Cache::new(file_system)), options: options.sanitize()}
+        Self { cache: Arc::new(Cache::new(file_system)), options: options.sanitize() }
     }
 
     /// Clone the resolver using the same underlying cache.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,13 @@ impl<Fs: FileSystem + Default> Default for ResolverGeneric<Fs> {
 
 impl<Fs: FileSystem + Default> ResolverGeneric<Fs> {
     pub fn new(options: ResolveOptions) -> Self {
-        Self { options: options.sanitize(), cache: Arc::new(Cache::default()) }
+        Self { options: options.sanitize(), cache: Arc::new(Cache::new(Fs::default())) }
     }
+}
 
+impl<Fs: FileSystem> ResolverGeneric<Fs> {
     pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
-        Self { cache: Arc::new(Cache::new(file_system)), ..Self::new(options) }
+        Self { cache: Arc::new(Cache::new(file_system)), options: options.sanitize()}
     }
 
     /// Clone the resolver using the same underlying cache.


### PR DESCRIPTION
- I want hide generics of `Resolver` using `Box<dyn ...>`. And trait object require object-safey.
- `ResolverGeneric<Box<dyn FileSystem>>` is valid, but these `impl`s require `Default`. This makes `ResolverGeneric<Box<dyn FileSystem>>` totally unusable.
- `ResolverGeneric<Box<dyn FileSystem + Default>>` is not valid because `Default` trait doesn't satisfy object-safety.

---

- Changes of this PR is backforwarded.