### PR TITLE
feat!: generic fs cache `type Resolver = ResolverGeneric<FsCache<FileSystemOs>>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,9 @@ rayon = { version = "1.10.0" }
 vfs = "0.12.0" # for testing with in memory file system
 
 [features]
-default = []
+default = ["fs_cache"]
+## Provides the `FsCache` implementation.
+fs_cache = []
 ## Enables the [PackageJson::raw_json] API,
 ## which returns the `package.json` with `serde_json::Value`.
 package_json_raw_json_api = []

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -79,13 +79,17 @@ pub trait CachedPath: Sized {
         ctx: &mut Ctx,
     ) -> Result<Option<(Self, Arc<PackageJson>)>, ResolveError>;
 
+    #[must_use]
     fn add_extension<C: Cache<Cp = Self>>(&self, ext: &str, cache: &C) -> Self;
 
+    #[must_use]
     fn replace_extension<C: Cache<Cp = Self>>(&self, ext: &str, cache: &C) -> Self;
 
     /// Returns a new path by resolving the given subpath (including "." and
     /// ".." components) with this path.
+    #[must_use]
     fn normalize_with<C: Cache<Cp = Self>>(&self, subpath: impl AsRef<Path>, cache: &C) -> Self;
 
+    #[must_use]
     fn normalize_root<C: Cache<Cp = Self>>(&self, _cache: &C) -> Self;
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,487 +1,91 @@
 use std::{
-    borrow::Cow,
-    cell::RefCell,
-    convert::AsRef,
-    hash::{BuildHasherDefault, Hash, Hasher},
-    io,
-    ops::Deref,
-    path::{Component, Path, PathBuf},
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+    path::{Path, PathBuf},
+    sync::Arc,
 };
 
-use cfg_if::cfg_if;
-use dashmap::{DashMap, DashSet};
-use once_cell::sync::OnceCell as OnceLock;
-use rustc_hash::FxHasher;
+use crate::{tsconfig::TsConfig, Ctx, PackageJson, ResolveError, ResolveOptions};
 
-use crate::{
-    context::ResolveContext as Ctx, package_json::PackageJson, path::PathUtil, FileMetadata,
-    FileSystem, ResolveError, ResolveOptions, TsConfig,
-};
+#[allow(clippy::missing_errors_doc)] // trait impls should be free to return any typesafe error
+pub trait Cache: Sized {
+    type Cp: CachedPath + Clone;
 
-static THREAD_COUNT: AtomicU64 = AtomicU64::new(1);
+    /// Clears the cache.
+    fn clear(&self);
 
-thread_local! {
-    /// Per-thread pre-allocated path that is used to perform operations on paths more quickly.
-    /// Learned from parcel <https://github.com/parcel-bundler/parcel/blob/a53f8f3ba1025c7ea8653e9719e0a61ef9717079/crates/parcel-resolver/src/cache.rs#L394>
-  pub static SCRATCH_PATH: RefCell<PathBuf> = RefCell::new(PathBuf::with_capacity(256));
-  pub static THREAD_ID: u64 = THREAD_COUNT.fetch_add(1, Ordering::SeqCst);
-}
+    /// Returns the cached value for a given path.
+    fn value(&self, path: &Path) -> Self::Cp;
 
-#[derive(Default)]
-pub struct Cache<Fs> {
-    pub(crate) fs: Fs,
-    paths: DashSet<PathEntry<'static>, BuildHasherDefault<IdentityHasher>>,
-    tsconfigs: DashMap<PathBuf, Arc<TsConfig>, BuildHasherDefault<FxHasher>>,
-}
+    /// Returns the canonical version of a `path`, resolving all symbolic links.
+    fn canonicalize(&self, path: &Self::Cp) -> Result<PathBuf, ResolveError>;
 
-/// An entry in the path cache. Can also be borrowed for lookups without allocations.
-enum PathEntry<'a> {
-    Owned(CachedPath),
-    Borrowed { hash: u64, path: &'a Path },
-}
+    /// Returns whether the given `path` points to a file.
+    fn is_file(&self, path: &Self::Cp, ctx: &mut Ctx) -> bool;
 
-impl Hash for PathEntry<'_> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            PathEntry::Owned(entry) => {
-                entry.hash.hash(state);
-            }
-            PathEntry::Borrowed { hash, .. } => {
-                hash.hash(state);
-            }
-        }
-    }
-}
+    /// Returns whether the given `path` points to a file.
+    fn is_dir(&self, path: &Self::Cp, ctx: &mut Ctx) -> bool;
 
-impl PartialEq for PathEntry<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        let self_path = match self {
-            PathEntry::Owned(info) => &info.path,
-            PathEntry::Borrowed { path, .. } => *path,
-        };
-        let other_path = match other {
-            PathEntry::Owned(info) => &info.path,
-            PathEntry::Borrowed { path, .. } => *path,
-        };
-        self_path.as_os_str() == other_path.as_os_str()
-    }
-}
-impl Eq for PathEntry<'_> {}
+    /// Returns the package.json stored in the given directory, if one exists.
+    ///
+    /// `path` is the path to a directory from which the `package.json` will be
+    /// read.
+    #[allow(clippy::type_complexity)]
+    fn get_package_json(
+        &self,
+        path: &Self::Cp,
+        options: &ResolveOptions,
+        ctx: &mut Ctx,
+    ) -> Result<Option<(Self::Cp, Arc<PackageJson>)>, ResolveError>;
 
-impl<Fs: FileSystem> Cache<Fs> {
-    pub fn new(fs: Fs) -> Self {
-        Self { fs, paths: DashSet::default(), tsconfigs: DashMap::default() }
-    }
-
-    pub fn clear(&self) {
-        self.paths.clear();
-        self.tsconfigs.clear();
-    }
-
-    #[allow(clippy::cast_possible_truncation)]
-    pub fn value(&self, path: &Path) -> CachedPath {
-        // `Path::hash` is slow: https://doc.rust-lang.org/std/path/struct.Path.html#impl-Hash-for-Path
-        // `path.as_os_str()` hash is not stable because we may joined a path like `foo/bar` and `foo\\bar` on windows.
-        let hash = {
-            let mut hasher = FxHasher::default();
-            path.as_os_str().hash(&mut hasher);
-            hasher.finish()
-        };
-        let key = PathEntry::Borrowed { hash, path };
-        // A DashMap is just an array of RwLock<HashSet>, sharded by hash to reduce lock contention.
-        // This uses the low level raw API to avoid cloning the value when using the `entry` method.
-        // First, find which shard the value is in, and check to see if we already have a value in the map.
-        let shard = self.paths.determine_shard(hash as usize);
-        {
-            // Scope the read lock.
-            let map = self.paths.shards()[shard].read();
-            if let Some((PathEntry::Owned(entry), _)) = map.get(hash, |v| v.0 == key) {
-                return entry.clone();
-            }
-        }
-        let parent = path.parent().map(|p| self.value(p));
-        let cached_path = CachedPath(Arc::new(CachedPathImpl::new(
-            hash,
-            path.to_path_buf().into_boxed_path(),
-            parent,
-        )));
-        self.paths.insert(PathEntry::Owned(cached_path.clone()));
-        cached_path
-    }
-
-    pub fn tsconfig<F: FnOnce(&mut TsConfig) -> Result<(), ResolveError>>(
+    /// Returns the tsconfig stored in the given path.
+    ///
+    /// `path` is either the path to a tsconfig (with or without `.json`
+    /// extension) or a directory from which the `tsconfig.json` will be read.
+    ///
+    /// `callback` can be used for modifying the returned tsconfig with
+    /// `extends`.
+    fn get_tsconfig<F: FnOnce(&mut TsConfig) -> Result<(), ResolveError>>(
         &self,
         root: bool,
         path: &Path,
-        callback: F, // callback for modifying tsconfig with `extends`
-    ) -> Result<Arc<TsConfig>, ResolveError> {
-        if let Some(tsconfig_ref) = self.tsconfigs.get(path) {
-            return Ok(Arc::clone(tsconfig_ref.value()));
-        }
-        let meta = self.fs.metadata(path).ok();
-        let tsconfig_path = if meta.is_some_and(|m| m.is_file) {
-            Cow::Borrowed(path)
-        } else if meta.is_some_and(|m| m.is_dir) {
-            Cow::Owned(path.join("tsconfig.json"))
-        } else {
-            let mut os_string = path.to_path_buf().into_os_string();
-            os_string.push(".json");
-            Cow::Owned(PathBuf::from(os_string))
-        };
-        let mut tsconfig_string = self
-            .fs
-            .read_to_string(&tsconfig_path)
-            .map_err(|_| ResolveError::TsconfigNotFound(path.to_path_buf()))?;
-        let mut tsconfig =
-            TsConfig::parse(root, &tsconfig_path, &mut tsconfig_string).map_err(|error| {
-                ResolveError::from_serde_json_error(tsconfig_path.to_path_buf(), &error)
-            })?;
-        callback(&mut tsconfig)?;
-        let tsconfig = Arc::new(tsconfig.build());
-        self.tsconfigs.insert(path.to_path_buf(), Arc::clone(&tsconfig));
-        Ok(tsconfig)
-    }
+        callback: F,
+    ) -> Result<Arc<TsConfig>, ResolveError>;
 }
 
-#[derive(Clone)]
-pub struct CachedPath(Arc<CachedPathImpl>);
+pub trait CachedPath: Sized {
+    fn path(&self) -> &Path;
 
-pub struct CachedPathImpl {
-    hash: u64,
-    path: Box<Path>,
-    parent: Option<CachedPath>,
-    meta: OnceLock<Option<FileMetadata>>,
-    canonicalized: OnceLock<Result<CachedPath, ResolveError>>,
-    canonicalizing: AtomicU64,
-    node_modules: OnceLock<Option<CachedPath>>,
-    package_json: OnceLock<Option<(CachedPath, Arc<PackageJson>)>>,
-}
+    fn to_path_buf(&self) -> PathBuf;
 
-impl CachedPathImpl {
-    const fn new(hash: u64, path: Box<Path>, parent: Option<CachedPath>) -> Self {
-        Self {
-            hash,
-            path,
-            parent,
-            meta: OnceLock::new(),
-            canonicalized: OnceLock::new(),
-            canonicalizing: AtomicU64::new(0),
-            node_modules: OnceLock::new(),
-            package_json: OnceLock::new(),
-        }
-    }
-}
+    fn parent(&self) -> Option<&Self>;
 
-impl Deref for CachedPath {
-    type Target = CachedPathImpl;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
-    }
-}
-
-impl CachedPath {
-    pub fn path(&self) -> &Path {
-        &self.0.path
-    }
-
-    pub fn to_path_buf(&self) -> PathBuf {
-        self.path.to_path_buf()
-    }
-
-    pub fn parent(&self) -> Option<&Self> {
-        self.0.parent.as_ref()
-    }
-
-    fn meta<Fs: FileSystem>(&self, fs: &Fs) -> Option<FileMetadata> {
-        *self.meta.get_or_init(|| fs.metadata(&self.path).ok())
-    }
-
-    pub fn is_file<Fs: FileSystem>(&self, fs: &Fs, ctx: &mut Ctx) -> bool {
-        if let Some(meta) = self.meta(fs) {
-            ctx.add_file_dependency(self.path());
-            meta.is_file
-        } else {
-            ctx.add_missing_dependency(self.path());
-            false
-        }
-    }
-
-    pub fn is_dir<Fs: FileSystem>(&self, fs: &Fs, ctx: &mut Ctx) -> bool {
-        self.meta(fs).map_or_else(
-            || {
-                ctx.add_missing_dependency(self.path());
-                false
-            },
-            |meta| meta.is_dir,
-        )
-    }
-
-    pub fn canonicalize<Fs: FileSystem>(&self, cache: &Cache<Fs>) -> Result<PathBuf, ResolveError> {
-        let cached_path = self.canocalize_impl(cache)?;
-        let path = cached_path.to_path_buf();
-        cfg_if! {
-            if #[cfg(windows)] {
-                let path = crate::FileSystemOs::strip_windows_prefix(path);
-            }
-        }
-        Ok(path)
-    }
-
-    /// Returns the canonical path, resolving all symbolic links.
-    ///
-    /// <https://github.com/parcel-bundler/parcel/blob/4d27ec8b8bd1792f536811fef86e74a31fa0e704/crates/parcel-resolver/src/cache.rs#L232>
-    fn canocalize_impl<Fs: FileSystem>(&self, cache: &Cache<Fs>) -> Result<Self, ResolveError> {
-        // Check if this thread is already canonicalizing. If so, we have found a circular symlink.
-        // If a different thread is canonicalizing, OnceLock will queue this thread to wait for the result.
-        let tid = THREAD_ID.with(|t| *t);
-        if self.0.canonicalizing.load(Ordering::Acquire) == tid {
-            return Err(io::Error::new(io::ErrorKind::NotFound, "Circular symlink").into());
-        }
-
-        self.0
-            .canonicalized
-            .get_or_init(|| {
-                self.0.canonicalizing.store(tid, Ordering::Release);
-
-                let res = self.parent().map_or_else(
-                    || Ok(self.normalize_root(cache)),
-                    |parent| {
-                        parent.canocalize_impl(cache).and_then(|parent_canonical| {
-                            let path = parent_canonical.normalize_with(
-                                self.path().strip_prefix(parent.path()).unwrap(),
-                                cache,
-                            );
-
-                            if cache.fs.symlink_metadata(self.path()).is_ok_and(|m| m.is_symlink) {
-                                let link = cache.fs.read_link(path.path())?;
-                                if link.is_absolute() {
-                                    return cache.value(&link.normalize()).canocalize_impl(cache);
-                                } else if let Some(dir) = path.parent() {
-                                    // Symlink is relative `../../foo.js`, use the path directory
-                                    // to resolve this symlink.
-                                    return dir.normalize_with(&link, cache).canocalize_impl(cache);
-                                }
-                                debug_assert!(
-                                    false,
-                                    "Failed to get path parent for {:?}.",
-                                    path.path()
-                                );
-                            }
-
-                            Ok(path)
-                        })
-                    },
-                );
-
-                self.0.canonicalizing.store(0, Ordering::Release);
-                res
-            })
-            .clone()
-    }
-
-    pub fn module_directory<Fs: FileSystem>(
+    fn module_directory<C: Cache<Cp = Self>>(
         &self,
         module_name: &str,
-        cache: &Cache<Fs>,
+        cache: &C,
         ctx: &mut Ctx,
-    ) -> Option<Self> {
-        let cached_path = cache.value(&self.path.join(module_name));
-        cached_path.is_dir(&cache.fs, ctx).then_some(cached_path)
-    }
+    ) -> Option<Self>;
 
-    pub fn cached_node_modules<Fs: FileSystem>(
-        &self,
-        cache: &Cache<Fs>,
-        ctx: &mut Ctx,
-    ) -> Option<Self> {
-        self.node_modules.get_or_init(|| self.module_directory("node_modules", cache, ctx)).clone()
-    }
-
-    /// Get package.json of the given path.
-    ///
-    /// # Errors
-    ///
-    /// * [ResolveError::JSON]
-    pub fn package_json<Fs: FileSystem>(
-        &self,
-        options: &ResolveOptions,
-        cache: &Cache<Fs>,
-        ctx: &mut Ctx,
-    ) -> Result<Option<(Self, Arc<PackageJson>)>, ResolveError> {
-        // Change to `std::sync::OnceLock::get_or_try_init` when it is stable.
-        let result = self
-            .package_json
-            .get_or_try_init(|| {
-                let package_json_path = self.path.join("package.json");
-                let Ok(package_json_string) = cache.fs.read_to_string(&package_json_path) else {
-                    return Ok(None);
-                };
-                let real_path = if options.symlinks {
-                    self.canonicalize(cache)?.join("package.json")
-                } else {
-                    package_json_path.clone()
-                };
-                PackageJson::parse(package_json_path.clone(), real_path, &package_json_string)
-                    .map(|package_json| Some((self.clone(), (Arc::new(package_json)))))
-                    .map_err(|error| ResolveError::from_serde_json_error(package_json_path, &error))
-            })
-            .cloned();
-        // https://github.com/webpack/enhanced-resolve/blob/58464fc7cb56673c9aa849e68e6300239601e615/lib/DescriptionFileUtils.js#L68-L82
-        match &result {
-            Ok(Some((_, package_json))) => {
-                ctx.add_file_dependency(&package_json.path);
-            }
-            Ok(None) => {
-                // Avoid an allocation by making this lazy
-                if let Some(deps) = &mut ctx.missing_dependencies {
-                    deps.push(self.path.join("package.json"));
-                }
-            }
-            Err(_) => {
-                if let Some(deps) = &mut ctx.file_dependencies {
-                    deps.push(self.path.join("package.json"));
-                }
-            }
-        }
-        result
-    }
+    fn cached_node_modules<C: Cache<Cp = Self>>(&self, cache: &C, ctx: &mut Ctx) -> Option<Self>;
 
     /// Find package.json of a path by traversing parent directories.
     ///
     /// # Errors
     ///
     /// * [ResolveError::JSON]
-    pub fn find_package_json<Fs: FileSystem>(
+    fn find_package_json<C: Cache<Cp = Self>>(
         &self,
         options: &ResolveOptions,
-        cache: &Cache<Fs>,
+        cache: &C,
         ctx: &mut Ctx,
-    ) -> Result<Option<(Self, Arc<PackageJson>)>, ResolveError> {
-        let mut cache_value = self;
-        // Go up directories when the querying path is not a directory
-        while !cache_value.is_dir(&cache.fs, ctx) {
-            if let Some(cv) = &cache_value.parent {
-                cache_value = cv;
-            } else {
-                break;
-            }
-        }
-        let mut cache_value = Some(cache_value);
-        while let Some(cv) = cache_value {
-            if let Some(package_json) = cv.package_json(options, cache, ctx)? {
-                return Ok(Some(package_json));
-            }
-            cache_value = cv.parent.as_ref();
-        }
-        Ok(None)
-    }
+    ) -> Result<Option<(Self, Arc<PackageJson>)>, ResolveError>;
 
-    pub fn add_extension<Fs: FileSystem>(&self, ext: &str, cache: &Cache<Fs>) -> Self {
-        SCRATCH_PATH.with_borrow_mut(|path| {
-            path.clear();
-            let s = path.as_mut_os_string();
-            s.push(self.path.as_os_str());
-            s.push(ext);
-            cache.value(path)
-        })
-    }
+    fn add_extension<C: Cache<Cp = Self>>(&self, ext: &str, cache: &C) -> Self;
 
-    pub fn replace_extension<Fs: FileSystem>(&self, ext: &str, cache: &Cache<Fs>) -> Self {
-        SCRATCH_PATH.with_borrow_mut(|path| {
-            path.clear();
-            let s = path.as_mut_os_string();
-            let self_len = self.path.as_os_str().len();
-            let self_bytes = self.path.as_os_str().as_encoded_bytes();
-            let slice_to_copy = self.path.extension().map_or(self_bytes, |previous_extension| {
-                &self_bytes[..self_len - previous_extension.len() - 1]
-            });
-            // SAFETY: ???
-            s.push(unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(slice_to_copy) });
-            s.push(ext);
-            cache.value(path)
-        })
-    }
+    fn replace_extension<C: Cache<Cp = Self>>(&self, ext: &str, cache: &C) -> Self;
 
-    /// Returns a new path by resolving the given subpath (including "." and ".." components) with this path.
-    pub fn normalize_with<P, Fs>(&self, subpath: P, cache: &Cache<Fs>) -> Self
-    where
-        P: AsRef<Path>,
-        Fs: FileSystem,
-    {
-        let subpath = subpath.as_ref();
-        let mut components = subpath.components();
-        let Some(head) = components.next() else { return cache.value(subpath) };
-        if matches!(head, Component::Prefix(..) | Component::RootDir) {
-            return cache.value(subpath);
-        }
-        SCRATCH_PATH.with_borrow_mut(|path| {
-            path.clear();
-            path.push(&self.path);
-            for component in std::iter::once(head).chain(components) {
-                match component {
-                    Component::CurDir => {}
-                    Component::ParentDir => {
-                        path.pop();
-                    }
-                    Component::Normal(c) => {
-                        cfg_if! {
-                            if #[cfg(target_family = "wasm")] {
-                                // Need to trim the extra \0 introduces by https://github.com/nodejs/uvwasi/issues/262
-                                path.push(c.to_string_lossy().trim_end_matches('\0'));
-                            } else {
-                                path.push(c);
-                            }
-                        }
-                    }
-                    Component::Prefix(..) | Component::RootDir => {
-                        unreachable!("Path {:?} Subpath {:?}", self.path, subpath)
-                    }
-                }
-            }
+    /// Returns a new path by resolving the given subpath (including "." and
+    /// ".." components) with this path.
+    fn normalize_with<C: Cache<Cp = Self>>(&self, subpath: impl AsRef<Path>, cache: &C) -> Self;
 
-            cache.value(path)
-        })
-    }
-
-    #[inline]
-    #[cfg(windows)]
-    pub fn normalize_root<Fs: FileSystem>(&self, cache: &Cache<Fs>) -> Self {
-        if self.path().as_os_str().as_encoded_bytes().last() == Some(&b'/') {
-            let mut path_string = self.path.to_string_lossy().into_owned();
-            path_string.pop();
-            path_string.push('\\');
-            cache.value(&PathBuf::from(path_string))
-        } else {
-            self.clone()
-        }
-    }
-    #[inline]
-    #[cfg(not(windows))]
-    pub fn normalize_root<Fs: FileSystem>(&self, _cache: &Cache<Fs>) -> Self {
-        self.clone()
-    }
-}
-
-/// Since the cache key is memoized, use an identity hasher
-/// to avoid double cache.
-#[derive(Default)]
-struct IdentityHasher(u64);
-
-impl Hasher for IdentityHasher {
-    fn write(&mut self, _: &[u8]) {
-        unreachable!("Invalid use of IdentityHasher")
-    }
-
-    fn write_u64(&mut self, n: u64) {
-        self.0 = n;
-    }
-
-    fn finish(&self) -> u64 {
-        self.0
-    }
+    fn normalize_root<C: Cache<Cp = Self>>(&self, _cache: &C) -> Self;
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,15 +1,9 @@
-use std::{
-    ops::{Deref, DerefMut},
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use crate::error::ResolveError;
 
 #[derive(Debug, Default, Clone)]
-pub struct ResolveContext(ResolveContextImpl);
-
-#[derive(Debug, Default, Clone)]
-pub struct ResolveContextImpl {
+pub struct ResolveContext {
     pub fully_specified: bool,
 
     pub query: Option<String>,
@@ -27,20 +21,6 @@ pub struct ResolveContextImpl {
 
     /// For avoiding infinite recursion, which will cause stack overflow.
     depth: u8,
-}
-
-impl Deref for ResolveContext {
-    type Target = ResolveContextImpl;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for ResolveContext {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
 }
 
 impl ResolveContext {
@@ -78,6 +58,11 @@ impl ResolveContext {
         self.resolving_alias = Some(alias);
     }
 
+    /// Increases the context's depth in order to detect recursion.
+    ///
+    /// ### Errors
+    ///
+    /// * [ResolveError::Recursion]
     pub fn test_for_infinite_recursion(&mut self) -> Result<(), ResolveError> {
         self.depth += 1;
         // 64 should be more than enough for detecting infinite recursion.

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,7 +107,8 @@ impl ResolveError {
         matches!(self, Self::Ignored(_))
     }
 
-    pub(crate) fn from_serde_json_error(path: PathBuf, error: &serde_json::Error) -> Self {
+    #[must_use]
+    pub fn from_serde_json_error(path: PathBuf, error: &serde_json::Error) -> Self {
         Self::JSON(JSONError {
             path,
             message: error.to_string(),

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -65,6 +65,21 @@ impl FileMetadata {
     pub const fn new(is_file: bool, is_dir: bool, is_symlink: bool) -> Self {
         Self { is_file, is_dir, is_symlink }
     }
+
+    #[must_use]
+    pub const fn is_file(self) -> bool {
+        self.is_file
+    }
+
+    #[must_use]
+    pub const fn is_dir(self) -> bool {
+        self.is_dir
+    }
+
+    #[must_use]
+    pub const fn is_symlink(self) -> bool {
+        self.is_symlink
+    }
 }
 
 #[cfg(feature = "yarn_pnp")]

--- a/src/fs_cache.rs
+++ b/src/fs_cache.rs
@@ -1,0 +1,499 @@
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    convert::AsRef,
+    hash::{BuildHasherDefault, Hash, Hasher},
+    io,
+    ops::Deref,
+    path::{Component, Path, PathBuf},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use cfg_if::cfg_if;
+use dashmap::{DashMap, DashSet};
+use once_cell::sync::OnceCell as OnceLock;
+use rustc_hash::FxHasher;
+
+use crate::{
+    cache::{Cache, CachedPath},
+    context::ResolveContext as Ctx,
+    package_json::PackageJson,
+    path::PathUtil,
+    FileMetadata, FileSystem, ResolveError, ResolveOptions, TsConfig,
+};
+
+static THREAD_COUNT: AtomicU64 = AtomicU64::new(1);
+
+thread_local! {
+    /// Per-thread pre-allocated path that is used to perform operations on paths more quickly.
+    /// Learned from parcel <https://github.com/parcel-bundler/parcel/blob/a53f8f3ba1025c7ea8653e9719e0a61ef9717079/crates/parcel-resolver/src/cache.rs#L394>
+  pub static SCRATCH_PATH: RefCell<PathBuf> = RefCell::new(PathBuf::with_capacity(256));
+  pub static THREAD_ID: u64 = THREAD_COUNT.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Cache implementation used for caching filesystem access.
+#[derive(Default)]
+pub struct FsCache<Fs> {
+    pub(crate) fs: Fs,
+    paths: DashSet<PathEntry<'static>, BuildHasherDefault<IdentityHasher>>,
+    tsconfigs: DashMap<PathBuf, Arc<TsConfig>, BuildHasherDefault<FxHasher>>,
+}
+
+/// An entry in the path cache. Can also be borrowed for lookups without allocations.
+enum PathEntry<'a> {
+    Owned(FsCachedPath),
+    Borrowed { hash: u64, path: &'a Path },
+}
+
+impl Hash for PathEntry<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            PathEntry::Owned(entry) => {
+                entry.hash.hash(state);
+            }
+            PathEntry::Borrowed { hash, .. } => {
+                hash.hash(state);
+            }
+        }
+    }
+}
+
+impl PartialEq for PathEntry<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        let self_path = match self {
+            PathEntry::Owned(info) => &info.path,
+            PathEntry::Borrowed { path, .. } => *path,
+        };
+        let other_path = match other {
+            PathEntry::Owned(info) => &info.path,
+            PathEntry::Borrowed { path, .. } => *path,
+        };
+        self_path.as_os_str() == other_path.as_os_str()
+    }
+}
+impl Eq for PathEntry<'_> {}
+
+impl<Fs: FileSystem> Cache for FsCache<Fs> {
+    type Cp = FsCachedPath;
+
+    fn clear(&self) {
+        self.paths.clear();
+        self.tsconfigs.clear();
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn value(&self, path: &Path) -> FsCachedPath {
+        // `Path::hash` is slow: https://doc.rust-lang.org/std/path/struct.Path.html#impl-Hash-for-Path
+        // `path.as_os_str()` hash is not stable because we may joined a path like `foo/bar` and `foo\\bar` on windows.
+        let hash = {
+            let mut hasher = FxHasher::default();
+            path.as_os_str().hash(&mut hasher);
+            hasher.finish()
+        };
+        let key = PathEntry::Borrowed { hash, path };
+        // A DashMap is just an array of RwLock<HashSet>, sharded by hash to reduce lock contention.
+        // This uses the low level raw API to avoid cloning the value when using the `entry` method.
+        // First, find which shard the value is in, and check to see if we already have a value in the map.
+        let shard = self.paths.determine_shard(hash as usize);
+        {
+            // Scope the read lock.
+            let map = self.paths.shards()[shard].read();
+            if let Some((PathEntry::Owned(entry), _)) = map.get(hash, |v| v.0 == key) {
+                return entry.clone();
+            }
+        }
+        let parent = path.parent().map(|p| self.value(p));
+        let cached_path = FsCachedPath(Arc::new(CachedPathImpl::new(
+            hash,
+            path.to_path_buf().into_boxed_path(),
+            parent,
+        )));
+        self.paths.insert(PathEntry::Owned(cached_path.clone()));
+        cached_path
+    }
+
+    fn canonicalize(&self, path: &Self::Cp) -> Result<PathBuf, ResolveError> {
+        let cached_path = self.canonicalize_impl(path)?;
+        let path = cached_path.to_path_buf();
+        cfg_if! {
+            if #[cfg(windows)] {
+                let path = crate::FileSystemOs::strip_windows_prefix(path);
+            }
+        }
+        Ok(path)
+    }
+
+    fn is_file(&self, path: &Self::Cp, ctx: &mut Ctx) -> bool {
+        if let Some(meta) = path.meta(&self.fs) {
+            ctx.add_file_dependency(path.path());
+            meta.is_file
+        } else {
+            ctx.add_missing_dependency(path.path());
+            false
+        }
+    }
+
+    fn is_dir(&self, path: &Self::Cp, ctx: &mut Ctx) -> bool {
+        path.meta(&self.fs).map_or_else(
+            || {
+                ctx.add_missing_dependency(path.path());
+                false
+            },
+            |meta| meta.is_dir,
+        )
+    }
+
+    fn get_package_json(
+        &self,
+        path: &Self::Cp,
+        options: &ResolveOptions,
+        ctx: &mut Ctx,
+    ) -> Result<Option<(Self::Cp, Arc<PackageJson>)>, ResolveError> {
+        // Change to `std::sync::OnceLock::get_or_try_init` when it is stable.
+        let result = path
+            .package_json
+            .get_or_try_init(|| {
+                let package_json_path = path.path.join("package.json");
+                let Ok(package_json_string) = self.fs.read_to_string(&package_json_path) else {
+                    return Ok(None);
+                };
+                let real_path = if options.symlinks {
+                    self.canonicalize(path)?.join("package.json")
+                } else {
+                    package_json_path.clone()
+                };
+                PackageJson::parse(package_json_path.clone(), real_path, &package_json_string)
+                    .map(|package_json| Some((path.clone(), (Arc::new(package_json)))))
+                    .map_err(|error| ResolveError::from_serde_json_error(package_json_path, &error))
+            })
+            .cloned();
+        // https://github.com/webpack/enhanced-resolve/blob/58464fc7cb56673c9aa849e68e6300239601e615/lib/DescriptionFileUtils.js#L68-L82
+        match &result {
+            Ok(Some((_, package_json))) => {
+                ctx.add_file_dependency(&package_json.path);
+            }
+            Ok(None) => {
+                // Avoid an allocation by making this lazy
+                if let Some(deps) = &mut ctx.missing_dependencies {
+                    deps.push(path.path.join("package.json"));
+                }
+            }
+            Err(_) => {
+                if let Some(deps) = &mut ctx.file_dependencies {
+                    deps.push(path.path.join("package.json"));
+                }
+            }
+        }
+        result
+    }
+
+    fn get_tsconfig<F: FnOnce(&mut TsConfig) -> Result<(), ResolveError>>(
+        &self,
+        root: bool,
+        path: &Path,
+        callback: F, // callback for modifying tsconfig with `extends`
+    ) -> Result<Arc<TsConfig>, ResolveError> {
+        if let Some(tsconfig) = self.tsconfigs.get(path) {
+            return Ok(Arc::clone(&tsconfig));
+        }
+        let meta = self.fs.metadata(path).ok();
+        let tsconfig_path = if meta.is_some_and(|m| m.is_file) {
+            Cow::Borrowed(path)
+        } else if meta.is_some_and(|m| m.is_dir) {
+            Cow::Owned(path.join("tsconfig.json"))
+        } else {
+            let mut os_string = path.to_path_buf().into_os_string();
+            os_string.push(".json");
+            Cow::Owned(PathBuf::from(os_string))
+        };
+        let mut tsconfig_string = self
+            .fs
+            .read_to_string(&tsconfig_path)
+            .map_err(|_| ResolveError::TsconfigNotFound(path.to_path_buf()))?;
+        let mut tsconfig =
+            TsConfig::parse(root, &tsconfig_path, &mut tsconfig_string).map_err(|error| {
+                ResolveError::from_serde_json_error(tsconfig_path.to_path_buf(), &error)
+            })?;
+        callback(&mut tsconfig)?;
+        let tsconfig = Arc::new(tsconfig.build());
+        self.tsconfigs.insert(path.to_path_buf(), Arc::clone(&tsconfig));
+        Ok(tsconfig)
+    }
+}
+
+impl<Fs: FileSystem> FsCache<Fs> {
+    pub fn new(fs: Fs) -> Self {
+        Self { fs, paths: DashSet::default(), tsconfigs: DashMap::default() }
+    }
+
+    /// Returns the canonical path, resolving all symbolic links.
+    ///
+    /// <https://github.com/parcel-bundler/parcel/blob/4d27ec8b8bd1792f536811fef86e74a31fa0e704/crates/parcel-resolver/src/cache.rs#L232>
+    fn canonicalize_impl(&self, path: &FsCachedPath) -> Result<FsCachedPath, ResolveError> {
+        // Check if this thread is already canonicalizing. If so, we have found a circular symlink.
+        // If a different thread is canonicalizing, OnceLock will queue this thread to wait for the result.
+        let tid = THREAD_ID.with(|t| *t);
+        if path.canonicalizing.load(Ordering::Acquire) == tid {
+            return Err(io::Error::new(io::ErrorKind::NotFound, "Circular symlink").into());
+        }
+
+        path.canonicalized
+            .get_or_init(|| {
+                path.canonicalizing.store(tid, Ordering::Release);
+
+                let res = path.parent().map_or_else(
+                    || Ok(path.normalize_root(self)),
+                    |parent| {
+                        self.canonicalize_impl(parent).and_then(|parent_canonical| {
+                            let normalized = parent_canonical.normalize_with(
+                                path.path().strip_prefix(parent.path()).unwrap(),
+                                self,
+                            );
+
+                            if self.fs.symlink_metadata(path.path()).is_ok_and(|m| m.is_symlink) {
+                                let link = self.fs.read_link(normalized.path())?;
+                                if link.is_absolute() {
+                                    return self.canonicalize_impl(&self.value(&link.normalize()));
+                                } else if let Some(dir) = normalized.parent() {
+                                    // Symlink is relative `../../foo.js`, use the path directory
+                                    // to resolve this symlink.
+                                    return self
+                                        .canonicalize_impl(&dir.normalize_with(&link, self));
+                                }
+                                debug_assert!(
+                                    false,
+                                    "Failed to get path parent for {:?}.",
+                                    normalized.path()
+                                );
+                            }
+
+                            Ok(normalized)
+                        })
+                    },
+                );
+
+                path.canonicalizing.store(0, Ordering::Release);
+                res
+            })
+            .clone()
+    }
+}
+
+#[derive(Clone)]
+pub struct FsCachedPath(Arc<CachedPathImpl>);
+
+pub struct CachedPathImpl {
+    hash: u64,
+    path: Box<Path>,
+    parent: Option<FsCachedPath>,
+    meta: OnceLock<Option<FileMetadata>>,
+    canonicalized: OnceLock<Result<FsCachedPath, ResolveError>>,
+    canonicalizing: AtomicU64,
+    node_modules: OnceLock<Option<FsCachedPath>>,
+    package_json: OnceLock<Option<(FsCachedPath, Arc<PackageJson>)>>,
+}
+
+impl CachedPathImpl {
+    const fn new(hash: u64, path: Box<Path>, parent: Option<FsCachedPath>) -> Self {
+        Self {
+            hash,
+            path,
+            parent,
+            meta: OnceLock::new(),
+            canonicalized: OnceLock::new(),
+            canonicalizing: AtomicU64::new(0),
+            node_modules: OnceLock::new(),
+            package_json: OnceLock::new(),
+        }
+    }
+}
+
+impl Deref for FsCachedPath {
+    type Target = CachedPathImpl;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl CachedPath for FsCachedPath {
+    fn path(&self) -> &Path {
+        &self.0.path
+    }
+
+    fn to_path_buf(&self) -> PathBuf {
+        self.path.to_path_buf()
+    }
+
+    fn parent(&self) -> Option<&Self> {
+        self.0.parent.as_ref()
+    }
+
+    fn module_directory<C: Cache<Cp = Self>>(
+        &self,
+        module_name: &str,
+        cache: &C,
+        ctx: &mut Ctx,
+    ) -> Option<Self> {
+        let cached_path = cache.value(&self.path.join(module_name));
+        cache.is_dir(&cached_path, ctx).then_some(cached_path)
+    }
+
+    fn cached_node_modules<C: Cache<Cp = Self>>(&self, cache: &C, ctx: &mut Ctx) -> Option<Self> {
+        self.node_modules.get_or_init(|| self.module_directory("node_modules", cache, ctx)).clone()
+    }
+
+    /// Find package.json of a path by traversing parent directories.
+    ///
+    /// # Errors
+    ///
+    /// * [ResolveError::JSON]
+    fn find_package_json<C: Cache<Cp = Self>>(
+        &self,
+        options: &ResolveOptions,
+        cache: &C,
+        ctx: &mut Ctx,
+    ) -> Result<Option<(Self, Arc<PackageJson>)>, ResolveError> {
+        let mut cache_value = self;
+        // Go up directories when the querying path is not a directory
+        while !cache.is_dir(cache_value, ctx) {
+            if let Some(cv) = &cache_value.parent {
+                cache_value = cv;
+            } else {
+                break;
+            }
+        }
+        let mut cache_value = Some(cache_value);
+        while let Some(cv) = cache_value {
+            if let Some(package_json) = cache.get_package_json(cv, options, ctx)? {
+                return Ok(Some(package_json));
+            }
+            cache_value = cv.parent.as_ref();
+        }
+        Ok(None)
+    }
+
+    fn add_extension<C: Cache<Cp = Self>>(&self, ext: &str, cache: &C) -> Self {
+        SCRATCH_PATH.with_borrow_mut(|path| {
+            path.clear();
+            let s = path.as_mut_os_string();
+            s.push(self.path.as_os_str());
+            s.push(ext);
+            cache.value(path)
+        })
+    }
+
+    fn replace_extension<C: Cache<Cp = Self>>(&self, ext: &str, cache: &C) -> Self {
+        SCRATCH_PATH.with_borrow_mut(|path| {
+            path.clear();
+            let s = path.as_mut_os_string();
+            let self_len = self.path.as_os_str().len();
+            let self_bytes = self.path.as_os_str().as_encoded_bytes();
+            let slice_to_copy = self.path.extension().map_or(self_bytes, |previous_extension| {
+                &self_bytes[..self_len - previous_extension.len() - 1]
+            });
+            // SAFETY: ???
+            s.push(unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(slice_to_copy) });
+            s.push(ext);
+            cache.value(path)
+        })
+    }
+
+    /// Returns a new path by resolving the given subpath (including "." and ".." components) with this path.
+    fn normalize_with<C: Cache<Cp = Self>>(&self, subpath: impl AsRef<Path>, cache: &C) -> Self {
+        let subpath = subpath.as_ref();
+        let mut components = subpath.components();
+        let Some(head) = components.next() else { return cache.value(subpath) };
+        if matches!(head, Component::Prefix(..) | Component::RootDir) {
+            return cache.value(subpath);
+        }
+        SCRATCH_PATH.with_borrow_mut(|path| {
+            path.clear();
+            path.push(&self.path);
+            for component in std::iter::once(head).chain(components) {
+                match component {
+                    Component::CurDir => {}
+                    Component::ParentDir => {
+                        path.pop();
+                    }
+                    Component::Normal(c) => {
+                        cfg_if! {
+                            if #[cfg(target_family = "wasm")] {
+                                // Need to trim the extra \0 introduces by https://github.com/nodejs/uvwasi/issues/262
+                                path.push(c.to_string_lossy().trim_end_matches('\0'));
+                            } else {
+                                path.push(c);
+                            }
+                        }
+                    }
+                    Component::Prefix(..) | Component::RootDir => {
+                        unreachable!("Path {:?} Subpath {:?}", self.path, subpath)
+                    }
+                }
+            }
+
+            cache.value(path)
+        })
+    }
+
+    #[inline]
+    #[cfg(windows)]
+    fn normalize_root(&self, cache: &C) -> Self {
+        if self.path().as_os_str().as_encoded_bytes().last() == Some(&b'/') {
+            let mut path_string = self.path.to_string_lossy().into_owned();
+            path_string.pop();
+            path_string.push('\\');
+            cache.value(&PathBuf::from(path_string))
+        } else {
+            self.clone()
+        }
+    }
+
+    #[inline]
+    #[cfg(not(windows))]
+    fn normalize_root<C: Cache<Cp = Self>>(&self, _cache: &C) -> Self {
+        self.clone()
+    }
+}
+
+impl FsCachedPath {
+    fn meta<Fs: FileSystem>(&self, fs: &Fs) -> Option<FileMetadata> {
+        *self.meta.get_or_init(|| fs.metadata(&self.path).ok())
+    }
+}
+
+impl Hash for FsCachedPath {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.hash.hash(state);
+    }
+}
+
+impl PartialEq for FsCachedPath {
+    fn eq(&self, other: &Self) -> bool {
+        self.path.as_os_str() == other.path.as_os_str()
+    }
+}
+
+impl Eq for FsCachedPath {}
+
+/// Since the cache key is memoized, use an identity hasher
+/// to avoid double cache.
+#[derive(Default)]
+struct IdentityHasher(u64);
+
+impl Hasher for IdentityHasher {
+    fn write(&mut self, _: &[u8]) {
+        unreachable!("Invalid use of IdentityHasher")
+    }
+
+    fn write_u64(&mut self, n: u64) {
+        self.0 = n;
+    }
+
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}

--- a/src/fs_cache.rs
+++ b/src/fs_cache.rs
@@ -441,7 +441,7 @@ impl CachedPath for FsCachedPath {
 
     #[inline]
     #[cfg(windows)]
-    fn normalize_root(&self, cache: &C) -> Self {
+    fn normalize_root<C: Cache<Cp = Self>>(&self, cache: &C) -> Self {
         if self.path().as_os_str().as_encoded_bytes().last() == Some(&b'/') {
             let mut path_string = self.path.to_string_lossy().into_owned();
             path_string.pop();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -797,10 +797,10 @@ impl<C: Cache> ResolverGeneric<C> {
     #[cfg(feature = "yarn_pnp")]
     fn load_pnp(
         &self,
-        cached_path: &FsCachedPath,
+        cached_path: &C::Cp,
         specifier: &str,
         ctx: &mut Ctx,
-    ) -> Result<Option<FsCachedPath>, ResolveError> {
+    ) -> Result<Option<C::Cp>, ResolveError> {
         let Some(pnp_manifest) = &self.options.pnp_manifest else { return Ok(None) };
         let resolution =
             pnp::resolve_to_unqualified_via_manifest(pnp_manifest, specifier, cached_path.path());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,8 +146,8 @@ impl<C: Cache + Default> ResolverGeneric<C> {
 }
 
 impl<C: Cache> ResolverGeneric<C> {
-    pub fn new_with_cache(cache: C, options: ResolveOptions) -> Self {
-        Self { cache: Arc::new(cache), options: options.sanitize() }
+    pub fn new_with_cache(cache: Arc<C>, options: ResolveOptions) -> Self {
+        Self { cache, options: options.sanitize() }
     }
 
     /// Clone the resolver using the same underlying cache.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 
 mod builtins;
 mod cache;
-mod context;
+pub mod context;
 mod error;
 #[cfg(feature = "fs_cache")]
 mod file_system;
@@ -74,7 +74,6 @@ use std::{
     sync::Arc,
 };
 
-use cache::CachedPath;
 use rustc_hash::FxHashSet;
 use serde_json::Value as JSONValue;
 
@@ -86,7 +85,7 @@ pub use crate::{
 
 pub use crate::{
     builtins::NODEJS_BUILTINS,
-    cache::Cache,
+    cache::{Cache, CachedPath},
     error::{JSONError, ResolveError, SpecifierError},
     options::{
         Alias, AliasValue, EnforceExtension, ResolveOptions, Restriction, TsconfigOptions,
@@ -94,13 +93,15 @@ pub use crate::{
     },
     package_json::PackageJson,
     resolution::Resolution,
+    tsconfig::{
+        CompilerOptions, CompilerOptionsPathsMap, ExtendsField, ProjectReference, TsConfig,
+    },
 };
 use crate::{
     context::ResolveContext as Ctx,
     package_json::JSONMap,
     path::{PathUtil, SLASH_START},
     specifier::Specifier,
-    tsconfig::{ExtendsField, ProjectReference, TsConfig},
 };
 
 type ResolveResult<Cp> = Result<Option<Cp>, ResolveError>;

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -13,7 +13,7 @@ fn alias() {
     use std::path::{Path, PathBuf};
 
     use super::memory_fs::MemoryFS;
-    use crate::ResolverGeneric;
+    use crate::{FsCache, ResolverGeneric};
 
     let f = Path::new("/");
 
@@ -34,8 +34,8 @@ fn alias() {
         ("/dashed-name", ""),
     ]);
 
-    let resolver = ResolverGeneric::<MemoryFS>::new_with_file_system(
-        file_system,
+    let resolver = ResolverGeneric::new_with_cache(
+        FsCache::new(file_system),
         ResolveOptions {
             alias: vec![
                 ("aliasA".into(), vec![AliasValue::from("a")]),

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -10,7 +10,10 @@ use crate::{AliasValue, Resolution, ResolveContext, ResolveError, ResolveOptions
 #[test]
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 fn alias() {
-    use std::path::{Path, PathBuf};
+    use std::{
+        path::{Path, PathBuf},
+        sync::Arc,
+    };
 
     use super::memory_fs::MemoryFS;
     use crate::{FsCache, ResolverGeneric};
@@ -35,7 +38,7 @@ fn alias() {
     ]);
 
     let resolver = ResolverGeneric::new_with_cache(
-        FsCache::new(file_system),
+        Arc::new(FsCache::new(file_system)),
         ResolveOptions {
             alias: vec![
                 ("aliasA".into(), vec![AliasValue::from("a")]),

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -5,7 +5,7 @@ mod windows {
     use std::path::PathBuf;
 
     use super::super::memory_fs::MemoryFS;
-    use crate::{ResolveContext, ResolveOptions, ResolverGeneric};
+    use crate::{FsCache, ResolveContext, ResolveOptions, ResolverGeneric};
 
     fn file_system() -> MemoryFS {
         MemoryFS::new(&[
@@ -20,8 +20,8 @@ mod windows {
     fn test() {
         let file_system = file_system();
 
-        let resolver = ResolverGeneric::<MemoryFS>::new_with_file_system(
-            file_system,
+        let resolver = ResolverGeneric::new_with_cache(
+            FsCache::new(file_system),
             ResolveOptions {
                 extensions: vec![".json".into(), ".js".into()],
                 modules: vec!["/modules".into(), "node_modules".into()],

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows {
-    use std::path::PathBuf;
+    use std::{path::PathBuf, sync::Arc};
 
     use super::super::memory_fs::MemoryFS;
     use crate::{FsCache, ResolveContext, ResolveOptions, ResolverGeneric};
@@ -21,7 +21,7 @@ mod windows {
         let file_system = file_system();
 
         let resolver = ResolverGeneric::new_with_cache(
-            FsCache::new(file_system),
+            Arc::new(FsCache::new(file_system)),
             ResolveOptions {
                 extensions: vec![".json".into(), ".js".into()],
                 modules: vec!["/modules".into(), "node_modules".into()],

--- a/src/tests/exports_field.rs
+++ b/src/tests/exports_field.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use serde_json::json;
 
-use crate::{Ctx, PathUtil, ResolveError, ResolveOptions, Resolver};
+use crate::{cache::CachedPath, Cache, Ctx, PathUtil, ResolveError, ResolveOptions, Resolver};
 
 #[test]
 fn test_simple() {

--- a/src/tests/fallback.rs
+++ b/src/tests/fallback.rs
@@ -3,7 +3,10 @@
 #[test]
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 fn fallback() {
-    use std::path::{Path, PathBuf};
+    use std::{
+        path::{Path, PathBuf},
+        sync::Arc,
+    };
 
     use super::memory_fs::MemoryFS;
     use crate::{AliasValue, FsCache, ResolveError, ResolveOptions, ResolverGeneric};
@@ -29,7 +32,7 @@ fn fallback() {
     ]);
 
     let resolver = ResolverGeneric::new_with_cache(
-        FsCache::new(file_system),
+        Arc::new(FsCache::new(file_system)),
         ResolveOptions {
             fallback: vec![
                 ("aliasA".into(), vec![AliasValue::Path("a".into())]),

--- a/src/tests/fallback.rs
+++ b/src/tests/fallback.rs
@@ -6,7 +6,7 @@ fn fallback() {
     use std::path::{Path, PathBuf};
 
     use super::memory_fs::MemoryFS;
-    use crate::{AliasValue, ResolveError, ResolveOptions, ResolverGeneric};
+    use crate::{AliasValue, FsCache, ResolveError, ResolveOptions, ResolverGeneric};
 
     let f = Path::new("/");
 
@@ -28,8 +28,8 @@ fn fallback() {
         ("/e/dir/file", ""),
     ]);
 
-    let resolver = ResolverGeneric::<MemoryFS>::new_with_file_system(
-        file_system,
+    let resolver = ResolverGeneric::new_with_cache(
+        FsCache::new(file_system),
         ResolveOptions {
             fallback: vec![
                 ("aliasA".into(), vec![AliasValue::Path("a".into())]),

--- a/src/tests/full_specified.rs
+++ b/src/tests/full_specified.rs
@@ -5,7 +5,7 @@ mod windows {
     use std::path::PathBuf;
 
     use super::super::memory_fs::MemoryFS;
-    use crate::{AliasValue, ResolveOptions, ResolverGeneric};
+    use crate::{AliasValue, FsCache, ResolveOptions, ResolverGeneric};
 
     fn file_system() -> MemoryFS {
         MemoryFS::new(&[
@@ -28,8 +28,8 @@ mod windows {
     fn test() {
         let file_system = file_system();
 
-        let resolver = ResolverGeneric::<MemoryFS>::new_with_file_system(
-            file_system,
+        let resolver = ResolverGeneric::new_with_cache(
+            FsCache::new(file_system),
             ResolveOptions {
                 alias: vec![
                     ("alias1".into(), vec![AliasValue::from("/a/abc")]),
@@ -79,8 +79,8 @@ mod windows {
     fn resolve_to_context() {
         let file_system = file_system();
 
-        let resolver = ResolverGeneric::<MemoryFS>::new_with_file_system(
-            file_system,
+        let resolver = ResolverGeneric::new_with_cache(
+            FsCache::new(file_system),
             ResolveOptions {
                 alias: vec![
                     ("alias1".into(), vec![AliasValue::from("/a/abc")]),

--- a/src/tests/full_specified.rs
+++ b/src/tests/full_specified.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows {
-    use std::path::PathBuf;
+    use std::{path::PathBuf, sync::Arc};
 
     use super::super::memory_fs::MemoryFS;
     use crate::{AliasValue, FsCache, ResolveOptions, ResolverGeneric};
@@ -29,7 +29,7 @@ mod windows {
         let file_system = file_system();
 
         let resolver = ResolverGeneric::new_with_cache(
-            FsCache::new(file_system),
+            Arc::new(FsCache::new(file_system)),
             ResolveOptions {
                 alias: vec![
                     ("alias1".into(), vec![AliasValue::from("/a/abc")]),
@@ -80,7 +80,7 @@ mod windows {
         let file_system = file_system();
 
         let resolver = ResolverGeneric::new_with_cache(
-            FsCache::new(file_system),
+            Arc::new(FsCache::new(file_system)),
             ResolveOptions {
                 alias: vec![
                     ("alias1".into(), vec![AliasValue::from("/a/abc")]),

--- a/src/tests/imports_field.rs
+++ b/src/tests/imports_field.rs
@@ -6,7 +6,9 @@ use std::path::Path;
 
 use serde_json::json;
 
-use crate::{Ctx, JSONMap, PathUtil, ResolveError, ResolveOptions, Resolver};
+use crate::{
+    cache::CachedPath, Cache, Ctx, JSONMap, PathUtil, ResolveError, ResolveOptions, Resolver,
+};
 
 #[test]
 fn test_simple() {

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -48,6 +48,8 @@ fn dashed_name() {
 
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows {
+    use std::sync::Arc;
+
     use super::super::memory_fs::MemoryFS;
     use crate::{FsCache, ResolveOptions};
 
@@ -58,8 +60,10 @@ mod windows {
         use crate::ResolverGeneric;
         let f = Path::new("/");
         let file_system = MemoryFS::new(&[]);
-        let resolver =
-            ResolverGeneric::new_with_cache(FsCache::new(file_system), ResolveOptions::default());
+        let resolver = ResolverGeneric::new_with_cache(
+            Arc::new(FsCache::new(file_system)),
+            ResolveOptions::default(),
+        );
         let resolved_path = resolver.resolve(f, "package");
         assert!(resolved_path.is_err());
     }

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -49,7 +49,7 @@ fn dashed_name() {
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows {
     use super::super::memory_fs::MemoryFS;
-    use crate::ResolveOptions;
+    use crate::{FsCache, ResolveOptions};
 
     #[test]
     fn no_package() {
@@ -58,10 +58,8 @@ mod windows {
         use crate::ResolverGeneric;
         let f = Path::new("/");
         let file_system = MemoryFS::new(&[]);
-        let resolver = ResolverGeneric::<MemoryFS>::new_with_file_system(
-            file_system,
-            ResolveOptions::default(),
-        );
+        let resolver =
+            ResolverGeneric::new_with_cache(FsCache::new(file_system), ResolveOptions::default());
         let resolved_path = resolver.resolve(f, "package");
         assert!(resolved_path.is_err());
     }

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -242,7 +242,7 @@ mod windows_test {
 
     use super::super::memory_fs::MemoryFS;
     use crate::{
-        ResolveError, ResolveOptions, ResolverGeneric, TsconfigOptions, TsconfigReferences,
+        FsCache, ResolveError, ResolveOptions, ResolverGeneric, TsconfigOptions, TsconfigReferences,
     };
 
     struct OneTest {
@@ -285,7 +285,7 @@ mod windows_test {
     }
 
     impl OneTest {
-        fn resolver(&self, root: &Path) -> ResolverGeneric<MemoryFS> {
+        fn resolver(&self, root: &Path) -> ResolverGeneric<FsCache<MemoryFS>> {
             let mut file_system = MemoryFS::default();
 
             file_system.add_file(&root.join("tsconfig.json"), &self.tsconfig);
@@ -308,7 +308,7 @@ mod windows_test {
                 options.main_fields.clone_from(main_fields);
             }
 
-            ResolverGeneric::<MemoryFS>::new_with_file_system(file_system, options)
+            ResolverGeneric::new_with_cache(FsCache::new(file_system), options)
         }
     }
 

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -238,7 +238,10 @@ fn test_template_variable() {
 
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 mod windows_test {
-    use std::path::{Path, PathBuf};
+    use std::{
+        path::{Path, PathBuf},
+        sync::Arc,
+    };
 
     use super::super::memory_fs::MemoryFS;
     use crate::{
@@ -308,7 +311,7 @@ mod windows_test {
                 options.main_fields.clone_from(main_fields);
             }
 
-            ResolverGeneric::new_with_cache(FsCache::new(file_system), options)
+            ResolverGeneric::new_with_cache(Arc::new(FsCache::new(file_system)), options)
         }
     }
 

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -84,11 +84,12 @@ impl TsConfig {
         self.path.parent().unwrap()
     }
 
-    pub(crate) fn parse(
-        root: bool,
-        path: &Path,
-        json: &mut str,
-    ) -> Result<Self, serde_json::Error> {
+    /// Parses the tsconfig from a JSON string.
+    ///
+    /// # Errors
+    ///
+    /// * Any error that can be returned by `serde_json::from_str()`.
+    pub fn parse(root: bool, path: &Path, json: &mut str) -> Result<Self, serde_json::Error> {
         _ = json_strip_comments::strip(json);
         let mut tsconfig: Self = serde_json::from_str(json)?;
         tsconfig.root = root;
@@ -104,7 +105,8 @@ impl TsConfig {
         Ok(tsconfig)
     }
 
-    pub(crate) fn build(mut self) -> Self {
+    #[must_use]
+    pub fn build(mut self) -> Self {
         if self.root {
             let dir = self.directory().to_path_buf();
             // Substitute template variable in `tsconfig.compilerOptions.paths`

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -78,6 +78,7 @@ impl TsConfig {
     /// # Panics
     ///
     /// * When the `tsconfig.json` path is misconfigured.
+    #[must_use]
     pub fn directory(&self) -> &Path {
         debug_assert!(self.path.file_name().is_some());
         self.path.parent().unwrap()


### PR DESCRIPTION
This PR makes the cache fully generic by introducing a `Cache` trait, and renaming the existing `Cache` to `FsCache`.

The `FileSystem` trait still exists, but is only relevant still for users of `FsCache`. By keeping the trait, I hope to minimize the amount of breaking changes, even though some still remain.

The most notable breaking change is that `ResolverGeneric::new_with_file_system(fs, ...)` has become `ResolverGeneric::new_with_cache(Arc::new(FsCache::new(fs)), ...)`.

Both `FsCache` and `FileSystem` are now behind a `fs_cache` feature flag, which is enabled by default.

I am actually considering to make both the `PackageJson` and `TsConfig` types generic as well (Biome already has its own, which ideally we would use directly for our custom `Cache` implementation). This should be achievable by introducing traits for them and adding them as associated types to the `Cache` trait. But before going too deep, I was hoping to first get feedback on the work so far :)