### PR TITLE
feat(napi): expose module type info in ResolveResult

### DIFF
--- a/napi/index.d.ts
+++ b/napi/index.d.ts
@@ -188,6 +188,8 @@ export interface NapiResolveOptions {
 export interface ResolveResult {
   path?: string
   error?: string
+  /** "type" field in the package.json file */
+  moduleType?: string
 }
 
 /**
@@ -199,7 +201,7 @@ export interface Restriction {
   regex?: string
 }
 
-export function sync(path: string, request: string): ResolveResult
+export declare function sync(path: string, request: string): ResolveResult
 
 /**
  * Tsconfig Options

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -23,6 +23,8 @@ mod tracing;
 pub struct ResolveResult {
     pub path: Option<String>,
     pub error: Option<String>,
+    /// "type" field in the package.json file
+    pub module_type: Option<String>,
 }
 
 fn resolve(resolver: &Resolver, path: &Path, request: &str) -> ResolveResult {
@@ -30,8 +32,13 @@ fn resolve(resolver: &Resolver, path: &Path, request: &str) -> ResolveResult {
         Ok(resolution) => ResolveResult {
             path: Some(resolution.full_path().to_string_lossy().to_string()),
             error: None,
+            module_type: resolution
+                .package_json()
+                .and_then(|p| p.r#type.as_ref())
+                .and_then(|t| t.as_str())
+                .map(|t| t.to_string()),
         },
-        Err(err) => ResolveResult { path: None, error: Some(err.to_string()) },
+        Err(err) => ResolveResult { path: None, module_type: None, error: Some(err.to_string()) },
     }
 }
 


### PR DESCRIPTION
See https://github.com/oxc-project/oxc-node/blob/main/src/lib.rs#L345-L358 for the context:

We need to know the module type for resolved paths, so we can pass it to the Node.js import loader hook.

This can also fix https://github.com/swc-project/swc-node/issues/788
