### PR TITLE
fix: normalize resolved result on Windows

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -44,7 +44,7 @@ impl<Fs: FileSystem> Cache<Fs> {
     pub fn value(&self, path: &Path) -> CachedPath {
         let hash = {
             let mut hasher = FxHasher::default();
-            path.as_os_str().hash(&mut hasher);
+            path.hash(&mut hasher);
             hasher.finish()
         };
         if let Some(cache_entry) = self.paths.get((hash, path).borrow() as &dyn CacheKey) {

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -117,3 +117,24 @@ fn resolve_hash_as_module() {
     let resolution = resolver.resolve(f, "#a");
     assert_eq!(resolution, Err(ResolveError::NotFound("#a".into())));
 }
+
+#[cfg(windows)]
+#[test]
+fn resolve_normalized_on_windows() {
+    let f = super::fixture();
+    let absolute = f.join("./foo/index.js");
+    let absolute_str = absolute.to_str().unwrap();
+    let normalized_absolute = absolute_str.replace('\\', "/");
+    let resolver = Resolver::new(ResolveOptions::default());
+
+    let resolution = resolver
+        .resolve(&f, &normalized_absolute)
+        .map(|r| r.full_path().to_str().unwrap().to_owned());
+    assert_eq!(resolution, Ok(absolute_str.to_owned()));
+
+    let normalized_f = f.to_str().unwrap().replace('\\', "/");
+    let resolution = resolver
+        .resolve(normalized_f, ".\\foo\\index.js")
+        .map(|r| r.full_path().to_str().unwrap().to_owned());
+    assert_eq!(resolution, Ok(absolute_str.to_owned()));
+}


### PR DESCRIPTION
#316 seems to break Windows.

If the specifier or the base directory contains a forward slash, the resolved result contained a forward slash.
This causes the same module to be resolved differently (e.g. `C:\\foo.js` and `C:/foo.js`) and ends up bundling the same module twice.

For example, `import './foo.js'; import '.\\foo.js'` should resolve to the same path.

To fix this, without reverting #316, I think it requires thinking about where to normalize the slashes. But it takes some time for me to do that, so in this PR I simply reverted the change.

reverts #316
