### PR TITLE
fix: alias value try fragment as path

### DIFF
--- a/fixtures/enhanced_resolve/test/fixtures/browser-module/package.json
+++ b/fixtures/enhanced_resolve/test/fixtures/browser-module/package.json
@@ -15,7 +15,8 @@
     "./xyz.js": "./lib/xyz.js",
     "./lib/non-existent.js": "./lib/non-existent.js",
     ".": false,
-    "./number": 1
+    "./number": 1,
+    "./foo": "./lib/replaced.js?query"
   },
   "innerBrowser1": {
     "field": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 return Err(err);
             }
             // enhanced-resolve: try fallback
-            self.load_alias(&cached_path, specifier, &self.options.fallback, ctx)
+            self.load_alias(cached_path, specifier, &self.options.fallback, ctx)
                 .and_then(|value| value.ok_or(err))
         })
     }

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -264,3 +264,17 @@ fn alias_fragment() {
         assert_eq!(resolved_path, Ok(expected), "{comment} {request}");
     }
 }
+
+#[test]
+fn alias_try_fragment_as_path() {
+    let f = super::fixture();
+    let resolver = Resolver::new(ResolveOptions {
+        alias: vec![(
+            "#".to_string(),
+            vec![AliasValue::Path(f.join("#").to_string_lossy().to_string())],
+        )],
+        ..ResolveOptions::default()
+    });
+    let resolution = resolver.resolve(&f, "#/a").map(|r| r.full_path());
+    assert_eq!(resolution, Ok(f.join("#").join("a.js")));
+}

--- a/src/tests/browser_field.rs
+++ b/src/tests/browser_field.rs
@@ -174,3 +174,16 @@ fn recursive() {
         assert_eq!(resolved_path, Err(ResolveError::Recursion), "{comment} {path:?} {request}");
     }
 }
+
+#[test]
+fn with_query() {
+    let f = super::fixture().join("browser-module");
+
+    let resolver = Resolver::new(ResolveOptions {
+        alias_fields: vec![vec!["browser".into()]],
+        ..ResolveOptions::default()
+    });
+
+    let resolved_path = resolver.resolve(&f, "./foo").map(|r| r.full_path());
+    assert_eq!(resolved_path, Ok(f.join("lib").join("browser.js?query")));
+}


### PR DESCRIPTION
https://github.com/oxc-project/oxc-resolver/pull/170 breaks [a case in Rspack](https://github.com/web-infra-dev/rspack/actions/runs/9313088014/job/25634999631?pr=6691#step:6:988):

```js
let resolve = resolver.create({ alias: { '#': path.resolve(__dirname, '#') } });
resolve(__dirname, '#/a');
```

PR is referenced from: https://github.com/webpack/enhanced-resolve/blob/e38970852a7f89b694f1053e285195511764a900/lib/ParsePlugin.js#L33-L73