### PR TITLE
feat: strip symbols and enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ include      = ["/src", "/examples", "/benches"]
 [lib]
 doctest = false
 
+[profile.release]
+strip = true
+lto = true
+
 [[bench]]
 name    = "resolver"
 harness = false


### PR DESCRIPTION
Strips symbols from the release build and enables LTO, which results in some reduction in size of the binary.

i've not been around rust in some time so this may be absolute nonsense. if so, feel free to close

as far as i can tell, stripping symbols/debug info is a no-brainer, but LTO can reduce performance in some cases. although the benchmark seemed the same or better locally

i feel like there will be other big savings to have too (without affecting perf), but i need to read up on this stuff more.  if you have any ideas, please do let me know and im happy to try them out