### PR TITLE
fix: tsconfig self-reference throw error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -81,6 +81,9 @@ pub enum ResolveError {
     /// Occurs when alias paths reference each other.
     #[error("Recursion in resolving")]
     Recursion,
+
+    #[error("{0} contains self-reference")]
+    TsconfigSelfReference(PathBuf),
 }
 
 impl ResolveError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,10 @@ pub enum ResolveError {
     #[error("Tsconfig not found {0}")]
     TsconfigNotFound(PathBuf),
 
+    /// Tsconfig's project reference path points to it self
+    #[error("Tsconfig's project reference path points to this tsconfig {0}")]
+    TsconfigSelfReference(PathBuf),
+
     #[error("{0}")]
     IOError(IOError),
 
@@ -81,9 +85,6 @@ pub enum ResolveError {
     /// Occurs when alias paths reference each other.
     #[error("Recursion in resolving")]
     Recursion,
-
-    #[error("{0} contains self-reference")]
-    TsconfigSelfReference(PathBuf),
 }
 
 impl ResolveError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1099,7 +1099,14 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                     let tsconfig = self.cache.tsconfig(
                         /* root */ true,
                         &reference_tsconfig_path,
-                        |_| Ok(()),
+                        |reference_tsconfig| {
+                            if reference_tsconfig.path == tsconfig.path {
+                                return Err(ResolveError::TsconfigSelfReference(
+                                    reference_tsconfig.path.clone(),
+                                ));
+                            }
+                            Ok(())
+                        },
                     )?;
                     reference.tsconfig.replace(tsconfig);
                 }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -29,7 +29,7 @@ pub struct TsConfig {
 
     /// Path to `tsconfig.json`. Contains the `tsconfig.json` filename.
     #[serde(skip)]
-    path: PathBuf,
+    pub path: PathBuf,
 
     #[serde(default)]
     pub extends: Option<ExtendsField>,

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -29,7 +29,7 @@ pub struct TsConfig {
 
     /// Path to `tsconfig.json`. Contains the `tsconfig.json` filename.
     #[serde(skip)]
-    pub path: PathBuf,
+    pub(crate) path: PathBuf,
 
     #[serde(default)]
     pub extends: Option<ExtendsField>,


### PR DESCRIPTION
Self-reference in tsconfig will cause short-lived invaild cache, more info see https://github.com/oxc-project/oxc-resolver/pull/210.

This PR will throw a TsconfigSelfReference error.