### PR TITLE
refactor!: remove `description_files` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ See [index.d.ts](https://github.com/oxc-project/oxc-resolver/blob/main/napi/inde
 
 | Field            | Default                     | Description                                                                                                                                   |
 | ---------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| descriptionFiles | ["package.json"]            | A list of description files to read from                                                                                                                  |
+| descriptionFiles | ["package.json"]            | A list of description files to read from                                                                                                      |
 | modules          | ["node_modules"]            | A list of directories to resolve modules from, can be absolute path or folder name                                                            |
 | cachePredicate   | function() { return true }; | A function which decides whether a request should be cached or not. An object is passed to the function with `path` and `request` properties. |
 | cacheWithContext | true                        | If unsafe cache is enabled, includes `request.context` in the cache key                                                                       |

--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ See [index.d.ts](https://github.com/oxc-project/oxc-resolver/blob/main/napi/inde
 | aliasFields      | []                        | A list of alias fields in description files                                                                                                               |
 | extensionAlias   | {}                        | An object which maps extension to extension aliases                                                                                                       |
 | conditionNames   | []                        | A list of exports field condition names                                                                                                                   |
-| descriptionFiles | ["package.json"]          | A list of description files to read from                                                                                                                  |
 | enforceExtension | false                     | Enforce that a extension from extensions must be used                                                                                                     |
 | exportsFields    | ["exports"]               | A list of exports fields in description files                                                                                                             |
 | extensions       | [".js", ".json", ".node"] | A list of extensions which should be tried for files                                                                                                      |
@@ -190,6 +189,7 @@ See [index.d.ts](https://github.com/oxc-project/oxc-resolver/blob/main/napi/inde
 
 | Field            | Default                     | Description                                                                                                                                   |
 | ---------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| descriptionFiles | ["package.json"]            | A list of description files to read from                                                                                                                  |
 | modules          | ["node_modules"]            | A list of directories to resolve modules from, can be absolute path or folder name                                                            |
 | cachePredicate   | function() { return true }; | A function which decides whether a request should be cached or not. An object is passed to the function with `path` and `request` properties. |
 | cacheWithContext | true                        | If unsafe cache is enabled, includes `request.context` in the cache key                                                                       |

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -156,7 +156,6 @@ impl ResolverFactory {
                 .map(|o| o.into_iter().map(|x| StrOrStrList(x).into()).collect::<Vec<_>>())
                 .unwrap_or(default.alias_fields),
             condition_names: op.condition_names.unwrap_or(default.condition_names),
-            description_files: op.description_files.unwrap_or(default.description_files),
             enforce_extension: op
                 .enforce_extension
                 .map(|enforce_extension| enforce_extension.into())

--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -38,11 +38,6 @@ pub struct NapiResolveOptions {
     /// Default `[]`
     pub condition_names: Option<Vec<String>>,
 
-    /// The JSON files to use for descriptions. (There was once a `bower.json`.)
-    ///
-    /// Default `["package.json"]`
-    pub description_files: Option<Vec<String>>,
-
     /// If true, it will not allow extension-less files.
     /// So by default `require('./foo')` works if `./foo` has a `.js` extension,
     /// but with this enabled only `require('./foo.js')` will work.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,30 +590,26 @@ impl<C: Cache> ResolverGeneric<C> {
     }
 
     fn load_as_directory(&self, cached_path: &C::Cp, ctx: &mut Ctx) -> ResolveResult<C::Cp> {
-        // TODO: Only package.json is supported, so warn about having other values
-        // Checking for empty files is needed for omitting checks on package.json
         // 1. If X/package.json is a file,
-        if !self.options.description_files.is_empty() {
-            // a. Parse X/package.json, and look for "main" field.
-            if let Some((_, package_json)) =
-                self.cache.get_package_json(cached_path, &self.options, ctx)?
-            {
-                // b. If "main" is a falsy value, GOTO 2.
-                for main_field in package_json.main_fields(&self.options.main_fields) {
-                    // c. let M = X + (json main field)
-                    let cached_path = cached_path.normalize_with(main_field, self.cache.as_ref());
-                    // d. LOAD_AS_FILE(M)
-                    if let Some(path) = self.load_as_file(&cached_path, ctx)? {
-                        return Ok(Some(path));
-                    }
-                    // e. LOAD_INDEX(M)
-                    if let Some(path) = self.load_index(&cached_path, ctx)? {
-                        return Ok(Some(path));
-                    }
+        // a. Parse X/package.json, and look for "main" field.
+        if let Some((_, package_json)) =
+            self.cache.get_package_json(cached_path, &self.options, ctx)?
+        {
+            // b. If "main" is a falsy value, GOTO 2.
+            for main_field in package_json.main_fields(&self.options.main_fields) {
+                // c. let M = X + (json main field)
+                let cached_path = cached_path.normalize_with(main_field, self.cache.as_ref());
+                // d. LOAD_AS_FILE(M)
+                if let Some(path) = self.load_as_file(&cached_path, ctx)? {
+                    return Ok(Some(path));
                 }
-                // f. LOAD_INDEX(X) DEPRECATED
-                // g. THROW "not found"
+                // e. LOAD_INDEX(M)
+                if let Some(path) = self.load_index(&cached_path, ctx)? {
+                    return Ok(Some(path));
+                }
             }
+            // f. LOAD_INDEX(X) DEPRECATED
+            // g. THROW "not found"
         }
         // 2. LOAD_INDEX(X)
         self.load_index(cached_path, ctx)
@@ -1286,7 +1282,6 @@ impl<C: Cache> ResolverGeneric<C> {
             Some(b'.') => Ok(tsconfig.directory().normalize_with(specifier)),
             _ => self
                 .clone_with_options(ResolveOptions {
-                    description_files: vec![],
                     extensions: vec![".json".into()],
                     main_files: vec!["tsconfig.json".into()],
                     ..ResolveOptions::default()

--- a/src/options.rs
+++ b/src/options.rs
@@ -41,11 +41,6 @@ pub struct ResolveOptions {
     /// Default `[]`
     pub condition_names: Vec<String>,
 
-    /// The JSON files to use for descriptions. (There was once a `bower.json`.)
-    ///
-    /// Default `["package.json"]`
-    pub description_files: Vec<String>,
-
     /// Set to [EnforceExtension::Enabled] for [ESM Mandatory file extensions](https://nodejs.org/api/esm.html#mandatory-file-extensions).
     ///
     /// If `enforce_extension` is set to [EnforceExtension::Enabled], resolution will not allow extension-less files.
@@ -443,7 +438,6 @@ impl Default for ResolveOptions {
             alias: vec![],
             alias_fields: vec![],
             condition_names: vec![],
-            description_files: vec!["package.json".into()],
             enforce_extension: EnforceExtension::Auto,
             extension_alias: vec![],
             exports_fields: vec![vec!["exports".into()]],
@@ -590,7 +584,6 @@ mod test {
             alias_fields: vec![],
             builtin_modules: false,
             condition_names: vec![],
-            description_files: vec![],
             enforce_extension: EnforceExtension::Disabled,
             exports_fields: vec![],
             extension_alias: vec![],

--- a/src/tests/incorrect_description_file.rs
+++ b/src/tests/incorrect_description_file.rs
@@ -2,7 +2,7 @@
 
 use rustc_hash::FxHashSet;
 
-use crate::{JSONError, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver};
+use crate::{JSONError, ResolveContext, ResolveError, Resolver};
 
 // should not resolve main in incorrect description file #1
 #[test]
@@ -44,22 +44,4 @@ fn incorrect_description_file_3() {
     let f = super::fixture().join("incorrect-package");
     let resolution = Resolver::default().resolve(f.join("pack2"), ".");
     assert!(resolution.is_err());
-}
-
-// `enhanced_resolve` does not have this test case
-#[test]
-fn no_description_file() {
-    let f = super::fixture_root().join("enhanced_resolve");
-
-    // has description file
-    let resolver = Resolver::default();
-    assert_eq!(
-        resolver.resolve(&f, ".").map(Resolution::into_path_buf),
-        Ok(f.join("lib/index.js"))
-    );
-
-    // without description file
-    let resolver =
-        Resolver::new(ResolveOptions { description_files: vec![], ..ResolveOptions::default() });
-    assert_eq!(resolver.resolve(&f, "."), Err(ResolveError::NotFound(".".into())));
 }


### PR DESCRIPTION
The only value for this option in the ecosystem is `package.json`.

This option also slightly impacts performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed support for customizing description files during module resolution; the resolver now always attempts to parse package.json when resolving directories.
- **Tests**
  - Removed a test related to custom description file behavior.
- **Chores**
  - Cleaned up unused imports in test files.
- **Documentation**
  - Moved the descriptionFiles option to the unimplemented options section in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->