### PR TITLE
fix: alias not found should return error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -871,6 +871,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 }
                 alias_key_raw
             };
+            let mut should_stop = false;
             for r in specifiers {
                 match r {
                     AliasValue::Path(alias_value) => {
@@ -885,6 +886,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                                 alias_value, // pass in original alias value, not parsed
                                 specifier,
                                 ctx,
+                                &mut should_stop,
                             )? {
                                 return Ok(Some(path));
                             }
@@ -900,6 +902,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                             new_specifier.path(), // pass in parsed alias value
                             specifier,
                             ctx,
+                            &mut should_stop,
                         )? {
                             return Ok(Some(path));
                         }
@@ -910,6 +913,10 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                         return Err(ResolveError::Ignored(path));
                     }
                 }
+            }
+            // Don't allow other aliasing or raw request
+            if should_stop {
+                return Err(ResolveError::NotFound(specifier.to_string()));
             }
         }
         Ok(None)
@@ -922,6 +929,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         alias_value: &str,
         request: &str,
         ctx: &mut Ctx,
+        should_stop: &mut bool,
     ) -> ResolveResult {
         if request != alias_value
             && !request.strip_prefix(alias_value).is_some_and(|prefix| prefix.starts_with('/'))
@@ -944,6 +952,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 Cow::Owned(normalized.to_string_lossy().to_string())
             };
 
+            *should_stop = true;
             ctx.with_fully_specified(false);
             return match self.require(cached_path, new_specifier.as_ref(), ctx) {
                 Err(ResolveError::NotFound(_)) => Ok(None),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -871,6 +871,9 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 }
                 alias_key_raw
             };
+            // It should stop resolving when all of the tried alias values
+            // failed to resolve.
+            // <https://github.com/webpack/enhanced-resolve/blob/570337b969eee46120a18b62b72809a3246147da/lib/AliasPlugin.js#L65>
             let mut should_stop = false;
             for r in specifiers {
                 match r {
@@ -914,7 +917,6 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                     }
                 }
             }
-            // Don't allow other aliasing or raw request
             if should_stop {
                 return Err(ResolveError::NotFound(specifier.to_string()));
             }

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -218,3 +218,17 @@ fn alias_is_full_path() {
         }
     }
 }
+
+#[test]
+fn alias_not_found() {
+    let f = super::fixture();
+    let resolver = Resolver::new(ResolveOptions {
+        alias: vec![(
+            "m1".to_string(),
+            vec![AliasValue::Path(f.join("node_modules").join("m2").to_string_lossy().to_string())],
+        )],
+        ..ResolveOptions::default()
+    });
+    let resolution = resolver.resolve(&f, "m1/a.js");
+    assert_eq!(resolution, Err(ResolveError::NotFound("m1/a.js".to_string())));
+}

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -219,8 +219,9 @@ fn alias_is_full_path() {
     }
 }
 
+// For the `should_stop` variable in `load_alias`
 #[test]
-fn alias_not_found() {
+fn all_alias_values_are_not_found() {
     let f = super::fixture();
     let resolver = Resolver::new(ResolveOptions {
         alias: vec![(


### PR DESCRIPTION
Not found matched alias should return error instead of continue resolving

https://github.com/webpack/enhanced-resolve/blob/570337b969eee46120a18b62b72809a3246147da/lib/AliasPlugin.js#L134-L135