### PR TITLE
Pre computed file facts as options

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -1,11 +1,13 @@
 use std::path::Path;
 use std::{fmt, path::PathBuf};
+use crate::Facts;
 
 /// Module Resolution Options
 ///
 /// Options are directly ported from [enhanced-resolve](https://github.com/webpack/enhanced-resolve#resolver-options).
 ///
 /// See [webpack resolve](https://webpack.js.org/configuration/resolve/) for information and examples
+/// 
 #[derive(Debug, Clone)]
 pub struct ResolveOptions {
     /// Path to TypeScript configuration file.
@@ -159,6 +161,7 @@ pub struct ResolveOptions {
     ///
     /// Default `false`
     pub builtin_modules: bool,
+    pub facts: Option<Facts>,
 }
 
 impl ResolveOptions {
@@ -476,6 +479,7 @@ impl Default for ResolveOptions {
             roots: vec![],
             symlinks: true,
             builtin_modules: false,
+            facts: None
         }
     }
 }
@@ -626,6 +630,7 @@ mod test {
             roots: vec![],
             symlinks: false,
             tsconfig: None,
+            facts: None
         };
 
         assert_eq!(format!("{options}"), "");


### PR DESCRIPTION
### Motivation
Make oxc-resolver work faster by using pre-computed facts to avoid reading the file system.

### Background
We have two types of pre-computed facts in a cache:

- **Package facts:**

```
"package_name": {
  path: String
  main_fields_and_values: {
    "main": String,
    ...
  },
  "export_fields_and_values": {
     "exports": String // JSON string
  },
}
```

- **List of files:** HashSet<String>

We calculate these facts by using `oxc-parser` and store them in a remote cache for our repo (which has ~200k files and growing). Anytime someone creates a branch and changes some files, we only recompute the facts for the changed files and reuse the other facts. Because of this process, computing facts is very cheap once we have a cache in place.

Using these facts, we speed up the resolution process by:

- Avoiding `read_to_string` for `package.json` files by using values from package facts
- speeding up the `is_file` function by asserting against the list of files
- avoiding `is_dir` calls

### Benchmarks
Resolution for 430k `.resolve` calls for relative imports and package imports (packages that exist in package facts):

**Using facts: ~2s**
**Without using facts: ~8s** 
