### PR TITLE
fix: don't panic when resolving `/` with `roots`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         ctx: &mut Ctx,
     ) -> Result<CachedPath, ResolveError> {
         // Make sure only relative or normal paths gets called
-        debug_assert!(Path::new(specifier).components().next().map_or(true, |c| matches!(
+        debug_assert!(Path::new(specifier).components().next().is_some_and(|c| matches!(
             c,
             Component::CurDir | Component::ParentDir | Component::Normal(_)
         )));
@@ -1091,6 +1091,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             return None;
         }
         if let Some(specifier) = specifier.strip_prefix(SLASH_START) {
+            let specifier = if specifier.is_empty() { "./" } else { specifier };
             for root in &self.options.roots {
                 let cached_path = self.cache.value(root);
                 if let Ok(path) = self.require_relative(&cached_path, specifier, ctx) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         ctx: &mut Ctx,
     ) -> Result<CachedPath, ResolveError> {
         // Make sure only relative or normal paths gets called
-        debug_assert!(Path::new(specifier).components().next().is_some_and(|c| matches!(
+        debug_assert!(Path::new(specifier).components().next().map_or(true, |c| matches!(
             c,
             Component::CurDir | Component::ParentDir | Component::Normal(_)
         )));

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -117,3 +117,12 @@ fn resolve_hash_as_module() {
     let resolution = resolver.resolve(f, "#a");
     assert_eq!(resolution, Err(ResolveError::NotFound("#a".into())));
 }
+
+#[test]
+fn resolve_root() {
+    let f = super::fixture();
+    let resolver =
+        Resolver::new(ResolveOptions { roots: vec![f.clone()], ..ResolveOptions::default() });
+    let resolution = resolver.resolve(f, "/");
+    assert_eq!(resolution, Err(ResolveError::NotFound("/".into())));
+}

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -117,12 +117,3 @@ fn resolve_hash_as_module() {
     let resolution = resolver.resolve(f, "#a");
     assert_eq!(resolution, Err(ResolveError::NotFound("#a".into())));
 }
-
-#[test]
-fn resolve_root() {
-    let f = super::fixture();
-    let resolver =
-        Resolver::new(ResolveOptions { roots: vec![f.clone()], ..ResolveOptions::default() });
-    let resolution = resolver.resolve(f, "/");
-    assert_eq!(resolution, Err(ResolveError::NotFound("/".into())));
-}

--- a/src/tests/roots.rs
+++ b/src/tests/roots.rs
@@ -92,7 +92,7 @@ fn roots_fall_through() {
 }
 
 #[test]
-fn should_not_error_with_slash() {
+fn should_not_panic_with_slash() {
     let f = super::fixture();
     let resolver =
         Resolver::new(ResolveOptions { roots: vec![f.clone()], ..ResolveOptions::default() });
@@ -101,14 +101,23 @@ fn should_not_error_with_slash() {
 }
 
 #[test]
-fn should_resolve_slash_to_index() {
+fn should_not_resolve_slash_if_importer_is_not_root() {
     let f = super::fixture();
+    let dir_with_index = super::fixture_root().join("./misc/dir-with-index");
+    let resolver =
+        Resolver::new(ResolveOptions { roots: vec![dir_with_index], ..ResolveOptions::default() });
+    let resolution = resolver.resolve(f, "/").map(|r| r.full_path());
+    assert_eq!(resolution, Err(ResolveError::NotFound("/".into())));
+}
+
+#[test]
+fn should_resolve_slash_to_index() {
     let dir_with_index = super::fixture_root().join("./misc/dir-with-index");
     let resolver = Resolver::new(ResolveOptions {
         roots: vec![dir_with_index.clone()],
         ..ResolveOptions::default()
     });
-    let resolution = resolver.resolve(f, "/").map(|r| r.full_path());
+    let resolution = resolver.resolve(dir_with_index.clone(), "/").map(|r| r.full_path());
     let expected = dir_with_index.join("index.js");
     assert_eq!(resolution, Ok(expected));
 }

--- a/src/tests/roots.rs
+++ b/src/tests/roots.rs
@@ -90,3 +90,25 @@ fn roots_fall_through() {
         Ok(absolute_path)
     );
 }
+
+#[test]
+fn should_not_error_with_slash() {
+    let f = super::fixture();
+    let resolver =
+        Resolver::new(ResolveOptions { roots: vec![f.clone()], ..ResolveOptions::default() });
+    let resolution = resolver.resolve(f, "/");
+    assert_eq!(resolution, Err(ResolveError::NotFound("/".into())));
+}
+
+#[test]
+fn should_resolve_slash_to_index() {
+    let f = super::fixture();
+    let dir_with_index = super::fixture_root().join("./misc/dir-with-index");
+    let resolver = Resolver::new(ResolveOptions {
+        roots: vec![dir_with_index.clone()],
+        ..ResolveOptions::default()
+    });
+    let resolution = resolver.resolve(f, "/").map(|r| r.full_path());
+    let expected = dir_with_index.join("index.js");
+    assert_eq!(resolution, Ok(expected));
+}


### PR DESCRIPTION
When calling `resolve(base_dir, "/?test.css")`, a panic happened.