### PR TITLE
fix: remove `#[cfg(target_os = "windows")]` logic in `canonicalize`

### DIFF
--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -118,15 +118,7 @@ impl FileSystem for FileSystemOs {
                             }
                         }
                         Component::RootDir => {
-                            #[cfg(target_os = "windows")]
-                            {
-                                path_buf.push("\\");
-                            }
-                            #[cfg(not(target_os = "windows"))]
-                            {
-                                #[allow(clippy::path_buf_push_overwrite)]
-                                path_buf.push("/");
-                            }
+                            path_buf = PathBuf::from("/");
                         }
                         Component::CurDir | Component::Prefix(_) => {}
                     }


### PR DESCRIPTION
I should have checked the file changes before click the **resolve conversation** button :(

![CleanShot 2024-07-10 at 22 47 27@2x](https://github.com/oxc-project/oxc-resolver/assets/3468483/aaaf3445-5dff-4b12-a182-8dd63bf9b9d7)
