### PR TITLE
fix: determine whether is builtin module after strip `node:` prefix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,9 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     fn require_core(&self, specifier: &str) -> Result<(), ResolveError> {
         if self.options.builtin_modules {
             let is_runtime_module = specifier.starts_with("node:");
-            if is_runtime_module || NODEJS_BUILTINS.binary_search(&specifier).is_ok() {
+            let specifier_without_runtime_prefix =
+                if is_runtime_module { &specifier[5..] } else { specifier };
+            if NODEJS_BUILTINS.binary_search(&specifier_without_runtime_prefix).is_ok() {
                 let resolved = if is_runtime_module {
                     specifier.to_string()
                 } else {

--- a/src/tests/builtins.rs
+++ b/src/tests/builtins.rs
@@ -106,6 +106,12 @@ fn fail() {
     let resolved_path = resolver.resolve(f, request);
     let err = ResolveError::NotFound(request.to_string());
     assert_eq!(resolved_path, Err(err), "{request}");
+
+    // `node:not-builtin` should failed since `not-builtin` is not a node builtin module
+    let request = "node:not-builtin";
+    let resolved_path = resolver.resolve(f, request);
+    let err = ResolveError::NotFound(request.to_string());
+    assert_eq!(resolved_path, Err(err), "{request}");
 }
 
 #[test]


### PR DESCRIPTION
according to the spec: 
> If packageSpecifier is a Node.js builtin module name, then
>    Return the string "node:" concatenated with packageSpecifier.

![image](https://github.com/user-attachments/assets/04033c8f-123c-40e9-a426-cc2d5f5a22b8)
![image](https://github.com/user-attachments/assets/a02183cd-3255-4888-bd3c-2b1e27e6719b)

