### PR TITLE
fix: RootsPlugin should fall through if it fails to resolve the roots

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,15 +333,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 return Ok(path);
             }
         }
-        if self.options.roots.is_empty() {
-            // 2. If X begins with '/'
-            //   a. set Y to be the file system root
-            let path = self.cache.value(Path::new(specifier));
-            if let Some(path) = self.load_as_file_or_directory(&path, specifier, ctx)? {
-                return Ok(path);
-            }
-            Err(ResolveError::NotFound(specifier.to_string()))
-        } else {
+        if !self.options.roots.is_empty() {
             for root in &self.options.roots {
                 let cached_path = self.cache.value(root);
                 if let Ok(path) = self.require_relative(
@@ -352,8 +344,14 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                     return Ok(path);
                 }
             }
-            Err(ResolveError::NotFound(specifier.to_string()))
         }
+        // 2. If X begins with '/'
+        //   a. set Y to be the file system root
+        let path = self.cache.value(Path::new(specifier));
+        if let Some(path) = self.load_as_file_or_directory(&path, specifier, ctx)? {
+            return Ok(path);
+        }
+        Err(ResolveError::NotFound(specifier.to_string()))
     }
 
     // 3. If X begins with './' or '/' or '../'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,16 +333,12 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 return Ok(path);
             }
         }
-        if !self.options.roots.is_empty() {
-            for root in &self.options.roots {
-                let cached_path = self.cache.value(root);
-                if let Ok(path) = self.require_relative(
-                    &cached_path,
-                    specifier.trim_start_matches(SLASH_START),
-                    ctx,
-                ) {
-                    return Ok(path);
-                }
+        // enhanced-resolve: RootsPlugin
+        for root in &self.options.roots {
+            let cached_path = self.cache.value(root);
+            let specifier = specifier.trim_start_matches(SLASH_START);
+            if let Ok(path) = self.require_relative(&cached_path, specifier, ctx) {
+                return Ok(path);
             }
         }
         // 2. If X begins with '/'

--- a/src/tests/roots.rs
+++ b/src/tests/roots.rs
@@ -78,3 +78,12 @@ fn prefer_absolute() {
         assert_eq!(resolved_path, Ok(expected), "{comment} {request}");
     }
 }
+
+#[test]
+fn roots_fall_through() {
+    let f = super::fixture();
+    let absolute_path = f.join("roots_fall_through/index.js");
+    let specifier = absolute_path.to_string_lossy();
+    let resolution = Resolver::new(ResolveOptions::default().with_root(&f)).resolve(&f, &specifier);
+    assert_eq!(resolution.map(|r| r.into_path_buf()), Ok(absolute_path));
+}

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -15,6 +15,16 @@ fn chinese() {
 }
 
 #[test]
+fn roots_fall_through() {
+    let dir = dir();
+    let absolute_path = dir.join("fixtures/misc/roots_fall_through/index.js");
+    let specifier = absolute_path.to_str().unwrap();
+    let resolution =
+        Resolver::new(ResolveOptions::default().with_root(&dir)).resolve(&dir, specifier);
+    assert_eq!(resolution.map(|r| r.into_path_buf()), Ok(absolute_path));
+}
+
+#[test]
 fn styled_components() {
     let dir = dir();
     let path = dir.join("fixtures/pnpm8");

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -15,16 +15,6 @@ fn chinese() {
 }
 
 #[test]
-fn roots_fall_through() {
-    let dir = dir();
-    let absolute_path = dir.join("fixtures/misc/roots_fall_through/index.js");
-    let specifier = absolute_path.to_str().unwrap();
-    let resolution =
-        Resolver::new(ResolveOptions::default().with_root(&dir)).resolve(&dir, specifier);
-    assert_eq!(resolution.map(|r| r.into_path_buf()), Ok(absolute_path));
-}
-
-#[test]
 fn styled_components() {
     let dir = dir();
     let path = dir.join("fixtures/pnpm8");


### PR DESCRIPTION
Prefix for https://github.com/web-infra-dev/rspack/pull/6340

In enhanced-resolve, when resolving with `roots` failed, will continue resolve it instead of returning error