### PR TITLE
chore: release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/oxc-project/oxc-resolver/compare/oxc_resolver-v2.0.0...oxc_resolver-v2.0.1) - 2024-11-08
+
+### Other
+
+- bring back the symlink optimization ([#298](https://github.com/oxc-project/oxc-resolver/pull/298))
+- *(deps)* update rust crate criterion2 to v2
+
 ## [2.0.0](https://github.com/oxc-project/oxc-resolver/compare/oxc_resolver-v1.12.0...oxc_resolver-v2.0.0) - 2024-10-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["napi"]
 resolver = "2"
 
 [package]
-version      = "2.0.0"
+version      = "2.0.1"
 name         = "oxc_resolver"
 authors      = ["Boshen <boshenc@gmail.com>"]
 categories   = ["development-tools"]

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-resolver",
-  "version": "2.0.0",
+  "version": "null",
   "description": "Oxc Resolver Node API",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION
## 🤖 New release
* `oxc_resolver`: 2.0.0 -> 2.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.1](https://github.com/oxc-project/oxc-resolver/compare/oxc_resolver-v2.0.0...oxc_resolver-v2.0.1) - 2024-11-08

### Other

- bring back the symlink optimization ([#298](https://github.com/oxc-project/oxc-resolver/pull/298))
- *(deps)* update rust crate criterion2 to v2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).