### PR TITLE
fix: properly handle DOS device paths in strip_windows_prefix

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,10 @@ pub enum ResolveError {
     #[error("{0}")]
     IOError(IOError),
 
+    /// For example, Windows UNC path with Volume GUID is not supported.
+    #[error("Path {0:?} contains unsupported construct.")]
+    PathNotSupported(PathBuf),
+
     /// Node.js builtin module when `Options::builtin_modules` is enabled.
     ///
     /// `is_runtime_module` can be used to determine whether the request

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -155,30 +155,52 @@ impl FileSystemOs {
     /// See [std::fs::read_link]
     #[inline]
     pub fn read_link(path: &Path) -> io::Result<PathBuf> {
-        let path = fs::read_link(path)?;
+        let target = fs::read_link(path)?;
         cfg_if! {
             if #[cfg(windows)] {
-                Ok(Self::strip_windows_prefix(path))
+                Ok(match Self::try_strip_windows_prefix(&target) {
+                    Some(path) => path,
+                    // We won't follow the link if we cannot represent its target properly.
+                    None => target,
+                })
             } else {
-                Ok(path)
+                Ok(target.to_path_buf())
             }
         }
     }
 
-    pub fn strip_windows_prefix<P: AsRef<Path>>(path: P) -> PathBuf {
-        const UNC_PATH_PREFIX: &[u8] = b"\\\\?\\UNC\\";
-        const LONG_PATH_PREFIX: &[u8] = b"\\\\?\\";
+    /// When applicable, converts a [DOS device path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths)
+    /// to a normal path (usually, "Traditional DOS paths" or "UNC path") that can be consumed by the `import`/`require` syntax of Node.js.
+    /// Returns `None` if the path cannot be represented as a normal path.
+    pub fn try_strip_windows_prefix<P: AsRef<Path>>(path: P) -> Option<PathBuf> {
+        // See https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
         let path_bytes = path.as_ref().as_os_str().as_encoded_bytes();
-        path_bytes
-            .strip_prefix(UNC_PATH_PREFIX)
-            .or_else(|| path_bytes.strip_prefix(LONG_PATH_PREFIX))
-            .map_or_else(
-                || path.as_ref().to_path_buf(),
-                |p| {
-                    // SAFETY: `as_encoded_bytes` ensures `p` is valid path bytes
-                    unsafe { PathBuf::from(std::ffi::OsStr::from_encoded_bytes_unchecked(p)) }
-                },
-            )
+
+        let path = if let Some(p) =
+            path_bytes.strip_prefix(br"\\?\UNC\").or(path_bytes.strip_prefix(br"\\.\UNC\"))
+        {
+            // UNC paths
+            unsafe {
+                PathBuf::from(std::ffi::OsStr::from_encoded_bytes_unchecked(&[br"\\", p].concat()))
+            }
+        } else if let Some(p) =
+            path_bytes.strip_prefix(br"\\?\").or(path_bytes.strip_prefix(br"\\.\"))
+        {
+            // Assuming traditional DOS path "\\?\C:\"
+            if p[1] != b':' {
+                // E.g.,
+                // \\?\Volume{b75e2c83-0000-0000-0000-602f00000000}
+                // \\?\BootPartition\
+                // It seems nodejs does not support DOS device paths with Volume GUIDs.
+                // This can happen if the path points to a Mounted Volume without a drive letter.
+                return None;
+            }
+            unsafe { PathBuf::from(std::ffi::OsStr::from_encoded_bytes_unchecked(p)) }
+        } else {
+            path.as_ref().to_path_buf()
+        };
+
+        Some(path)
     }
 }
 
@@ -244,4 +266,38 @@ fn metadata() {
         "FileMetadata { is_file: true, is_dir: true, is_symlink: true }"
     );
     let _ = meta;
+}
+
+#[test]
+fn test_strip_windows_prefix() {
+    assert_eq!(
+        FileSystemOs::try_strip_windows_prefix(PathBuf::from(
+            r"\\?\C:\Users\user\Documents\file.txt"
+        )),
+        Some(PathBuf::from(r"C:\Users\user\Documents\file.txt"))
+    );
+
+    assert_eq!(
+        FileSystemOs::try_strip_windows_prefix(PathBuf::from(
+            r"\\.\C:\Users\user\Documents\file.txt"
+        )),
+        Some(PathBuf::from(r"C:\Users\user\Documents\file.txt"))
+    );
+
+    assert_eq!(
+        FileSystemOs::try_strip_windows_prefix(PathBuf::from(r"\\?\UNC\server\share\file.txt")),
+        Some(PathBuf::from(r"\\server\share\file.txt"))
+    );
+
+    assert_eq!(
+        FileSystemOs::try_strip_windows_prefix(PathBuf::from(
+            r"\\?\Volume{c8ec34d8-3ba6-45c3-9b9d-3e4148e12d00}\file.txt"
+        )),
+        None
+    );
+
+    assert_eq!(
+        FileSystemOs::try_strip_windows_prefix(PathBuf::from(r"\\?\BootPartition\file.txt")),
+        None
+    );
 }

--- a/src/fs_cache.rs
+++ b/src/fs_cache.rs
@@ -79,11 +79,8 @@ impl<Fs: FileSystem> Cache for FsCache<Fs> {
         let cached_path = self.canonicalize_impl(path)?;
         let path = cached_path.to_path_buf();
         cfg_if! {
-            if #[cfg(windows)] {
-                match crate::FileSystemOs::try_strip_windows_prefix(&path) {
-                    Some(path) => Ok(path),
-                    None => Err(ResolveError::PathNotSupported(path)),
-                }
+            if #[cfg(target_os = "windows")] {
+                crate::windows::try_strip_windows_prefix(path)
             } else {
                 Ok(path)
             }

--- a/src/fs_cache.rs
+++ b/src/fs_cache.rs
@@ -80,10 +80,14 @@ impl<Fs: FileSystem> Cache for FsCache<Fs> {
         let path = cached_path.to_path_buf();
         cfg_if! {
             if #[cfg(windows)] {
-                let path = crate::FileSystemOs::strip_windows_prefix(path);
+                match crate::FileSystemOs::try_strip_windows_prefix(&path) {
+                    Some(path) => Ok(path),
+                    None => Err(ResolveError::PathNotSupported(path)),
+                }
+            } else {
+                Ok(path)
             }
         }
-        Ok(path)
     }
 
     fn is_file(&self, path: &Self::Cp, ctx: &mut Ctx) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ mod specifier;
 mod tsconfig;
 #[cfg(feature = "fs_cache")]
 mod tsconfig_serde;
+#[cfg(target_os = "windows")]
+mod windows;
 
 #[cfg(test)]
 mod tests;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+use crate::ResolveError;
+
+/// When applicable, converts a [DOS device path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths)
+/// to a normal path (usually, "Traditional DOS paths" or "UNC path") that can be consumed by the `import`/`require` syntax of Node.js.
+/// Returns `None` if the path cannot be represented as a normal path.
+pub fn try_strip_windows_prefix(path: PathBuf) -> Result<PathBuf, ResolveError> {
+    // See https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+    let path_bytes = path.as_os_str().as_encoded_bytes();
+
+    let path = if let Some(p) =
+        path_bytes.strip_prefix(br"\\?\UNC\").or_else(|| path_bytes.strip_prefix(br"\\.\UNC\"))
+    {
+        // UNC paths
+        // SAFETY:
+        unsafe {
+            PathBuf::from(std::ffi::OsStr::from_encoded_bytes_unchecked(&[br"\\", p].concat()))
+        }
+    } else if let Some(p) =
+        path_bytes.strip_prefix(br"\\?\").or_else(|| path_bytes.strip_prefix(br"\\.\"))
+    {
+        // Assuming traditional DOS path "\\?\C:\"
+        if p[1] != b':' {
+            // E.g.,
+            // \\?\Volume{b75e2c83-0000-0000-0000-602f00000000}
+            // \\?\BootPartition\
+            // It seems nodejs does not support DOS device paths with Volume GUIDs.
+            // This can happen if the path points to a Mounted Volume without a drive letter.
+            return Err(ResolveError::PathNotSupported(path));
+        }
+        // SAFETY:
+        unsafe { PathBuf::from(std::ffi::OsStr::from_encoded_bytes_unchecked(p)) }
+    } else {
+        path
+    };
+
+    Ok(path)
+}
+
+#[test]
+fn test_try_strip_windows_prefix() {
+    let pass = [
+        (r"\\?\C:\Users\user\Documents\file1.txt", r"C:\Users\user\Documents\file1.txt"),
+        (r"\\.\C:\Users\user\Documents\file2.txt", r"C:\Users\user\Documents\file2.txt"),
+        (r"\\?\UNC\server\share\file3.txt", r"\\server\share\file3.txt"),
+    ];
+
+    for (path, expected) in pass {
+        assert_eq!(try_strip_windows_prefix(PathBuf::from(path)), Ok(PathBuf::from(expected)));
+    }
+
+    let fail = [
+        r"\\?\Volume{c8ec34d8-3ba6-45c3-9b9d-3e4148e12d00}\file4.txt",
+        r"\\?\BootPartition\file4.txt",
+    ];
+
+    for path in fail {
+        assert_eq!(
+            try_strip_windows_prefix(PathBuf::from(path)),
+            Err(crate::ResolveError::PathNotSupported(PathBuf::from(path)))
+        );
+    }
+}


### PR DESCRIPTION
Fixes #454 

This PR changed the name and return type of `strip_windows_prefix` to `try_strip_windows_prefix`, allowing it to return `None` to indicate unsupported [DOS device paths](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths).

Most significantly, symlinks referring to a drive without drive letter, usually accessed via a mount point (Mounted Volume), should not be resolved at all, as nodejs `import`/`require` does not support such properly, as of Node 22.

This PR also rectified the [UNC path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#unc-paths) resolution to prepend the `"\\"` portion to the path.
