### PR TITLE
feat: deserialize `verbatim_module_syntax` from compilerOptions

### DIFF
--- a/src/tsconfig_serde.rs
+++ b/src/tsconfig_serde.rs
@@ -125,6 +125,9 @@ pub struct CompilerOptionsSerde {
 
     /// <https://www.typescriptlang.org/tsconfig/#jsxImportSource>
     pub jsx_import_source: Option<String>,
+
+    /// <https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax>
+    pub verbatim_module_syntax: Option<bool>,
 }
 
 impl CompilerOptions for CompilerOptionsSerde {


### PR DESCRIPTION
1. related to https://github.com/rolldown/rolldown/issues/3777, rolldown needs this field to merge tsc options.