### PR TITLE
perf: improve call to `Path::ends_with`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,10 +742,12 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         module_name: &str,
         ctx: &mut Ctx,
     ) -> Option<CachedPath> {
-        if cached_path.path().ends_with(module_name) {
-            Some(cached_path.clone())
-        } else if module_name == "node_modules" {
+        if module_name == "node_modules" {
             cached_path.cached_node_modules(&self.cache, ctx)
+        } else if cached_path.path().components().next_back()
+            == Some(Component::Normal(OsStr::new(module_name)))
+        {
+            Some(cached_path.clone())
         } else {
             cached_path.module_directory(module_name, &self.cache, ctx)
         }


### PR DESCRIPTION
`Path::ends_with` converts the comparator to a `Path` and compares all components.

```rust
    #[must_use]
    pub fn ends_with<P: AsRef<Path>>(&self, child: P) -> bool {
        self._ends_with(child.as_ref())
    }

    fn _ends_with(&self, child: &Path) -> bool {
        iter_after(self.components().rev(), child.components().rev()).is_some()
    }
```

`module_name` in `cached_path.path().ends_with(module_name)` is guaranteed to be a single component so this overhead can be avoided.

I also change the order of comparisons to check `node_modules` because that's the majority of the case.