### PR TITLE
feat: give an specific error for matched alias not found

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,10 @@ pub enum ResolveError {
     #[error("Cannot find module '{0}'")]
     NotFound(/* specifier */ String),
 
+    /// Matched alias value  not found
+    #[error("Cannot find module '{0}' for matched aliased key '{1}'")]
+    MatchedAliasNotFound(/* specifier */ String, /* alias key */ String),
+
     /// Tsconfig not found
     #[error("Tsconfig not found {0}")]
     TsconfigNotFound(PathBuf),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -972,7 +972,10 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 }
             }
             if should_stop {
-                return Err(ResolveError::NotFound(specifier.to_string()));
+                return Err(ResolveError::MatchedAliasNotFound(
+                    specifier.to_string(),
+                    alias_key.to_string(),
+                ));
             }
         }
         Ok(None)
@@ -1011,7 +1014,9 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             *should_stop = true;
             ctx.with_fully_specified(false);
             return match self.require(cached_path, new_specifier.as_ref(), ctx) {
-                Err(ResolveError::NotFound(_)) => Ok(None),
+                Err(ResolveError::NotFound(_) | ResolveError::MatchedAliasNotFound(_, _)) => {
+                    Ok(None)
+                }
                 Ok(path) => return Ok(Some(path)),
                 Err(err) => return Err(err),
             };

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -231,7 +231,10 @@ fn all_alias_values_are_not_found() {
         ..ResolveOptions::default()
     });
     let resolution = resolver.resolve(&f, "m1/a.js");
-    assert_eq!(resolution, Err(ResolveError::NotFound("m1/a.js".to_string())));
+    assert_eq!(
+        resolution,
+        Err(ResolveError::MatchedAliasNotFound("m1/a.js".to_string(), "m1".to_string(),))
+    );
 }
 
 #[test]


### PR DESCRIPTION
The vite resolver `alais` has a case like this `{ '/@vite/env': '/@fs/xxx' }`, it could be work because the the rollup `alaisPlugin`
not checked the `/@fs/xxx` could be resolved. But the oxc resolver will do check it,  here the oxc resolver always give a error with `Module Not Found`, it is difficult to see the reasons.

Here add an `ResolveError::MatchedAliasNotFound` error to make alais resolve error msg clear to find the reasons.