### PR TITLE
refactor!: remove `modules` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ See [index.d.ts](https://github.com/oxc-project/oxc-resolver/blob/main/napi/inde
 | fullySpecified   | false                     | Request passed to resolve is already fully specified and extensions or main files are not resolved for it (they are still resolved for internal requests) |
 | mainFields       | ["main"]                  | A list of main fields in description files                                                                                                                |
 | mainFiles        | ["index"]                 | A list of main files in directories                                                                                                                       |
-| modules          | ["node_modules"]          | A list of directories to resolve modules from, can be absolute path or folder name                                                                        |
 | resolveToContext | false                     | Resolve to a context instead of a file                                                                                                                    |
 | preferRelative   | false                     | Prefer to resolve module requests as relative request and fallback to resolving as module                                                                 |
 | preferAbsolute   | false                     | Prefer to resolve server-relative urls as absolute paths before falling back to resolve in roots                                                          |
@@ -191,6 +190,7 @@ See [index.d.ts](https://github.com/oxc-project/oxc-resolver/blob/main/napi/inde
 
 | Field            | Default                     | Description                                                                                                                                   |
 | ---------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| modules          | ["node_modules"]            | A list of directories to resolve modules from, can be absolute path or folder name                                                                        |
 | cachePredicate   | function() { return true }; | A function which decides whether a request should be cached or not. An object is passed to the function with `path` and `request` properties. |
 | cacheWithContext | true                        | If unsafe cache is enabled, includes `request.context` in the cache key                                                                       |
 | plugins          | []                          | A list of additional resolve plugins which should be applied                                                                                  |

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ See [index.d.ts](https://github.com/oxc-project/oxc-resolver/blob/main/napi/inde
 
 | Field            | Default                     | Description                                                                                                                                   |
 | ---------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| modules          | ["node_modules"]            | A list of directories to resolve modules from, can be absolute path or folder name                                                                        |
+| modules          | ["node_modules"]            | A list of directories to resolve modules from, can be absolute path or folder name                                                            |
 | cachePredicate   | function() { return true }; | A function which decides whether a request should be cached or not. An object is passed to the function with `path` and `request` properties. |
 | cacheWithContext | true                        | If unsafe cache is enabled, includes `request.context` in the cache key                                                                       |
 | plugins          | []                          | A list of additional resolve plugins which should be applied                                                                                  |

--- a/napi/index.d.ts
+++ b/napi/index.d.ts
@@ -132,12 +132,6 @@ export interface NapiResolveOptions {
    */
   mainFiles?: Array<string>
   /**
-   * A list of directories to resolve modules from, can be absolute path or folder name.
-   *
-   * Default `["node_modules"]`
-   */
-  modules?: string | string[]
-  /**
    * Resolve to a context instead of a file.
    *
    * Default `false`

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -198,7 +198,6 @@ impl ResolverFactory {
                 .map(|o| StrOrStrList(o).into())
                 .unwrap_or(default.main_fields),
             main_files: op.main_files.unwrap_or(default.main_files),
-            modules: op.modules.map(|o| StrOrStrList(o).into()).unwrap_or(default.modules),
             resolve_to_context: op.resolve_to_context.unwrap_or(default.resolve_to_context),
             prefer_relative: op.prefer_relative.unwrap_or(default.prefer_relative),
             prefer_absolute: op.prefer_absolute.unwrap_or(default.prefer_absolute),

--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -105,12 +105,6 @@ pub struct NapiResolveOptions {
     /// Default `["index"]`
     pub main_files: Option<Vec<String>>,
 
-    /// A list of directories to resolve modules from, can be absolute path or folder name.
-    ///
-    /// Default `["node_modules"]`
-    #[napi(ts_type = "string | string[]")]
-    pub modules: Option<StrOrStrListType>,
-
     /// Resolve to a context instead of a file.
     ///
     /// Default `false`

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -62,8 +62,6 @@ pub trait CachedPath: Sized {
 
     fn parent(&self) -> Option<&Self>;
 
-    fn cached_node_modules<C: Cache<Cp = Self>>(&self, cache: &C, ctx: &mut Ctx) -> Option<Self>;
-
     /// Find package.json of a path by traversing parent directories.
     #[allow(clippy::type_complexity)]
     fn find_package_json<C: Cache<Cp = Self>>(

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -64,13 +64,6 @@ pub trait CachedPath: Sized {
 
     fn node_modules(&self) -> Option<&Self>;
 
-    fn module_directory<C: Cache<Cp = Self>>(
-        &self,
-        module_name: &str,
-        cache: &C,
-        ctx: &mut Ctx,
-    ) -> Option<Self>;
-
     fn cached_node_modules<C: Cache<Cp = Self>>(&self, cache: &C, ctx: &mut Ctx) -> Option<Self>;
 
     /// Find package.json of a path by traversing parent directories.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -62,8 +62,6 @@ pub trait CachedPath: Sized {
 
     fn parent(&self) -> Option<&Self>;
 
-    fn node_modules(&self) -> Option<&Self>;
-
     fn cached_node_modules<C: Cache<Cp = Self>>(&self, cache: &C, ctx: &mut Ctx) -> Option<Self>;
 
     /// Find package.json of a path by traversing parent directories.

--- a/src/fs_cache.rs
+++ b/src/fs_cache.rs
@@ -305,22 +305,17 @@ impl CachedPath for FsCachedPath {
         self.0.parent.as_ref()
     }
 
-    fn module_directory<C: Cache<Cp = Self>>(
-        &self,
-        module_name: &str,
-        cache: &C,
-        ctx: &mut Ctx,
-    ) -> Option<Self> {
-        let cached_path = cache.value(&self.path.join(module_name));
-        cache.is_dir(&cached_path, ctx).then_some(cached_path)
-    }
-
     fn node_modules(&self) -> Option<&Self> {
         self.node_modules.get().and_then(|o| o.as_ref())
     }
 
     fn cached_node_modules<C: Cache<Cp = Self>>(&self, cache: &C, ctx: &mut Ctx) -> Option<Self> {
-        self.node_modules.get_or_init(|| self.module_directory("node_modules", cache, ctx)).clone()
+        self.node_modules
+            .get_or_init(|| {
+                let cached_path = cache.value(&self.path.join("node_modules"));
+                cache.is_dir(&cached_path, ctx).then_some(cached_path)
+            })
+            .clone()
     }
 
     /// Find package.json of a path by traversing parent directories.

--- a/src/fs_cache.rs
+++ b/src/fs_cache.rs
@@ -265,7 +265,6 @@ pub struct CachedPathImpl {
     meta: OnceLock<Option<FileMetadata>>,
     canonicalized: OnceLock<Result<FsCachedPath, ResolveError>>,
     canonicalizing: AtomicU64,
-    node_modules: OnceLock<Option<FsCachedPath>>,
     package_json: OnceLock<Option<(FsCachedPath, Arc<PackageJsonSerde>)>>,
 }
 
@@ -278,7 +277,6 @@ impl CachedPathImpl {
             meta: OnceLock::new(),
             canonicalized: OnceLock::new(),
             canonicalizing: AtomicU64::new(0),
-            node_modules: OnceLock::new(),
             package_json: OnceLock::new(),
         }
     }
@@ -303,15 +301,6 @@ impl CachedPath for FsCachedPath {
 
     fn parent(&self) -> Option<&Self> {
         self.0.parent.as_ref()
-    }
-
-    fn cached_node_modules<C: Cache<Cp = Self>>(&self, cache: &C, ctx: &mut Ctx) -> Option<Self> {
-        self.node_modules
-            .get_or_init(|| {
-                let cached_path = cache.value(&self.path.join("node_modules"));
-                cache.is_dir(&cached_path, ctx).then_some(cached_path)
-            })
-            .clone()
     }
 
     /// Find package.json of a path by traversing parent directories.

--- a/src/fs_cache.rs
+++ b/src/fs_cache.rs
@@ -305,10 +305,6 @@ impl CachedPath for FsCachedPath {
         self.0.parent.as_ref()
     }
 
-    fn node_modules(&self) -> Option<&Self> {
-        self.node_modules.get().and_then(|o| o.as_ref())
-    }
-
     fn cached_node_modules<C: Cache<Cp = Self>>(&self, cache: &C, ctx: &mut Ctx) -> Option<Self> {
         self.node_modules
             .get_or_init(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,14 +772,10 @@ impl<C: Cache> ResolverGeneric<C> {
         // 2. for each DIR in DIRS:
         for cached_path in std::iter::successors(Some(cached_path), |p| p.parent()) {
             // Skip if /path/to/node_modules does not exist
-            if !self.cache.is_dir(cached_path, ctx) {
+            let cached_path = cached_path.normalize_with("node_modules", self.cache.as_ref());
+            if !self.cache.is_dir(&cached_path, ctx) {
                 continue;
             }
-
-            let Some(cached_path) = cached_path.cached_node_modules(self.cache.as_ref(), ctx)
-            else {
-                continue;
-            };
             // Optimize node_modules lookup by inspecting whether the package exists
             // From LOAD_PACKAGE_EXPORTS(X, DIR)
             // 1. Try to interpret X as a combination of NAME and SUBPATH where the name
@@ -1322,10 +1318,10 @@ impl<C: Cache> ResolverGeneric<C> {
         // 11. While parentURL is not the file system root,
         for cached_path in std::iter::successors(Some(cached_path), |p| p.parent()) {
             // 1. Let packageURL be the URL resolution of "node_modules/" concatenated with packageSpecifier, relative to parentURL.
-            let Some(cached_path) = cached_path.cached_node_modules(self.cache.as_ref(), ctx)
-            else {
+            let cached_path = cached_path.normalize_with("node_modules", self.cache.as_ref());
+            if !self.cache.is_dir(&cached_path, ctx) {
                 continue;
-            };
+            }
             // 2. Set parentURL to the parent folder URL of parentURL.
             let cached_path = cached_path.normalize_with(package_name, self.cache.as_ref());
             // 3. If the folder at packageURL does not exist, then

--- a/src/options.rs
+++ b/src/options.rs
@@ -113,11 +113,6 @@ pub struct ResolveOptions {
     /// Default `["index"]`
     pub main_files: Vec<String>,
 
-    /// A list of directories to resolve modules from, can be absolute path or folder name.
-    ///
-    /// Default `["node_modules"]`
-    pub modules: Vec<String>,
-
     /// A manifest loaded from pnp::load_pnp_manifest.
     ///
     /// Default `None`
@@ -328,22 +323,6 @@ impl ResolveOptions {
         self
     }
 
-    /// Adds a module to [ResolveOptions::modules]
-    ///
-    /// ## Examples
-    ///
-    /// ```
-    /// use oxc_resolver::{ResolveOptions};
-    ///
-    /// let options = ResolveOptions::default().with_module("module");
-    /// assert!(options.modules.contains(&"module".to_string()));
-    /// ```
-    #[must_use]
-    pub fn with_module<M: Into<String>>(mut self, module: M) -> Self {
-        self.modules.push(module.into());
-        self
-    }
-
     /// Adds a main file to [ResolveOptions::main_files]
     ///
     /// ## Examples
@@ -474,7 +453,6 @@ impl Default for ResolveOptions {
             fully_specified: false,
             main_fields: vec!["main".into()],
             main_files: vec!["index".into()],
-            modules: vec!["node_modules".into()],
             #[cfg(feature = "yarn_pnp")]
             pnp_manifest: None,
             resolve_to_context: false,
@@ -529,9 +507,6 @@ impl fmt::Display for ResolveOptions {
         }
         if !self.main_files.is_empty() {
             write!(f, "main_files:{:?},", self.main_files)?;
-        }
-        if !self.modules.is_empty() {
-            write!(f, "modules:{:?},", self.modules)?;
         }
         if self.resolve_to_context {
             write!(f, "resolve_to_context:{:?},", self.resolve_to_context)?;
@@ -625,7 +600,6 @@ mod test {
             imports_fields: vec![],
             main_fields: vec![],
             main_files: vec![],
-            modules: vec![],
             #[cfg(feature = "yarn_pnp")]
             pnp_manifest: None,
             prefer_absolute: false,

--- a/src/options.rs
+++ b/src/options.rs
@@ -582,7 +582,7 @@ mod test {
             ..ResolveOptions::default()
         };
 
-        let expected = r#"tsconfig:TsconfigOptions { config_file: "tsconfig.json", references: Auto },alias:[("a", [Ignore])],alias_fields:[["browser"]],condition_names:["require"],enforce_extension:Enabled,exports_fields:[["exports"]],imports_fields:[["imports"]],extension_alias:[(".js", [".ts"])],extensions:[".js", ".json", ".node"],fallback:[("fallback", [Ignore])],fully_specified:true,main_fields:["main"],main_files:["index"],modules:["node_modules"],resolve_to_context:true,prefer_relative:true,prefer_absolute:true,restrictions:[Path("restrictions")],roots:["roots"],symlinks:true,builtin_modules:true,"#;
+        let expected = r#"tsconfig:TsconfigOptions { config_file: "tsconfig.json", references: Auto },alias:[("a", [Ignore])],alias_fields:[["browser"]],condition_names:["require"],enforce_extension:Enabled,exports_fields:[["exports"]],imports_fields:[["imports"]],extension_alias:[(".js", [".ts"])],extensions:[".js", ".json", ".node"],fallback:[("fallback", [Ignore])],fully_specified:true,main_fields:["main"],main_files:["index"],resolve_to_context:true,prefer_relative:true,prefer_absolute:true,restrictions:[Path("restrictions")],roots:["roots"],symlinks:true,builtin_modules:true,"#;
         assert_eq!(format!("{options}"), expected);
 
         let options = ResolveOptions {

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -21,20 +21,20 @@ fn alias() {
     let f = Path::new("/");
 
     let file_system = MemoryFS::new(&[
-        ("/a/index", ""),
-        ("/a/dir/index", ""),
-        ("/recursive/index", ""),
-        ("/recursive/dir/index", ""),
-        ("/b/index", ""),
-        ("/b/dir/index", ""),
-        ("/c/index", ""),
-        ("/c/dir/index", ""),
-        ("/d/index.js", ""),
-        ("/d/dir/.empty", ""),
-        ("/e/index", ""),
-        ("/e/anotherDir/index", ""),
-        ("/e/dir/file", ""),
-        ("/dashed-name", ""),
+        ("/node_modules/a/index", ""),
+        ("/node_modules/a/dir/index", ""),
+        ("/node_modules/recursive/index", ""),
+        ("/node_modules/recursive/dir/index", ""),
+        ("/node_modules/b/index", ""),
+        ("/node_modules/b/dir/index", ""),
+        ("/node_modules/c/index", ""),
+        ("/node_modules/c/dir/index", ""),
+        ("/node_modules/d/index.js", ""),
+        ("/node_modules/d/dir/.empty", ""),
+        ("/node_modules/e/index", ""),
+        ("/node_modules/e/anotherDir/index", ""),
+        ("/node_modules/e/dir/file", ""),
+        ("/node_modules/dashed-name", ""),
     ]);
 
     let resolver = ResolverGeneric::new_with_cache(
@@ -43,7 +43,7 @@ fn alias() {
             alias: vec![
                 ("aliasA".into(), vec![AliasValue::from("a")]),
                 ("b$".into(), vec![AliasValue::from("a/index")]),
-                ("c$".into(), vec![AliasValue::from("/a/index")]),
+                ("c$".into(), vec![AliasValue::from("/node_modules/a/index")]),
                 (
                     "multiAlias".into(),
                     vec![
@@ -55,79 +55,82 @@ fn alias() {
                     ],
                 ),
                 ("recursive".into(), vec![AliasValue::from("recursive/dir")]),
-                ("/d/dir".into(), vec![AliasValue::from("/c/dir")]),
-                ("/d/index.js".into(), vec![AliasValue::from("/c/index")]),
-                ("#".into(), vec![AliasValue::from("/c/dir")]),
-                ("@".into(), vec![AliasValue::from("/c/dir")]),
+                ("/node_modules/d/dir".into(), vec![AliasValue::from("/node_modules/c/dir")]),
+                (
+                    "/node_modules/d/index.js".into(),
+                    vec![AliasValue::from("/node_modules/c/index")],
+                ),
+                ("#".into(), vec![AliasValue::from("/node_modules/c/dir")]),
+                ("@".into(), vec![AliasValue::from("/node_modules/c/dir")]),
                 ("ignored".into(), vec![AliasValue::Ignore]),
                 // not part of enhanced-resolve, added to make sure query in alias value would work
                 ("alias_query".into(), vec![AliasValue::from("a?query_after")]),
                 ("alias_fragment".into(), vec![AliasValue::from("a#fragment_after")]),
                 ("dash".into(), vec![AliasValue::Ignore]),
-                ("@scope/package-name/file$".into(), vec![AliasValue::from("/c/dir")]),
+                ("@scope/package-name/file$".into(), vec![AliasValue::from("/node_modules/c/dir")]),
                 // wildcard https://github.com/webpack/enhanced-resolve/pull/439
-                ("@adir/*".into(), vec![AliasValue::from("./a/")]), // added to test value without wildcard
-                ("@*".into(), vec![AliasValue::from("/*")]),
-                ("@e*".into(), vec![AliasValue::from("/e/*")]),
-                ("@e*file".into(), vec![AliasValue::from("/e*file")]),
+                ("@adir/*".into(), vec![AliasValue::from("./node_modules/a/")]), // added to test value without wildcard
+                ("@*".into(), vec![AliasValue::from("/node_modules/*")]),
+                ("@e*".into(), vec![AliasValue::from("/node_modules/e/*")]),
+                ("@e*file".into(), vec![AliasValue::from("/node_modules/e*file")]),
             ],
-            modules: vec!["/".into()],
             ..ResolveOptions::default()
         },
     );
 
     #[rustfmt::skip]
     let pass = [
-        ("should resolve a not aliased module 1", "a", "/a/index"),
-        ("should resolve a not aliased module 2", "a/index", "/a/index"),
-        ("should resolve a not aliased module 3", "a/dir", "/a/dir/index"),
-        ("should resolve a not aliased module 4", "a/dir/index", "/a/dir/index"),
-        ("should resolve an aliased module 1", "aliasA", "/a/index"),
-        ("should resolve an aliased module 2", "aliasA/index", "/a/index"),
-        ("should resolve an aliased module 3", "aliasA/dir", "/a/dir/index"),
-        ("should resolve an aliased module 4", "aliasA/dir/index", "/a/dir/index"),
-        ("should resolve '#' alias 1", "#", "/c/dir/index"),
-        ("should resolve '#' alias 2", "#/index", "/c/dir/index"),
-        ("should resolve '@' alias 1", "@", "/c/dir/index"),
-        ("should resolve '@' alias 2", "@/index", "/c/dir/index"),
-        ("should resolve '@' alias 3", "@/", "/c/dir/index"),
-        ("should resolve a recursive aliased module 1", "recursive", "/recursive/dir/index"),
-        ("should resolve a recursive aliased module 2", "recursive/index", "/recursive/dir/index"),
-        ("should resolve a recursive aliased module 3", "recursive/dir", "/recursive/dir/index"),
-        ("should resolve a recursive aliased module 4", "recursive/dir/index", "/recursive/dir/index"),
-        ("should resolve a file aliased module 1", "b", "/a/index"),
-        ("should resolve a file aliased module 2", "c", "/a/index"),
-        ("should resolve a file aliased module with a query 1", "b?query", "/a/index?query"),
-        ("should resolve a file aliased module with a query 2", "c?query", "/a/index?query"),
-        ("should resolve a path in a file aliased module 1", "b/index", "/b/index"),
-        ("should resolve a path in a file aliased module 2", "b/dir", "/b/dir/index"),
-        ("should resolve a path in a file aliased module 3", "b/dir/index", "/b/dir/index"),
-        ("should resolve a path in a file aliased module 4", "c/index", "/c/index"),
-        ("should resolve a path in a file aliased module 5", "c/dir", "/c/dir/index"),
-        ("should resolve a path in a file aliased module 6", "c/dir/index", "/c/dir/index"),
-        ("should resolve a file aliased file 1", "d", "/c/index"),
-        ("should resolve a file aliased file 2", "d/dir/index", "/c/dir/index"),
-        ("should resolve a file in multiple aliased dirs 1", "multiAlias/dir/file", "/e/dir/file"),
-        ("should resolve a file in multiple aliased dirs 2", "multiAlias/anotherDir", "/e/anotherDir/index"),
+        ("should resolve a not aliased module 1", "a", "a/index"),
+        ("should resolve a not aliased module 2", "a/index", "a/index"),
+        ("should resolve a not aliased module 3", "a/dir", "a/dir/index"),
+        ("should resolve a not aliased module 4", "a/dir/index", "a/dir/index"),
+        ("should resolve an aliased module 1", "aliasA", "a/index"),
+        ("should resolve an aliased module 2", "aliasA/index", "a/index"),
+        ("should resolve an aliased module 3", "aliasA/dir", "a/dir/index"),
+        ("should resolve an aliased module 4", "aliasA/dir/index", "a/dir/index"),
+        ("should resolve '#' alias 1", "#", "c/dir/index"),
+        ("should resolve '#' alias 2", "#/index", "c/dir/index"),
+        ("should resolve '@' alias 1", "@", "c/dir/index"),
+        ("should resolve '@' alias 2", "@/index", "c/dir/index"),
+        ("should resolve '@' alias 3", "@/", "c/dir/index"),
+        ("should resolve a recursive aliased module 1", "recursive", "recursive/dir/index"),
+        ("should resolve a recursive aliased module 2", "recursive/index", "recursive/dir/index"),
+        ("should resolve a recursive aliased module 3", "recursive/dir", "recursive/dir/index"),
+        ("should resolve a recursive aliased module 4", "recursive/dir/index", "recursive/dir/index"),
+        ("should resolve a file aliased module 1", "b", "a/index"),
+        ("should resolve a file aliased module 2", "c", "a/index"),
+        ("should resolve a file aliased module with a query 1", "b?query", "a/index?query"),
+        ("should resolve a file aliased module with a query 2", "c?query", "a/index?query"),
+        ("should resolve a path in a file aliased module 1", "b/index", "b/index"),
+        ("should resolve a path in a file aliased module 2", "b/dir", "b/dir/index"),
+        ("should resolve a path in a file aliased module 3", "b/dir/index", "b/dir/index"),
+        ("should resolve a path in a file aliased module 4", "c/index", "c/index"),
+        ("should resolve a path in a file aliased module 5", "c/dir", "c/dir/index"),
+        ("should resolve a path in a file aliased module 6", "c/dir/index", "c/dir/index"),
+        ("should resolve a file aliased file 1", "d", "c/index"),
+        ("should resolve a file aliased file 2", "d/dir/index", "c/dir/index"),
+        ("should resolve a file in multiple aliased dirs 1", "multiAlias/dir/file", "e/dir/file"),
+        ("should resolve a file in multiple aliased dirs 2", "multiAlias/anotherDir", "e/anotherDir/index"),
         // wildcard
-        ("should resolve wildcard alias 1", "@a", "/a/index"),
-        ("should resolve wildcard alias 2", "@a/dir", "/a/dir/index"),
-        ("should resolve wildcard alias 3", "@e/dir/file", "/e/dir/file"),
-        ("should resolve wildcard alias 4", "@e/anotherDir", "/e/anotherDir/index"),
-        ("should resolve wildcard alias 5", "@e/dir/file", "/e/dir/file"),
+        ("should resolve wildcard alias 1", "@a", "a/index"),
+        ("should resolve wildcard alias 2", "@a/dir", "a/dir/index"),
+        ("should resolve wildcard alias 3", "@e/dir/file", "e/dir/file"),
+        ("should resolve wildcard alias 4", "@e/anotherDir", "e/anotherDir/index"),
+        ("should resolve wildcard alias 5", "@e/dir/file", "e/dir/file"),
         // added to test value without wildcard
-        ("should resolve scoped package name with sub dir 1", "@adir/index", "/a/index"),
-        ("should resolve scoped package name with sub dir 2", "@adir/dir", "/a/index"),
+        ("should resolve scoped package name with sub dir 1", "@adir/index", "a/index"),
+        ("should resolve scoped package name with sub dir 2", "@adir/dir", "a/index"),
         // not part of enhanced-resolve, added to make sure query in alias value works
-        ("should resolve query in alias value", "alias_query?query_before", "/a/index?query_after"),
-        ("should resolve query in alias value", "alias_fragment#fragment_before", "/a/index#fragment_after"),
-        ("should resolve dashed name", "dashed-name", "/dashed-name"),
-        ("should resolve scoped package name with sub dir", "@scope/package-name/file", "/c/dir/index"),
+        ("should resolve query in alias value", "alias_query?query_before", "a/index?query_after"),
+        ("should resolve query in alias value", "alias_fragment#fragment_before", "a/index#fragment_after"),
+        ("should resolve dashed name", "dashed-name", "dashed-name"),
+        ("should resolve scoped package name with sub dir", "@scope/package-name/file", "c/dir/index"),
     ];
 
     for (comment, request, expected) in pass {
         let resolved_path = resolver.resolve(f, request).map(|r| r.full_path());
-        assert_eq!(resolved_path, Ok(PathBuf::from(expected)), "{comment} {request}");
+        let expected = PathBuf::from("/node_modules").join(expected);
+        assert_eq!(resolved_path, Ok(expected), "{comment} {request}");
     }
 
     #[rustfmt::skip]
@@ -174,12 +177,14 @@ fn check_slash(path: &Path) {
 fn absolute_path() {
     let f = super::fixture();
     let resolver = Resolver::new(ResolveOptions {
-        alias: vec![(f.join("foo").to_str().unwrap().to_string(), vec![AliasValue::Ignore])],
-        modules: vec![f.clone().to_str().unwrap().to_string()],
+        alias: vec![(
+            f.join("node_modules/m1").to_str().unwrap().to_string(),
+            vec![AliasValue::Ignore],
+        )],
         ..ResolveOptions::default()
     });
-    let resolution = resolver.resolve(&f, "foo/index");
-    assert_eq!(resolution, Err(ResolveError::Ignored(f.join("foo"))));
+    let resolution = resolver.resolve(&f, "m1/a.js");
+    assert_eq!(resolution, Err(ResolveError::Ignored(f.join("node_modules/m1"))));
 }
 
 #[test]

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -178,13 +178,13 @@ fn absolute_path() {
     let f = super::fixture();
     let resolver = Resolver::new(ResolveOptions {
         alias: vec![(
-            f.join("node_modules/m1").to_str().unwrap().to_string(),
+            f.join("node_modules").join("m1").to_str().unwrap().to_string(),
             vec![AliasValue::Ignore],
         )],
         ..ResolveOptions::default()
     });
     let resolution = resolver.resolve(&f, "m1/a.js");
-    assert_eq!(resolution, Err(ResolveError::Ignored(f.join("node_modules/m1"))));
+    assert_eq!(resolution, Err(ResolveError::Ignored(f.join("node_modules").join("m1"))));
 }
 
 #[test]

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -12,7 +12,7 @@ mod windows {
             ("/a/b/node_modules/some-module/index.js", ""),
             ("/a/node_modules/module/package.json", r#"{"main":"entry.js"}"#),
             ("/a/node_modules/module/file.js", r#"{"main":"entry.js"}"#),
-            ("/modules/other-module/file.js", ""),
+            ("/node_modules/other-module/file.js", ""),
         ])
     }
 
@@ -24,7 +24,6 @@ mod windows {
             Arc::new(FsCache::new(file_system)),
             ResolveOptions {
                 extensions: vec![".json".into(), ".js".into()],
-                modules: vec!["/modules".into(), "node_modules".into()],
                 ..ResolveOptions::default()
             },
         );
@@ -57,7 +56,6 @@ mod windows {
                     "/a/b/c",
                     // "/a/b/c/node_modules",
                     // missing single file modules
-                    "/modules/module",
                     "/a/b/node_modules/module",
                     // missing files with alternative extensions
                     "/a/node_modules/module/file",
@@ -68,12 +66,12 @@ mod windows {
                 "fast found module",
                 "/a/b/c",
                 "other-module/file.js",
-                "/modules/other-module/file.js",
+                "/node_modules/other-module/file.js",
                 // These dependencies are different from enhanced-resolve due to different code path to
                 // querying the file system
                 vec![
                     // symlink checks
-                    "/modules/other-module/file.js",
+                    "/node_modules/other-module/file.js",
                     // "/modules/other-module",
                     // "/modules",
                     // "/",
@@ -84,9 +82,10 @@ mod windows {
                     "/a/b/c",
                     "/a/b/package.json",
                     "/a/package.json",
+                    "/a/node_modules/other-module",
+                    "/a/b/node_modules/other-module",
                     "/package.json",
-                    "/modules/other-module/package.json",
-                    "/modules/package.json",
+                    "/node_modules/other-module/package.json",
                 ],
             ),
         ];

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -48,18 +48,14 @@ mod windows {
                 ],
                 vec![
                     // missing package.jsons
-                    // "/a/b/c/package.json",
-                    "/a/b/package.json",
-                    "/a/package.json",
                     "/package.json",
-                    // missing modules directories
-                    "/a/b/c",
-                    // "/a/b/c/node_modules",
-                    // missing single file modules
-                    "/a/b/node_modules/module",
-                    // missing files with alternative extensions
+                    "/a/package.json",
                     "/a/node_modules/module/file",
+                    "/a/b/package.json",
+                    "/a/b/node_modules/module",
                     "/a/node_modules/module/file.json",
+                    "/a/b/c/node_modules",
+                    "/a/b/c",
                 ],
             ),
             (
@@ -78,14 +74,14 @@ mod windows {
                 ],
                 vec![
                     // missing package.jsons
-                    // "/a/b/c/package.json",
-                    "/a/b/c",
-                    "/a/b/package.json",
+                    "/package.json",
                     "/a/package.json",
                     "/a/node_modules/other-module",
+                    "/a/b/package.json",
                     "/a/b/node_modules/other-module",
-                    "/package.json",
                     "/node_modules/other-module/package.json",
+                    "/a/b/c/node_modules",
+                    "/a/b/c",
                 ],
             ),
         ];

--- a/src/tests/fallback.rs
+++ b/src/tests/fallback.rs
@@ -14,21 +14,21 @@ fn fallback() {
     let f = Path::new("/");
 
     let file_system = MemoryFS::new(&[
-        ("/a/index", ""),
-        ("/a/dir/index", ""),
-        ("/recursive/index", ""),
-        ("/recursive/dir/index", ""),
-        ("/recursive/dir/file", ""),
-        ("/recursive/dir/dir/index", ""),
-        ("/b/index", ""),
-        ("/b/dir/index", ""),
-        ("/c/index", ""),
-        ("/c/dir/index", ""),
-        ("/d/index.js", ""),
-        ("/d/dir/.empty", ""),
-        ("/e/index", ""),
-        ("/e/anotherDir/index", ""),
-        ("/e/dir/file", ""),
+        ("/node_modules/a/index", ""),
+        ("/node_modules/a/dir/index", ""),
+        ("/node_modules/recursive/index", ""),
+        ("/node_modules/recursive/dir/index", ""),
+        ("/node_modules/recursive/dir/file", ""),
+        ("/node_modules/recursive/dir/dir/index", ""),
+        ("/node_modules/b/index", ""),
+        ("/node_modules/b/dir/index", ""),
+        ("/node_modules/c/index", ""),
+        ("/node_modules/c/dir/index", ""),
+        ("/node_modules/d/index.js", ""),
+        ("/node_modules/d/dir/.empty", ""),
+        ("/node_modules/e/index", ""),
+        ("/node_modules/e/anotherDir/index", ""),
+        ("/node_modules/e/dir/file", ""),
     ]);
 
     let resolver = ResolverGeneric::new_with_cache(
@@ -36,8 +36,8 @@ fn fallback() {
         ResolveOptions {
             fallback: vec![
                 ("aliasA".into(), vec![AliasValue::Path("a".into())]),
-                ("b$".into(), vec![AliasValue::Path("a/index".into())]),
-                ("c$".into(), vec![AliasValue::Path("/a/index".into())]),
+                ("b$".into(), vec![AliasValue::Path("node_modules/a/index".into())]),
+                ("c$".into(), vec![AliasValue::Path("node_modules/a/index".into())]),
                 (
                     "multiAlias".into(),
                     vec![
@@ -49,46 +49,46 @@ fn fallback() {
                     ],
                 ),
                 ("recursive".into(), vec![AliasValue::Path("recursive/dir".into())]),
-                ("/d/dir".into(), vec![AliasValue::Path("/c/dir".into())]),
-                ("/d/index.js".into(), vec![AliasValue::Path("/c/index".into())]),
+                ("/d/dir".into(), vec![AliasValue::Path("/node_modules/c/dir".into())]),
+                ("/d/index.js".into(), vec![AliasValue::Path("/node_modules/c/index".into())]),
                 ("ignored".into(), vec![AliasValue::Ignore]),
                 ("node:path".into(), vec![AliasValue::Ignore]),
             ],
-            modules: vec!["/".into()],
             ..ResolveOptions::default()
         },
     );
 
     #[rustfmt::skip]
     let pass = [
-        ("should resolve a not aliased module 1", "a", "/a/index"),
-        ("should resolve a not aliased module 2", "a/index", "/a/index"),
-        ("should resolve a not aliased module 3", "a/dir", "/a/dir/index"),
-        ("should resolve a not aliased module 4", "a/dir/index", "/a/dir/index"),
-        ("should resolve an fallback module 1", "aliasA", "/a/index"),
-        ("should resolve an fallback module 2", "aliasA/index", "/a/index"),
-        ("should resolve an fallback module 3", "aliasA/dir", "/a/dir/index"),
-        ("should resolve an fallback module 4", "aliasA/dir/index", "/a/dir/index"),
-        ("should resolve a recursive aliased module 1", "recursive", "/recursive/index"),
-        ("should resolve a recursive aliased module 2", "recursive/index", "/recursive/index"),
-        ("should resolve a recursive aliased module 3", "recursive/dir", "/recursive/dir/index"),
-        ("should resolve a recursive aliased module 4", "recursive/dir/index", "/recursive/dir/index"),
-        ("should resolve a recursive aliased module 5", "recursive/file", "/recursive/dir/file"),
-        ("should resolve a file aliased module with a query 1", "b?query", "/b/index?query"),
-        ("should resolve a file aliased module with a query 2", "c?query", "/c/index?query"),
-        ("should resolve a path in a file aliased module 1", "b/index", "/b/index"),
-        ("should resolve a path in a file aliased module 2", "b/dir", "/b/dir/index"),
-        ("should resolve a path in a file aliased module 3", "b/dir/index", "/b/dir/index"),
-        ("should resolve a path in a file aliased module 4", "c/index", "/c/index"),
-        ("should resolve a path in a file aliased module 5", "c/dir", "/c/dir/index"),
-        ("should resolve a path in a file aliased module 6", "c/dir/index", "/c/dir/index"),
-        ("should resolve a file in multiple aliased dirs 1", "multiAlias/dir/file", "/e/dir/file"),
-        ("should resolve a file in multiple aliased dirs 2", "multiAlias/anotherDir", "/e/anotherDir/index"),
+        ("should resolve a not aliased module 1", "a", "a/index"),
+        ("should resolve a not aliased module 2", "a/index", "a/index"),
+        ("should resolve a not aliased module 3", "a/dir", "a/dir/index"),
+        ("should resolve a not aliased module 4", "a/dir/index", "a/dir/index"),
+        ("should resolve an fallback module 1", "aliasA", "a/index"),
+        ("should resolve an fallback module 2", "aliasA/index", "a/index"),
+        ("should resolve an fallback module 3", "aliasA/dir", "a/dir/index"),
+        ("should resolve an fallback module 4", "aliasA/dir/index", "a/dir/index"),
+        ("should resolve a recursive aliased module 1", "recursive", "recursive/index"),
+        ("should resolve a recursive aliased module 2", "recursive/index", "recursive/index"),
+        ("should resolve a recursive aliased module 3", "recursive/dir", "recursive/dir/index"),
+        ("should resolve a recursive aliased module 4", "recursive/dir/index", "recursive/dir/index"),
+        ("should resolve a recursive aliased module 5", "recursive/file", "recursive/dir/file"),
+        ("should resolve a file aliased module with a query 1", "b?query", "b/index?query"),
+        ("should resolve a file aliased module with a query 2", "c?query", "c/index?query"),
+        ("should resolve a path in a file aliased module 1", "b/index", "b/index"),
+        ("should resolve a path in a file aliased module 2", "b/dir", "b/dir/index"),
+        ("should resolve a path in a file aliased module 3", "b/dir/index", "b/dir/index"),
+        ("should resolve a path in a file aliased module 4", "c/index", "c/index"),
+        ("should resolve a path in a file aliased module 5", "c/dir", "c/dir/index"),
+        ("should resolve a path in a file aliased module 6", "c/dir/index", "c/dir/index"),
+        ("should resolve a file in multiple aliased dirs 1", "multiAlias/dir/file", "e/dir/file"),
+        ("should resolve a file in multiple aliased dirs 2", "multiAlias/anotherDir", "e/anotherDir/index"),
     ];
 
     for (comment, request, expected) in pass {
         let resolved_path = resolver.resolve(f, request).map(|r| r.full_path());
-        assert_eq!(resolved_path, Ok(PathBuf::from(expected)), "{comment} {request}");
+        let expected = PathBuf::from("/node_modules").join(expected);
+        assert_eq!(resolved_path, Ok(expected), "{comment} {request}");
     }
 
     #[rustfmt::skip]

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -65,19 +65,6 @@ fn resolve() {
 }
 
 #[test]
-fn issue238_resolve() {
-    let f = super::fixture().join("issue-238");
-    let resolver = Resolver::new(ResolveOptions {
-        extensions: vec![".js".into(), ".jsx".into(), ".ts".into(), ".tsx".into()],
-        modules: vec!["src/a".into(), "src/b".into(), "src/common".into(), "node_modules".into()],
-        ..ResolveOptions::default()
-    });
-    let resolved_path =
-        resolver.resolve(f.join("src/common"), "config/myObjectFile").map(|r| r.full_path());
-    assert_eq!(resolved_path, Ok(f.join("src/common/config/myObjectFile.js")),);
-}
-
-#[test]
 fn prefer_relative() {
     let f = super::fixture();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -108,7 +108,6 @@ fn options_api() {
         .with_fully_specified(true)
         .with_main_field("asdf")
         .with_main_file("main")
-        .with_module("module")
         .with_prefer_absolute(true)
         .with_prefer_relative(true)
         .with_root(PathBuf::new())


### PR DESCRIPTION
The only value for this option in the ecosystem is node_modules.

This option also slightly impacts performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect the removal of the `modules` option from supported options.
- **Refactor**
  - Simplified module resolution by removing support for custom module directories, relying solely on standard `node_modules` resolution.
  - Removed configuration options, methods, and internal logic related to custom module directories.
- **Tests**
  - Updated test setups to reflect module paths rooted under `/node_modules`.
  - Removed a specific module resolution test related to custom module paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->