### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [**breaking**] replace `FileSystem::canonicalize` with `FileSystem::read_link` (#331)
-- faster and stable path hash for the cache (#328)
 
 ### Other
 
 - guard `load_alias` on hot path (#339)
-- use `as_os_str` for `Hash` and `PartialEq` operations (#338)
-- run clippy with `--all-targets` (#333)
-- increase hash size (#329)
-- add dprint (#326)
-- update dependencies
-- *(deps)* update rust crates
-- update README logo
 
 ## [2.1.1](https://github.com/oxc-project/oxc-resolver/compare/oxc_resolver-v2.1.0...oxc_resolver-v2.1.1) - 2024-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/oxc-project/oxc-resolver/compare/oxc_resolver-v2.1.1...oxc_resolver-v3.0.0) - 2024-12-11
+
+### Added
+
+- [**breaking**] replace `FileSystem::canonicalize` with `FileSystem::read_link` (#331)
+- faster and stable path hash for the cache (#328)
+
+### Other
+
+- guard `load_alias` on hot path (#339)
+- use `as_os_str` for `Hash` and `PartialEq` operations (#338)
+- run clippy with `--all-targets` (#333)
+- increase hash size (#329)
+- add dprint (#326)
+- update dependencies
+- *(deps)* update rust crates
+- update README logo
+
 ## [2.1.1](https://github.com/oxc-project/oxc-resolver/compare/oxc_resolver-v2.1.0...oxc_resolver-v2.1.1) - 2024-11-22
 
 ### Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "2.1.1"
+version = "3.0.0"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "oxc_resolver"
-version = "2.1.1"
+version = "3.0.0"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = ["development-tools"]
 edition = "2021"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-resolver",
-  "version": "null",
+  "version": "3.0.0",
   "description": "Oxc Resolver Node API",
   "main": "index.js",
   "browser": "browser.js",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-resolver",
-  "version": "2.1.1",
+  "version": "null",
   "description": "Oxc Resolver Node API",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION
## 🤖 New release
* `oxc_resolver`: 2.1.1 -> 3.0.0 (⚠️ API breaking changes)

### ⚠️ `oxc_resolver` breaking changes

```
--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_method_added.ron

Failed in:
  trait method oxc_resolver::FileSystem::read_link in file /tmp/.tmptmsXac/oxc-resolver/src/file_system.rs:52

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_method_missing.ron

Failed in:
  method canonicalize of trait FileSystem, previously in file /tmp/.tmpa9nJqt/oxc_resolver/src/file_system.rs:62
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.0](https://github.com/oxc-project/oxc-resolver/compare/oxc_resolver-v2.1.1...oxc_resolver-v3.0.0) - 2024-12-12

### Added

- [**breaking**] replace `FileSystem::canonicalize` with `FileSystem::read_link` (#331)
- faster and stable path hash for the cache (#328)

### Other

- guard `load_alias` on hot path (#339)
- use `as_os_str` for `Hash` and `PartialEq` operations (#338)
- run clippy with `--all-targets` (#333)
- increase hash size (#329)
- add dprint (#326)
- update dependencies
- *(deps)* update rust crates
- update README logo
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).