### PR TITLE
feat!: add `ResolveError::Builtin::is_runtime_module`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -44,8 +44,10 @@ pub enum ResolveError {
     ///
     /// This is an error due to not being a Node.js runtime.
     /// The `alias` option can be used to resolve a builtin module to a polyfill.
-    #[error("Builtin module {0}")]
-    Builtin(String),
+    /// User could get specifier before adding `node:` by `prefixed_with_node_colon`, using
+    /// boolean to avoid allocation
+    #[error("Builtin module {resolved}")]
+    Builtin { resolved: String, prefixed_with_node_colon: bool },
 
     /// All of the aliased extension are not found
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,12 +40,12 @@ pub enum ResolveError {
     #[error("{0}")]
     IOError(IOError),
 
-    /// Node.js builtin modules
+    /// Node.js builtin module when `Options::builtin_modules` is enabled.
     ///
-    /// This is an error due to not being a Node.js runtime.
-    /// The `alias` option can be used to resolve a builtin module to a polyfill.
-    /// User could get specifier before adding `node:` by `prefixed_with_node_colon`, using
-    /// boolean to avoid allocation
+    /// `prefixed_with_node_colon` can be used to determine whether the request
+    /// was prefixed `node:` or not.
+    ///
+    /// `resolved` is always prefixed with "node:" in compliance with the ESM specification.
     #[error("Builtin module {resolved}")]
     Builtin { resolved: String, prefixed_with_node_colon: bool },
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,12 +42,12 @@ pub enum ResolveError {
 
     /// Node.js builtin module when `Options::builtin_modules` is enabled.
     ///
-    /// `prefixed_with_node_colon` can be used to determine whether the request
-    /// was prefixed `node:` or not.
+    /// `is_runtime_module` can be used to determine whether the request
+    /// was prefixed with `node:` or not.
     ///
     /// `resolved` is always prefixed with "node:" in compliance with the ESM specification.
     #[error("Builtin module {resolved}")]
-    Builtin { resolved: String, prefixed_with_node_colon: bool },
+    Builtin { resolved: String, is_runtime_module: bool },
 
     /// All of the aliased extension are not found
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,16 +325,14 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     //   1. Return the string "node:" concatenated with packageSpecifier.
     fn require_core(&self, specifier: &str) -> Result<(), ResolveError> {
         if self.options.builtin_modules {
-            let starts_with_node = specifier.starts_with("node:");
-            if starts_with_node || NODEJS_BUILTINS.binary_search(&specifier).is_ok() {
-                let mut specifier = specifier.to_string();
-                if !starts_with_node {
-                    specifier = format!("node:{specifier}");
-                }
-                return Err(ResolveError::Builtin {
-                    resolved: specifier,
-                    prefixed_with_node_colon: !starts_with_node,
-                });
+            let is_runtime_module = specifier.starts_with("node:");
+            if is_runtime_module || NODEJS_BUILTINS.binary_search(&specifier).is_ok() {
+                let resolved = if is_runtime_module {
+                    specifier.to_string()
+                } else {
+                    format!("node:{specifier}")
+                };
+                return Err(ResolveError::Builtin { resolved, is_runtime_module });
             }
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,7 +331,10 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 if !starts_with_node {
                     specifier = format!("node:{specifier}");
                 }
-                return Err(ResolveError::Builtin(specifier));
+                return Err(ResolveError::Builtin {
+                    resolved: specifier,
+                    prefixed_with_node_colon: !starts_with_node,
+                });
             }
         }
         Ok(())

--- a/src/tests/builtins.rs
+++ b/src/tests/builtins.rs
@@ -87,8 +87,12 @@ fn builtins() {
     for request in pass {
         let prefixed_request = format!("node:{request}");
         for request in [prefixed_request.clone(), request.to_string()] {
+            let starts_with_node = request.starts_with("node:");
             let resolved_path = resolver.resolve(f, &request).map(|r| r.full_path());
-            let err = ResolveError::Builtin(prefixed_request.clone());
+            let err = ResolveError::Builtin {
+                resolved: prefixed_request.clone(),
+                prefixed_with_node_colon: !starts_with_node,
+            };
             assert_eq!(resolved_path, Err(err), "{request}");
         }
     }
@@ -114,8 +118,12 @@ fn imports() {
     });
 
     for request in ["#fs", "#http"] {
+        let prefixed_with_node_colon = request == "#fs";
         let resolved_path = resolver.resolve(f.clone(), request).map(|r| r.full_path());
-        let err = ResolveError::Builtin(format!("node:{}", request.trim_start_matches('#')));
+        let err = ResolveError::Builtin {
+            resolved: (format!("node:{}", request.trim_start_matches('#'))),
+            prefixed_with_node_colon,
+        };
         assert_eq!(resolved_path, Err(err));
     }
 }

--- a/src/tests/builtins.rs
+++ b/src/tests/builtins.rs
@@ -91,7 +91,7 @@ fn builtins() {
             let resolved_path = resolver.resolve(f, &request).map(|r| r.full_path());
             let err = ResolveError::Builtin {
                 resolved: prefixed_request.clone(),
-                prefixed_with_node_colon: !starts_with_node,
+                is_runtime_module: starts_with_node,
             };
             assert_eq!(resolved_path, Err(err), "{request}");
         }
@@ -117,12 +117,11 @@ fn imports() {
         ..ResolveOptions::default()
     });
 
-    for request in ["#fs", "#http"] {
-        let prefixed_with_node_colon = request == "#fs";
+    for (request, is_runtime_module) in [("#fs", false), ("#http", true)] {
         let resolved_path = resolver.resolve(f.clone(), request).map(|r| r.full_path());
         let err = ResolveError::Builtin {
             resolved: (format!("node:{}", request.trim_start_matches('#'))),
-            prefixed_with_node_colon,
+            is_runtime_module,
         };
         assert_eq!(resolved_path, Err(err));
     }


### PR DESCRIPTION
`ResolveError::Builtin::is_runtime_module` can be used to determine whether the original specifier was prefixed with `node:` or not.