### PR TITLE
fix: handle query and fragment in pacakge.json `exports` and `imports` field

### DIFF
--- a/fixtures/enhanced_resolve/test/fixtures/exports-field/node_modules/exports-field/package.json
+++ b/fixtures/enhanced_resolve/test/fixtures/exports-field/node_modules/exports-field/package.json
@@ -13,6 +13,8 @@
       "node": "./lib/",
       "default": "./lib/"
     },
-    "./dist/a.js": "./../../a.js"
+    "./dist/a.js": "./../../a.js",
+    "./query.js": "./x.js?query",
+    "./fragment.js": "./x.js#fragment"
   }
 }

--- a/fixtures/enhanced_resolve/test/fixtures/imports-field/package.json
+++ b/fixtures/enhanced_resolve/test/fixtures/imports-field/package.json
@@ -7,7 +7,9 @@
     "#b": "../b.js",
     "#ccc/": "c/",
     "#c": "c",
-    "#a/": "a/"
+    "#a/": "a/",
+    "#query": "./a.js?query",
+    "#fragment": "./a.js#fragment"
   },
   "other": {
     "imports": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1634,6 +1634,12 @@ impl<C: Cache> ResolverGeneric<C> {
 
         // 1. If target is a String, then
         if let Some(target) = target.as_string() {
+            // Target string con contain queries or fragments:
+            // `"exports": { ".": { "default": "./foo.js?query#fragment" }`
+            let parsed = Specifier::parse(target).map_err(ResolveError::Specifier)?;
+            ctx.with_query_fragment(parsed.query, parsed.fragment);
+            let target = parsed.path();
+
             // 1. If target does not start with "./", then
             if !target.starts_with("./") {
                 // 1. If isImports is false, or if target starts with "../" or "/", or if target is a valid URL, then

--- a/src/tests/exports_field.rs
+++ b/src/tests/exports_field.rs
@@ -29,6 +29,8 @@ fn test_simple() {
     let pass = [
         ("resolve root using exports field, not a main field", f.clone(), "exports-field", f.join("node_modules/exports-field/x.js")),
         ("resolver should respect condition names", f.clone(), "exports-field/dist/main.js", f.join("node_modules/exports-field/lib/lib2/main.js")),
+        ("should resolve query", f.clone(), "exports-field/query.js", f.join("node_modules/exports-field/x.js?query")),
+        ("should resolve fragment", f.clone(), "exports-field/fragment.js", f.join("node_modules/exports-field/x.js#fragment")),
         // enhanced_resolve behaves differently to node.js. enhanced_resolve fallbacks when an
         // array item is unresolved, where as node.js fallbacks when an array has an
         // InvalidPackageTarget error.

--- a/src/tests/imports_field.rs
+++ b/src/tests/imports_field.rs
@@ -26,6 +26,8 @@ fn test_simple() {
     #[rustfmt::skip]
     let pass = [
         ("should resolve using imports field instead of self-referencing", f.clone(), "#imports-field", f.join("b.js")),
+        ("should resolve query", f.clone(), "#query", f.join("a.js?query")),
+        ("should resolve fragment", f.clone(), "#fragment", f.join("a.js#fragment")),
         ("should resolve using imports field instead of self-referencing for a subpath", f.join("dir"), "#imports-field", f.join("b.js")),
         ("should resolve package #1", f.clone(), "#a/dist/main.js", f.join("node_modules/a/lib/lib2/main.js")),
         ("should resolve package #3", f.clone(), "#ccc/index.js", f.join("node_modules/c/index.js")),


### PR DESCRIPTION
package.json `exports` and `imports` field con contain queries or fragments:

`"exports": { ".": { "default": "./foo.js?query#fragment" }`

closes #417