### PR TITLE
feat: substitute path that starts with `${configDir}/` in tsconfig.compilerOptions.paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Rust port of [enhanced-resolve].
   * support extending tsconfig defined in `tsconfig.extends`
   * support paths alias defined in `tsconfig.compilerOptions.paths`
   * support project references defined `tsconfig.references`
+  * support [template variable ${configDir} for substitution of config files directory path](https://github.com/microsoft/TypeScript/pull/58042)
 * supports in-memory file system via the `FileSystem` trait
 * contains `tracing` instrumentation
 

--- a/fixtures/tsconfig/cases/paths_template_variable/tsconfig1.json
+++ b/fixtures/tsconfig/cases/paths_template_variable/tsconfig1.json
@@ -1,0 +1,3 @@
+{
+  "extends":	"../../tsconfig_template_variable.json"
+}

--- a/fixtures/tsconfig/cases/paths_template_variable/tsconfig2.json
+++ b/fixtures/tsconfig/cases/paths_template_variable/tsconfig2.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "paths": {
+      "foo": ["${configDir}/foo.js"]
+    }
+  }
+}

--- a/fixtures/tsconfig/cases/project_references/app/tsconfig.json
+++ b/fixtures/tsconfig/cases/project_references/app/tsconfig.json
@@ -15,6 +15,9 @@
     },
     {
       "path": "../project_c/tsconfig.json"
+    },
+    {
+      "path": "../../paths_template_variable/tsconfig2.json"
     }
   ]
 }

--- a/fixtures/tsconfig/tsconfig_template_variable.json
+++ b/fixtures/tsconfig/tsconfig_template_variable.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "foo": ["${configDir}/foo.js"]
+    }
+  }
+}

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -25,6 +25,11 @@ fn auto() {
         // Does not have paths alias
         (f.join("project_a"), "./index.ts", f.join("project_a/index.ts")),
         (f.join("project_c"), "./index.ts", f.join("project_c/index.ts")),
+        // Template variable
+        {
+            let dir = f.parent().unwrap().join("paths_template_variable");
+            (dir.clone(), "foo", dir.join("foo.js"))
+        }
     ];
 
     for (path, request, expected) in pass {


### PR DESCRIPTION
closes #129

NOTE: All tests cases are just a head replacement of `${configDir}/`, so we are constrained as such. configDir is always an absolute path, so replacing within a pass is not logical.