### PR TITLE
chore: fix just benchmark

### DIFF
--- a/justfile
+++ b/justfile
@@ -58,9 +58,9 @@ doc:
 codecov:
   cargo codecov --html
 
-# Run the benchmarks. See `tasks/benchmark`
+# Run the benchmarks.
 benchmark:
-  cargo benchmark
+  cargo bench
 
 # Run cargo-fuzz
 fuzz:


### PR DESCRIPTION
`cargo benchmark` throws "no such command" on my machine. Probably this should be `cargo bench`?