### PR TITLE
perf: remove a useless `load_as_directory` call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -828,9 +828,6 @@ impl<C: Cache> ResolverGeneric<C> {
             if let Some(path) = self.load_as_file(&cached_path, ctx)? {
                 return Ok(Some(path));
             }
-            if let Some(path) = self.load_as_directory(&cached_path, ctx)? {
-                return Ok(Some(path));
-            }
         }
         Ok(None)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved efficiency by removing redundant directory loading attempts during module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->