### PR TITLE
perf: cache whether a path is `node_modules` or inside `node_modules`

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -62,6 +62,10 @@ pub trait CachedPath: Sized {
 
     fn parent(&self) -> Option<&Self>;
 
+    fn is_node_modules(&self) -> bool;
+
+    fn inside_node_modules(&self) -> bool;
+
     /// Find package.json of a path by traversing parent directories.
     #[allow(clippy::type_complexity)]
     fn find_package_json<C: Cache<Cp = Self>>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,13 +287,11 @@ impl<C: Cache> ResolverGeneric<C> {
         // Algorithm:
         // Find `node_modules/package/package.json`
         // or the first package.json if the path is not inside node_modules.
-        // TODO(perf): cache whether a directory is inside `node_modules`?
-        let inside_node_modules = iter::successors(Some(cached_path), |cp| cp.parent())
-            .any(|cp| cp.path().ends_with("node_modules"));
+        let inside_node_modules = cached_path.inside_node_modules();
         if inside_node_modules {
             let mut last = None;
             for cp in iter::successors(Some(cached_path), |cp| cp.parent()) {
-                if cp.path().ends_with("node_modules") {
+                if cp.is_node_modules() {
                     break;
                 }
                 if self.cache.is_dir(cp, ctx) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to detect if a path is a "node_modules" directory or located inside one.
- **Refactor**
	- Improved internal logic to use new detection methods for "node_modules" directories, enhancing reliability when searching for package files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->