### PR TITLE
fix: lazily read package.json.exports for shared resolvers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@ mod tsconfig;
 #[cfg(test)]
 mod tests;
 
-use rustc_hash::FxHashSet;
 use std::{
     borrow::Cow,
     cmp::Ordering,
@@ -69,6 +68,9 @@ use std::{
     path::{Component, Path, PathBuf},
     sync::Arc,
 };
+
+use rustc_hash::FxHashSet;
+use serde_json::Value as JSONValue;
 use typescript_tsconfig_json::ExtendsField;
 
 pub use crate::{
@@ -86,11 +88,11 @@ use crate::{
     cache::{Cache, CachedPath},
     context::ResolveContext as Ctx,
     file_system::FileSystemOs,
+    package_json::ImportExportMap,
     path::{PathUtil, SLASH_START},
     specifier::Specifier,
     tsconfig::{ProjectReference, TsConfig},
 };
-use nodejs_package_json::{ImportExportField, ImportExportKey, ImportExportMap};
 
 type ResolveResult = Result<Option<CachedPath>, ResolveError>;
 
@@ -755,8 +757,8 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         for exports in package_json.exports_fields(&self.options.exports_fields) {
             if let Some(path) = self.package_exports_resolve(
                 cached_path.path(),
-                subpath,
-                &exports?,
+                &format!(".{subpath}"),
+                exports,
                 &self.options.condition_names,
                 ctx,
             )? {
@@ -796,8 +798,8 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             for exports in package_json.exports_fields(&self.options.exports_fields) {
                 if let Some(cached_path) = self.package_exports_resolve(
                     package_url,
-                    subpath,
-                    &exports?,
+                    &format!(".{subpath}"),
+                    exports,
                     &self.options.condition_names,
                     ctx,
                 )? {
@@ -1142,8 +1144,8 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                         for exports in package_json.exports_fields(&self.options.exports_fields) {
                             if let Some(path) = self.package_exports_resolve(
                                 cached_path.path(),
-                                subpath,
-                                &exports?,
+                                &format!(".{subpath}"),
+                                exports,
                                 &self.options.condition_names,
                                 ctx,
                             )? {
@@ -1180,18 +1182,17 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         &self,
         package_url: &Path,
         subpath: &str,
-        exports: &ImportExportField,
+        exports: &JSONValue,
         conditions: &[String],
         ctx: &mut Ctx,
     ) -> ResolveResult {
         // 1. If exports is an Object with both a key starting with "." and a key not starting with ".", throw an Invalid Package Configuration error.
-        if let ImportExportField::Map(map) = exports {
+        if let JSONValue::Object(map) = exports {
             let mut has_dot = false;
             let mut without_dot = false;
             for key in map.keys() {
-                has_dot =
-                    has_dot || matches!(key, ImportExportKey::Main | ImportExportKey::Pattern(_));
-                without_dot = without_dot || matches!(key, ImportExportKey::CustomCondition(_));
+                has_dot = has_dot || key.starts_with(|s| s == '.' || s == '#');
+                without_dot = without_dot || !key.starts_with(|s| s == '.' || s == '#');
                 if has_dot && without_dot {
                     return Err(ResolveError::InvalidPackageConfig(
                         package_url.join("package.json"),
@@ -1201,7 +1202,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         }
         // 2. If subpath is equal to ".", then
         // Note: subpath is not prepended with a dot when passed in.
-        if subpath.is_empty() {
+        if subpath == "." {
             // enhanced-resolve appends query and fragment when resolving exports field
             // https://github.com/webpack/enhanced-resolve/blob/a998c7d218b7a9ec2461fc4fddd1ad5dd7687485/lib/ExportsFieldPlugin.js#L57-L62
             // This is only need when querying the main export, otherwise ctx is passed through.
@@ -1209,24 +1210,23 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 let query = ctx.query.clone().unwrap_or_default();
                 let fragment = ctx.fragment.clone().unwrap_or_default();
                 return Err(ResolveError::PackagePathNotExported(
-                    format!("./{subpath}{query}{fragment}"),
+                    format!("./{}{query}{fragment}", subpath.trim_start_matches('.')),
                     package_url.join("package.json"),
                 ));
             }
             // 1. Let mainExport be undefined.
             let main_export = match exports {
-                ImportExportField::None => None,
                 // 2. If exports is a String or Array, or an Object containing no keys starting with ".", then
-                ImportExportField::String(_) | ImportExportField::Array(_) => {
+                JSONValue::String(_) | JSONValue::Array(_) => {
                     // 1. Set mainExport to exports.
                     Some(exports)
                 }
                 // 3. Otherwise if exports is an Object containing a "." property, then
-                ImportExportField::Map(map) => {
+                JSONValue::Object(map) => {
                     // 1. Set mainExport to exports["."].
-                    map.get(&ImportExportKey::Main).map_or_else(
+                    map.get(".").map_or_else(
                         || {
-                            if map.keys().any(|key| matches!(key, ImportExportKey::Pattern(_))) {
+                            if map.keys().any(|key| key.starts_with("./") || key.starts_with('#')) {
                                 None
                             } else {
                                 Some(exports)
@@ -1235,6 +1235,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                         Some,
                     )
                 }
+                _ => None,
             };
             // 4. If mainExport is not undefined, then
             if let Some(main_export) = main_export {
@@ -1255,7 +1256,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             }
         }
         // 3. Otherwise, if exports is an Object and all keys of exports start with ".", then
-        if let ImportExportField::Map(exports) = exports {
+        if let JSONValue::Object(exports) = exports {
             // 1. Let matchKey be the string "./" concatenated with subpath.
             // Note: `package_imports_exports_resolve` does not require the leading dot.
             let match_key = &subpath;
@@ -1274,7 +1275,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         }
         // 4. Throw a Package Path Not Exported error.
         Err(ResolveError::PackagePathNotExported(
-            format!(".{subpath}"),
+            subpath.to_string(),
             package_url.join("package.json"),
         ))
     }
@@ -1339,7 +1340,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         // 1. If matchKey is a key of matchObj and does not contain "*", then
         if !match_key.contains('*') {
             // 1. Let target be the value of matchObj[matchKey].
-            if let Some(target) = match_obj.get(&ImportExportKey::Pattern(match_key.to_string())) {
+            if let Some(target) = match_obj.get(match_key) {
                 // 2. Return the result of PACKAGE_TARGET_RESOLVE(packageURL, target, null, isImports, conditions).
                 return self.package_target_resolve(
                     package_url,
@@ -1359,7 +1360,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         // 2. Let expansionKeys be the list of keys of matchObj containing only a single "*", sorted by the sorting function PATTERN_KEY_COMPARE which orders in descending order of specificity.
         // 3. For each key expansionKey in expansionKeys, do
         for (expansion_key, target) in match_obj {
-            if let ImportExportKey::Pattern(expansion_key) = expansion_key {
+            if expansion_key.starts_with("./") || expansion_key.starts_with('#') {
                 // 1. Let patternBase be the substring of expansionKey up to but excluding the first "*" character.
                 if let Some((pattern_base, pattern_trailer)) = expansion_key.split_once('*') {
                     // 2. If matchKey starts with but is not equal to patternBase, then
@@ -1412,7 +1413,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         &self,
         package_url: &Path,
         target_key: &str,
-        target: &ImportExportField,
+        target: &JSONValue,
         pattern_match: Option<&str>,
         is_imports: bool,
         conditions: &[String],
@@ -1445,9 +1446,8 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         }
 
         match target {
-            ImportExportField::None => {}
             // 1. If target is a String, then
-            ImportExportField::String(target) => {
+            JSONValue::String(target) => {
                 // 1. If target does not start with "./", then
                 if !target.starts_with("./") {
                     // 1. If isImports is false, or if target starts with "../" or "/", or if target is a valid URL, then
@@ -1488,14 +1488,14 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 return Ok(Some(value));
             }
             // 2. Otherwise, if target is a non-null Object, then
-            ImportExportField::Map(target) => {
+            JSONValue::Object(target) => {
                 // 1. If exports contains any index property keys, as defined in ECMA-262 6.1.7 Array Index, throw an Invalid Package Configuration error.
                 // 2. For each property p of target, in object insertion order as,
                 for (i, (key, target_value)) in target.iter().enumerate() {
                     // https://nodejs.org/api/packages.html#conditional-exports
                     // "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. This condition should always come last.
                     // Note: node.js does not throw this but enhanced-resolve does.
-                    let is_default = matches!(key, ImportExportKey::CustomCondition(condition) if condition == "default");
+                    let is_default = key == "default";
                     if i < target.len() - 1 && is_default {
                         return Err(ResolveError::InvalidPackageConfigDefault(
                             package_url.join("package.json"),
@@ -1503,9 +1503,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                     }
 
                     // 1. If p equals "default" or conditions contains an entry for p, then
-                    if is_default
-                        || matches!(key, ImportExportKey::CustomCondition(condition) if conditions.contains(condition))
-                    {
+                    if is_default || conditions.contains(key) {
                         // 1. Let targetValue be the value of the p property in target.
                         // 2. Let resolved be the result of PACKAGE_TARGET_RESOLVE( packageURL, targetValue, patternMatch, isImports, conditions).
                         let resolved = self.package_target_resolve(
@@ -1528,12 +1526,12 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 return Ok(None);
             }
             // 3. Otherwise, if target is an Array, then
-            ImportExportField::Array(targets) => {
+            JSONValue::Array(targets) => {
                 // 1. If _target.length is zero, return null.
                 if targets.is_empty() {
                     // Note: return PackagePathNotExported has the same effect as return because there are no matches.
                     return Err(ResolveError::PackagePathNotExported(
-                        format!(".{}", pattern_match.unwrap_or(".")),
+                        pattern_match.unwrap_or(".").to_string(),
                         package_url.join("package.json"),
                     ));
                 }
@@ -1563,6 +1561,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 // 3. Return or throw the last fallback resolution null return or error.
                 // Note: see `resolved.is_err() && i == targets.len()`
             }
+            _ => {}
         }
         // 4. Otherwise, if target is null, return null.
         Ok(None)

--- a/src/package_json.rs
+++ b/src/package_json.rs
@@ -3,11 +3,13 @@
 //! Code related to export field are copied from [Parcel's resolver](https://github.com/parcel-bundler/parcel/blob/v2/packages/utils/node-resolver-rs/src/package_json.rs)
 use std::path::{Path, PathBuf};
 
-use nodejs_package_json::{BrowserField, ImportExportField, ImportExportMap};
+use nodejs_package_json::BrowserField;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::Value as JSONValue;
 
 use crate::{path::PathUtil, ResolveError, ResolveOptions};
+
+pub type ImportExportMap = serde_json::Map<String, JSONValue>;
 
 /// Deserialized package.json
 #[derive(Debug, Default)]
@@ -18,7 +20,7 @@ pub struct PackageJson {
     /// Realpath to `package.json`. Contains the `package.json` filename.
     pub realpath: PathBuf,
 
-    raw_json: std::sync::Arc<serde_json::Value>,
+    raw_json: std::sync::Arc<JSONValue>,
 
     /// The "name" field defines your package's name.
     /// The "name" field can be used in addition to the "exports" field to self-reference a package using its name.
@@ -47,7 +49,7 @@ impl PackageJson {
         json: &str,
         options: &ResolveOptions,
     ) -> Result<Self, serde_json::Error> {
-        let mut raw_json: Value = serde_json::from_str(json)?;
+        let mut raw_json: JSONValue = serde_json::from_str(json)?;
         let mut package_json = Self::default();
 
         package_json.browser_fields.reserve_exact(options.alias_fields.len());
@@ -70,11 +72,8 @@ impl PackageJson {
                 json_object.get("name").and_then(|field| field.as_str()).map(ToString::to_string);
 
             // Add imports.
-            package_json.imports = json_object
-                .get("imports")
-                .map(ImportExportMap::deserialize)
-                .transpose()?
-                .map(Box::new);
+            package_json.imports =
+                json_object.get("imports").and_then(|v| v.as_object()).cloned().map(Box::new);
 
             // Dynamically create `browser_fields`.
             let dir = path.parent().unwrap();
@@ -110,9 +109,9 @@ impl PackageJson {
     }
 
     fn get_value_by_path<'a>(
-        fields: &'a serde_json::Map<String, serde_json::Value>,
+        fields: &'a serde_json::Map<String, JSONValue>,
         path: &[String],
-    ) -> Option<&'a serde_json::Value> {
+    ) -> Option<&'a JSONValue> {
         if path.is_empty() {
             return None;
         }
@@ -139,7 +138,7 @@ impl PackageJson {
     /// They are: `description`, `keywords`, `scripts`,
     /// `dependencies` and `devDependencies`, `peerDependencies`, `optionalDependencies`.
     #[cfg(feature = "package_json_raw_json_api")]
-    pub fn raw_json(&self) -> &std::sync::Arc<serde_json::Value> {
+    pub fn raw_json(&self) -> &std::sync::Arc<JSONValue> {
         &self.raw_json
     }
 
@@ -176,19 +175,12 @@ impl PackageJson {
     pub(crate) fn exports_fields<'a>(
         &'a self,
         exports_fields: &'a [Vec<String>],
-    ) -> impl Iterator<Item = Result<ImportExportField, ResolveError>> + '_ {
-        exports_fields
-            .iter()
-            .filter_map(|object_path| {
-                self.raw_json
-                    .as_object()
-                    .and_then(|json_object| Self::get_value_by_path(json_object, object_path))
-            })
-            // TODO: PERF: should cache this deserialize
-            .map(|exports| {
-                ImportExportField::deserialize(exports)
-                    .map_err(|err| ResolveError::from_serde_json_error(self.path.clone(), &err))
-            })
+    ) -> impl Iterator<Item = &'a JSONValue> + '_ {
+        exports_fields.iter().filter_map(|object_path| {
+            self.raw_json
+                .as_object()
+                .and_then(|json_object| Self::get_value_by_path(json_object, object_path))
+        })
     }
 
     /// Resolve the request string for this package.json by looking at the `browser` field.
@@ -217,13 +209,10 @@ impl PackageJson {
         Ok(None)
     }
 
-    fn alias_value<'a>(
-        key: &Path,
-        value: &'a serde_json::Value,
-    ) -> Result<Option<&'a str>, ResolveError> {
+    fn alias_value<'a>(key: &Path, value: &'a JSONValue) -> Result<Option<&'a str>, ResolveError> {
         match value {
-            serde_json::Value::String(value) => Ok(Some(value.as_str())),
-            serde_json::Value::Bool(b) if !b => Err(ResolveError::Ignored(key.to_path_buf())),
+            JSONValue::String(value) => Ok(Some(value.as_str())),
+            JSONValue::Bool(b) if !b => Err(ResolveError::Ignored(key.to_path_buf())),
             _ => Ok(None),
         }
     }

--- a/src/tests/exports_field.rs
+++ b/src/tests/exports_field.rs
@@ -183,6 +183,27 @@ fn field_name_path() {
 }
 
 #[test]
+fn shared_resolvers() {
+    let f3 = super::fixture().join("exports-field3");
+
+    let resolver1 = Resolver::new(ResolveOptions {
+        exports_fields: vec![vec!["exportsField".into(), "exports".into()]],
+        extensions: vec![".js".into()],
+        ..ResolveOptions::default()
+    });
+    let resolved_path = resolver1.resolve(&f3, "exports-field").map(|r| r.full_path());
+    assert_eq!(resolved_path, Ok(f3.join("node_modules/exports-field/main.js")));
+
+    let resolver2 = resolver1.clone_with_options(ResolveOptions {
+        exports_fields: vec![vec!["ex".into()]],
+        extensions: vec![".js".into()],
+        ..ResolveOptions::default()
+    });
+    let resolved_path = resolver2.resolve(&f3, "exports-field").map(|r| r.full_path());
+    assert_eq!(resolved_path, Ok(f3.join("node_modules/exports-field/index")));
+}
+
+#[test]
 fn extension_alias_1_2() {
     let f = super::fixture().join("exports-field-and-extension-alias");
 

--- a/src/tests/imports_field.rs
+++ b/src/tests/imports_field.rs
@@ -8,7 +8,7 @@ use crate::{Ctx, ImportExportMap, PathUtil, ResolveError, ResolveOptions, Resolv
 use std::path::Path;
 
 #[test]
-fn test() {
+fn test_simple() {
     let f = super::fixture().join("imports-field");
     let f2 = super::fixture().join("imports-exports-wildcard/node_modules/m/");
 


### PR DESCRIPTION
relates #135

This PR removes all encapsulations around imports / exports map so we can dynamically retrieve and evaluate their values :-(