### PR TITLE
fix: resolve module `ipaddr.js` correctly when `extensionAlias` is provided

### DIFF
--- a/examples/resolver.rs
+++ b/examples/resolver.rs
@@ -18,7 +18,7 @@ fn main() {
         alias_fields: vec![vec!["browser".into()]],
         alias: vec![("asdf".into(), vec![AliasValue::from("./test.js")])],
         extensions: vec![".js".into(), ".ts".into()],
-        extension_alias: vec![(".js".into(), vec![".ts".into()])],
+        extension_alias: vec![(".js".into(), vec![".ts".into(), ".js".into()])],
         ..ResolveOptions::default()
     };
 

--- a/fixtures/pnpm/package.json
+++ b/fixtures/pnpm/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "devDependencies": {
     "axios": "1.6.2",
-    "styled-components": "6.1.1",
-    "postcss": "8.4.33"
+    "ipaddr.js": "2.2.0",
+    "postcss": "8.4.33",
+    "styled-components": "6.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       axios:
         specifier: 1.6.2
         version: 1.6.2
+      ipaddr.js:
+        specifier: 2.2.0
+        version: 2.2.0
       postcss:
         specifier: 8.4.33
         version: 8.4.33
@@ -894,6 +897,10 @@ packages:
   inquirer@10.0.1:
     resolution: {integrity: sha512-XgthhRIn0Ci9JdGJpUo2EtpPfaczbooZbGTN+FTzSCyUb7YHJcPPnuSXfeG5903bJMy3OyEoVTQMnvO4Ly5tFg==}
     engines: {node: '>=18'}
+
+  ipaddr.js@2.2.0:
+    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
+    engines: {node: '>= 10'}
 
   irregular-plurals@3.5.0:
     resolution: {integrity: sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==}
@@ -2194,6 +2201,8 @@ snapshots:
       mute-stream: 1.0.0
       run-async: 3.0.0
       rxjs: 7.8.1
+
+  ipaddr.js@2.2.0: {}
 
   irregular-plurals@3.5.0: {}
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,8 +43,8 @@ pub enum ResolveError {
     Builtin(String),
 
     /// All of the aliased extension are not found
-    #[error("All of the aliased extension are not found")]
-    ExtensionAlias,
+    #[error("All of the aliased extensions are not found for {0}")]
+    ExtensionAlias(PathBuf),
 
     /// The provided path specifier cannot be parsed
     #[error("{0}")]

--- a/src/tests/exports_field.rs
+++ b/src/tests/exports_field.rs
@@ -269,7 +269,7 @@ fn extension_alias_throw_error() {
     let fail = [
         // enhanced-resolve has two test cases that are exactly the same here
         // https://github.com/webpack/enhanced-resolve/blob/a998c7d218b7a9ec2461fc4fddd1ad5dd7687485/test/exportsField.test.js#L2976-L3024
-        ("should throw error with the `extensionAlias` option", f, "pkg/string.js", ResolveError::ExtensionAlias),
+        ("should throw error with the `extensionAlias` option", f.clone(), "pkg/string.js", ResolveError::ExtensionAlias(f.join("node_modules/pkg/dist/string.js"))),
         // TODO: The error is PackagePathNotExported in enhanced-resolve
         // ("should throw error with the `extensionAlias` option", f.clone(), "pkg/string.js", ResolveError::PackagePathNotExported("node_modules/pkg/dist/string.ts".to_string())),
     ];

--- a/src/tests/extension_alias.rs
+++ b/src/tests/extension_alias.rs
@@ -31,12 +31,16 @@ fn extension_alias() {
 
     #[rustfmt::skip]
     let fail = [
-        ("should not allow to fallback to the original extension or add extensions", f, "./index.mjs"),
+        ("should not allow to fallback to the original extension or add extensions", f.clone(), "./index.mjs"),
     ];
 
     for (comment, path, request) in fail {
         let resolution = resolver.resolve(&path, request);
-        assert_eq!(resolution, Err(ResolveError::ExtensionAlias), "{comment} {path:?} {request}");
+        assert_eq!(
+            resolution,
+            Err(ResolveError::ExtensionAlias(f.join(request))),
+            "{comment} {path:?} {request}"
+        );
     }
 }
 

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -102,3 +102,31 @@ fn postcss() {
     let resolution = resolver.resolve(&module_path, "./lib/terminal-highlight");
     assert_eq!(resolution, Err(ResolveError::Ignored(module_path.join("lib/terminal-highlight"))));
 }
+
+#[test]
+fn ipaddr_js() {
+    let dir = dir();
+    let path = dir.join("fixtures/pnpm");
+    let module_path =
+        dir.join("node_modules/.pnpm/ipaddr.js@2.2.0/node_modules/ipaddr.js/lib/ipaddr.js");
+
+    let resolvers = [
+        // with `extension_alias`
+        Resolver::new(ResolveOptions {
+            extension_alias: vec![(".js".into(), vec![".js".into(), ".ts".into(), ".tsx".into()])],
+            ..ResolveOptions::default()
+        }),
+        // with `extensions` should still resolve to module main
+        Resolver::new(ResolveOptions {
+            extensions: vec![(".ts".into())],
+            ..ResolveOptions::default()
+        }),
+        // default
+        Resolver::default(),
+    ];
+
+    for resolver in resolvers {
+        let resolution = resolver.resolve(&path, "ipaddr.js").map(|r| r.full_path());
+        assert_eq!(resolution, Ok(module_path.clone()));
+    }
+}


### PR DESCRIPTION
closes #227

Managed to figure this out after stepping through https://github.com/webpack/enhanced-resolve/blob/main/lib/ExtensionAliasPlugin.js