### PR TITLE
fix: tsconfig self-references cause short-lived invaild cache

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1096,6 +1096,10 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 let directory = tsconfig.directory().to_path_buf();
                 for reference in &mut tsconfig.references {
                     let reference_tsconfig_path = directory.normalize_with(&reference.path);
+                    if reference_tsconfig_path == path {
+                        // skip current working path to avoid setting cache as a invalid value
+                        continue;
+                    }
                     let tsconfig = self.cache.tsconfig(
                         /* root */ true,
                         &reference_tsconfig_path,


### PR DESCRIPTION
The resolver will load references and write them to cache. However, if the resolver receives a new request when self_reference is saved to the cache but other reference not finish , the new request will fail.

Here is a simple example

``` rust
Resolver::new(ResolveOptions {
    tsconfig: Some(TsconfigOptions {
        config_file: PathBuf::from("/apps/a/tsconfig.json"),
        references: TsconfigReferences::Paths(vec![
            "/apps/a/tsconfig.json".into(),
            "/apps/b".into(), // mark 1
            "/apps/c".into()
        ])
    })
})
```

1. The first request comes, and the resolver executes to mark1.
The tsconfig cache will contains `/apps/a/tsconfig.json` which insert by https://github.com/oxc-project/oxc-resolver/blob/a662c9810cbb81302a0fa6e6d4741e81291cc93b/src/lib.rs#L1099

2. The next request comes, and the resolver will use the cached tsconfig which is no tsconfig info. This request will be failed