### PR TITLE
fix: incorrect resolution when using shared resolvers with different `main_fields`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,7 +515,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 cached_path.package_json(&self.cache.fs, &self.options, ctx)?
             {
                 // b. If "main" is a falsy value, GOTO 2.
-                for main_field in &package_json.main_fields {
+                for main_field in package_json.main_fields(&self.options.main_fields) {
                     // c. let M = X + (json main field)
                     let main_field_path = cached_path.path().normalize_with(main_field);
                     // d. LOAD_AS_FILE(M)
@@ -1149,7 +1149,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                         // 6. Otherwise, if packageSubpath is equal to ".", then
                         if subpath == "." {
                             // 1. If pjson.main is a string, then
-                            for main_field in &package_json.main_fields {
+                            for main_field in package_json.main_fields(&self.options.main_fields) {
                                 // 1. Return the URL resolution of main in packageURL.
                                 let path = cached_path.path().normalize_with(main_field);
                                 let cached_path = self.cache.value(&path);

--- a/src/tests/main_field.rs
+++ b/src/tests/main_field.rs
@@ -6,19 +6,19 @@ use crate::{ResolveOptions, Resolver};
 fn test() {
     let f = super::fixture().join("restrictions");
 
-    let resolver = Resolver::new(ResolveOptions {
+    let resolver1 = Resolver::new(ResolveOptions {
         main_fields: vec!["style".into()],
         ..ResolveOptions::default()
     });
 
-    let resolution = resolver.resolve(&f, "pck2").map(|r| r.full_path());
+    let resolution = resolver1.resolve(&f, "pck2").map(|r| r.full_path());
     assert_eq!(resolution, Ok(f.join("node_modules/pck2/index.css")));
 
-    let resolver = Resolver::new(ResolveOptions {
+    let resolver2 = resolver1.clone_with_options(ResolveOptions {
         main_fields: vec!["module".into(), "main".into()],
         ..ResolveOptions::default()
     });
 
-    let resolution = resolver.resolve(&f, "pck2").map(|r| r.full_path());
+    let resolution = resolver2.resolve(&f, "pck2").map(|r| r.full_path());
     assert_eq!(resolution, Ok(f.join("node_modules/pck2/module.js")));
 }


### PR DESCRIPTION
The modified test case

```rust
fn test() {
    let f = super::fixture().join("restrictions");

    let resolver1 = Resolver::new(ResolveOptions {
        main_fields: vec!["style".into()],
        ..ResolveOptions::default()
    });

    let resolution = resolver1.resolve(&f, "pck2").map(|r| r.full_path());
    assert_eq!(resolution, Ok(f.join("node_modules/pck2/index.css")));

    let resolver2 = resolver1.clone_with_options(ResolveOptions {
        main_fields: vec!["module".into(), "main".into()],
        ..ResolveOptions::default()
    });

    let resolution = resolver2.resolve(&f, "pck2").map(|r| r.full_path());
    assert_eq!(resolution, Ok(f.join("node_modules/pck2/module.js")));
}
```

failed to revolve due to package.json caching the value of `main_fields: vec!["style".into()]`, the second resolution `main_fields: vec!["module".into(), "main".into()]` would yield nothing because package.json#mainFields still holds the value of "style".

This PR changes caching the options to retrieving the values dynamically. I need to continue the work on all the other fields in https://github.com/oxc-project/oxc-resolver/issues/135

But I need to hotfix the `main_fields` change first for Rspack.