### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/oxc-project/oxc-resolver/compare/oxc_resolver-v1.11.0...oxc_resolver-v2.0.0) - 2024-09-17
+
+### Added
+
+- give a specific error for matched alias not found ([#238](https://github.com/oxc-project/oxc-resolver/pull/238))
+
+### Fixed
+
+- fix .github/workflows/release-plz.yml
+
+### Other
+
+- *(deps)* update crate-ci/typos action to v1.24.6
+- *(deps)* update npm packages
+- *(deps)* update npm packages
+- *(deps)* update npm packages
+- set `GH_TOKEN` for "Bump package.json" in release-plz.yml
+- update package.json in release-plz.yml ([#242](https://github.com/oxc-project/oxc-resolver/pull/242))
+- apply `semver_check` to release-plz ([#241](https://github.com/oxc-project/oxc-resolver/pull/241))
+- *(deps)* update dependency rust to v1.81.0 ([#239](https://github.com/oxc-project/oxc-resolver/pull/239))
+- *(deps)* update crate-ci/typos action to v1.24.5
+- *(deps)* update crate-ci/typos action to v1.24.4
+- *(deps)* update crate-ci/typos action to v1.24.3
+- add esm / cjs `condition_names` to examples
+
 ## [1.11.0](https://github.com/oxc-project/oxc_resolver/compare/oxc_resolver-v1.10.2...oxc_resolver-v1.11.0) - 2024-08-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "1.11.0"
+version = "2.0.0"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["napi"]
 resolver = "2"
 
 [package]
-version      = "1.11.0"
+version      = "2.0.0"
 name         = "oxc_resolver"
 authors      = ["Boshen <boshenc@gmail.com>"]
 categories   = ["development-tools"]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-resolver",
-  "version": "1.11.0",
+  "version": "null",
   "description": "Oxc Resolver Node API",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION
## 🤖 New release
* `oxc_resolver`: 1.11.0 -> 2.0.0 (⚠️ API breaking changes)

### ⚠️ `oxc_resolver` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant ResolveError:MatchedAliasNotFound in /tmp/.tmppszKtL/oxc-resolver/src/error.rs:29
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/oxc-project/oxc-resolver/compare/oxc_resolver-v1.11.0...oxc_resolver-v2.0.0) - 2024-09-17

### Added

- give a specific error for matched alias not found ([#238](https://github.com/oxc-project/oxc-resolver/pull/238))

### Fixed

- fix .github/workflows/release-plz.yml

### Other

- *(deps)* update crate-ci/typos action to v1.24.6
- *(deps)* update npm packages
- *(deps)* update npm packages
- *(deps)* update npm packages
- set `GH_TOKEN` for "Bump package.json" in release-plz.yml
- update package.json in release-plz.yml ([#242](https://github.com/oxc-project/oxc-resolver/pull/242))
- apply `semver_check` to release-plz ([#241](https://github.com/oxc-project/oxc-resolver/pull/241))
- *(deps)* update dependency rust to v1.81.0 ([#239](https://github.com/oxc-project/oxc-resolver/pull/239))
- *(deps)* update crate-ci/typos action to v1.24.5
- *(deps)* update crate-ci/typos action to v1.24.4
- *(deps)* update crate-ci/typos action to v1.24.3
- add esm / cjs `condition_names` to examples
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).