### PR TITLE
feat: deserialize `preserve_value_imports` and `imports_not_used_as_values` from `compilerOptions`

### DIFF
--- a/src/tsconfig_serde.rs
+++ b/src/tsconfig_serde.rs
@@ -137,6 +137,12 @@ pub struct CompilerOptionsSerde {
     /// <https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax>
     pub verbatim_module_syntax: Option<bool>,
 
+    /// <https://www.typescriptlang.org/tsconfig/#preserveValueImports>
+    pub preserve_value_imports: Option<bool>,
+
+    /// <https://www.typescriptlang.org/tsconfig/#importsNotUsedAsValues>
+    pub imports_not_used_as_values: Option<String>,
+
     /// <https://www.typescriptlang.org/tsconfig/#target>
     pub target: Option<String>,
 }

--- a/src/tsconfig_serde.rs
+++ b/src/tsconfig_serde.rs
@@ -136,6 +136,9 @@ pub struct CompilerOptionsSerde {
 
     /// <https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax>
     pub verbatim_module_syntax: Option<bool>,
+
+    /// <https://www.typescriptlang.org/tsconfig/#target>
+    pub target: Option<String>,
 }
 
 impl CompilerOptions for CompilerOptionsSerde {


### PR DESCRIPTION
Related to https://github.com/rolldown/rolldown/pull/4174

Align with [rolldown-vite](https://github.com/vitejs/rolldown-vite/blob/da2cc9626520e2556c0dd0b5273dbd1aa4a5a7c8/packages/vite/src/node/plugins/oxc.ts#L146-L190)

In fact, `preserveValueImports` and `importsNotUsedAsValues` have been deprecated and replaced by `verbatimModuleSyntax`. However, for compatibility and alignment with `rolldown-vite`, I had to suggest adding them.