### PR TITLE
feat: export package.json `type` and `sideEffects` field by default for bundlers

### DIFF
--- a/src/package_json.rs
+++ b/src/package_json.rs
@@ -24,6 +24,16 @@ pub struct PackageJson {
     /// <https://nodejs.org/api/packages.html#name>
     pub name: Option<String>,
 
+    /// The "type" field.
+    ///
+    /// <https://nodejs.org/api/packages.html#type>
+    pub r#type: Option<JSONValue>,
+
+    /// The "sideEffects" field.
+    ///
+    /// <https://webpack.js.org/guides/tree-shaking>
+    pub side_effects: Option<JSONValue>,
+
     raw_json: std::sync::Arc<JSONValue>,
 }
 
@@ -51,9 +61,11 @@ impl PackageJson {
                 json_object.remove("optionalDependencies");
             }
 
-            // Add name.
+            // Add name, type and sideEffects.
             package_json.name =
                 json_object.get("name").and_then(|field| field.as_str()).map(ToString::to_string);
+            package_json.r#type = json_object.get("type").cloned();
+            package_json.side_effects = json_object.get("sideEffects").cloned();
         }
 
         package_json.path = path;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -35,9 +35,10 @@ fn eq() {
 #[test]
 fn package_json() {
     let resolution = resolve("./tests/package.json");
-    assert!(resolution
-        .package_json()
-        .is_some_and(|json| json.name.as_ref().is_some_and(|name| name == "name")));
+    let package_json = resolution.package_json().unwrap();
+    assert_eq!(package_json.name.as_ref().unwrap(), "name");
+    assert_eq!(package_json.r#type.as_ref().unwrap().as_str(), "module".into());
+    assert!(package_json.side_effects.as_ref().unwrap().is_object());
 }
 
 #[cfg(feature = "package_json_raw_json_api")]

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,3 +1,5 @@
 {
-  "name": "name"
+  "name": "name",
+  "type": "module",
+  "sideEffects": {}
 }


### PR DESCRIPTION
The fields are pretty small in size, but we can try and remove the clones if necessary.