### PR TITLE
chore: add .yarn to gitignore

### DIFF
--- a/fixtures/pnp/.gitignore
+++ b/fixtures/pnp/.gitignore
@@ -1,1 +1,7 @@
-install_state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions


### PR DESCRIPTION
Since `.yarn/cache` files are not committed in the repo, I guess this repo does not use the Zero-Installs feature. In that case, `.yarn/cache` should be gitignored.
https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
