### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,26 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [**breaking**] add `ResolveError::Builtin::prefixed_with_node_colon` ([#272](https://github.com/oxc-project/oxc-resolver/pull/272))
+- [**breaking**] add `add ResolveError::Builtin::is_runtime_module` ([#272](https://github.com/oxc-project/oxc-resolver/pull/272))
 
 ### Fixed
 
 - use `fs::canonicalize` to cover symlink edge cases ([#284](https://github.com/oxc-project/oxc-resolver/pull/284))
 - extensionAlias cannot resolve mathjs ([#273](https://github.com/oxc-project/oxc-resolver/pull/273))
-
-### Other
-
-- fix test warning
-- relax versions for downstream use
-- use default features for `rustc-hash`
-- apply latest `cargo +nightly fmt` ([#281](https://github.com/oxc-project/oxc-resolver/pull/281))
-- add more clippy fixes ([#279](https://github.com/oxc-project/oxc-resolver/pull/279))
-- clean up elided lifetimes ([#277](https://github.com/oxc-project/oxc-resolver/pull/277))
-- *(deps)* update rust crate serde_json to v1.0.132
-- *(deps)* update rust crates ([#266](https://github.com/oxc-project/oxc-resolver/pull/266))
-- *(README)* should be `new ResolverFactory`
-- *(deps)* update rust crates
-- update README
 
 ## [1.12.0](https://github.com/oxc-project/oxc_resolver/compare/oxc_resolver-v1.11.0...oxc_resolver-v1.12.0) - 2024-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/oxc-project/oxc-resolver/compare/oxc_resolver-v1.12.0...oxc_resolver-v2.0.0) - 2024-10-22
+
+### Added
+
+- [**breaking**] add `ResolveError::Builtin::prefixed_with_node_colon` ([#272](https://github.com/oxc-project/oxc-resolver/pull/272))
+
+### Fixed
+
+- use `fs::canonicalize` to cover symlink edge cases ([#284](https://github.com/oxc-project/oxc-resolver/pull/284))
+- extensionAlias cannot resolve mathjs ([#273](https://github.com/oxc-project/oxc-resolver/pull/273))
+
+### Other
+
+- fix test warning
+- relax versions for downstream use
+- use default features for `rustc-hash`
+- apply latest `cargo +nightly fmt` ([#281](https://github.com/oxc-project/oxc-resolver/pull/281))
+- add more clippy fixes ([#279](https://github.com/oxc-project/oxc-resolver/pull/279))
+- clean up elided lifetimes ([#277](https://github.com/oxc-project/oxc-resolver/pull/277))
+- *(deps)* update rust crate serde_json to v1.0.132
+- *(deps)* update rust crates ([#266](https://github.com/oxc-project/oxc-resolver/pull/266))
+- *(README)* should be `new ResolverFactory`
+- *(deps)* update rust crates
+- update README
+
 ## [1.12.0](https://github.com/oxc-project/oxc_resolver/compare/oxc_resolver-v1.11.0...oxc_resolver-v1.12.0) - 2024-09-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "1.12.0"
+version = "2.0.0"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["napi"]
 resolver = "2"
 
 [package]
-version      = "1.12.0"
+version      = "2.0.0"
 name         = "oxc_resolver"
 authors      = ["Boshen <boshenc@gmail.com>"]
 categories   = ["development-tools"]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-resolver",
-  "version": "1.12.0",
+  "version": "null",
   "description": "Oxc Resolver Node API",
   "main": "index.js",
   "browser": "browser.js",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-resolver",
-  "version": "null",
+  "version": "2.0.0",
   "description": "Oxc Resolver Node API",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION
## 🤖 New release
* `oxc_resolver`: 1.12.0 -> 2.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/oxc-project/oxc-resolver/compare/oxc_resolver-v1.12.0...oxc_resolver-v2.0.0) - 2024-10-22

### Added

- [**breaking**] add `ResolveError::Builtin::prefixed_with_node_colon` ([#272](https://github.com/oxc-project/oxc-resolver/pull/272))

### Fixed

- use `fs::canonicalize` to cover symlink edge cases ([#284](https://github.com/oxc-project/oxc-resolver/pull/284))
- extensionAlias cannot resolve mathjs ([#273](https://github.com/oxc-project/oxc-resolver/pull/273))

### Other

- fix test warning
- relax versions for downstream use
- use default features for `rustc-hash`
- apply latest `cargo +nightly fmt` ([#281](https://github.com/oxc-project/oxc-resolver/pull/281))
- add more clippy fixes ([#279](https://github.com/oxc-project/oxc-resolver/pull/279))
- clean up elided lifetimes ([#277](https://github.com/oxc-project/oxc-resolver/pull/277))
- *(deps)* update rust crate serde_json to v1.0.132
- *(deps)* update rust crates ([#266](https://github.com/oxc-project/oxc-resolver/pull/266))
- *(README)* should be `new ResolverFactory`
- *(deps)* update rust crates
- update README
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).