### PR TITLE
Use papaya instead of dashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,20 +308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,12 +388,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -516,7 +496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -535,16 +515,6 @@ name = "litrs"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -681,15 +651,16 @@ version = "3.0.3"
 dependencies = [
  "cfg-if",
  "criterion2",
- "dashmap",
  "document-features",
  "indexmap 2.7.0",
  "json-strip-comments",
  "normalize-path",
  "once_cell",
+ "papaya",
  "pnp",
  "rayon",
  "rustc-hash",
+ "seize",
  "serde",
  "serde_json",
  "simdutf8",
@@ -699,16 +670,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.9.10"
+name = "papaya"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "dc7c76487f7eaa00a0fc1d7f88dc6b295aec478d11b0fc79f857b62c2874124c"
 dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
+ "equivalent",
+ "seize",
 ]
 
 [[package]]
@@ -863,10 +831,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
+name = "seize"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "d84b0c858bdd30cb56f5597f8b3bf702ec23829e652cc636a1e5a7b9de46ae93"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "semver"
@@ -1194,6 +1166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,12 @@ name = "resolver"
 
 [dependencies]
 cfg-if = "1"
-dashmap = { version = "6", features = ["raw-api"] }
 indexmap = { version = "2", features = ["serde"] }
 json-strip-comments = "1"
 once_cell = "1" # Use `std::sync::OnceLock::get_or_try_init` when it is stable.
+papaya = "0.1.8"
 rustc-hash = { version = "2" }
+seize = { version = "0.4" }
 serde = { version = "1", features = ["derive"] } # derive for Deserialize from package.json
 serde_json = { version = "1", features = ["preserve_order"] } # preserve_order: package_json.exports requires order such as `["require", "import", "default"]`
 simdutf8 = { version = "0.1" }


### PR DESCRIPTION
This PR replaces uses of `dashmap` in the `Cache` with `papaya`: https://github.com/ibraheemdev/papaya/
`papaya` is designed for read-heavy workloads, which seems quite fitting for your caching use case. We've also switched to it in Biome and are getting good results.

Note this PR currently depends on an unmerged feature I proposed, so I'm leaving it in Draft until this is merged: https://github.com/ibraheemdev/papaya/pull/45

Performance results on my machine:

```
Benchmarking resolver/single-thread: Collecting 100 samples in estimated 5.0029 s (91k iteresolver/single-thread  time:   [53.564 µs 53.785 µs 54.015 µs]
                        change: [−13.249% −11.794% −10.385%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe
Benchmarking resolver/multi-thread: Collecting 100 samples in estimated 5.0311 s (152k iteresolver/multi-thread   time:   [37.287 µs 39.436 µs 41.322 µs]
                        change: [−14.069% −10.050% −5.5926%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  19 (19.00%) high severe
Benchmarking resolver/resolve from symlinks: Collecting 100 samples in estimated 5.2374 s resolver/resolve from symlinks
                        time:   [14.284 ms 14.309 ms 14.334 ms]
                        change: [−7.1326% −6.8864% −6.6154%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```

So a roughly 10~11% speedup on the first two benchmarks, and almost 7% on the one involving symlinks.