### PR TITLE
chore(napi): make mimalloc optional to build

### DIFF
--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -18,10 +18,14 @@ napi-derive = { version = "3.0.0-alpha" }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = ["std", "fmt"] } # Omit the `regex` feature
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "freebsd"), not(target_arch = "arm"), not(target_family = "wasm")))'.dependencies]
-mimalloc-safe = { version = "0.1.50", features = ["skip_collect_on_exit"] }
+mimalloc-safe = { version = "0.1.50", optional = true, features = ["skip_collect_on_exit"] }
 
 [target.'cfg(all(target_os = "linux", not(target_arch = "arm")))'.dependencies]
-mimalloc-safe = { version = "0.1.50", features = ["skip_collect_on_exit", "local_dynamic_tls"] }
+mimalloc-safe = { version = "0.1.50", optional = true, features = ["skip_collect_on_exit", "local_dynamic_tls"] }
 
 [build-dependencies]
 napi-build = "2.1.6"
+
+[features]
+default = []
+allocator = ["dep:mimalloc-safe"]

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -1,4 +1,9 @@
-#[cfg(all(not(target_arch = "arm"), not(target_os = "freebsd"), not(target_family = "wasm")))]
+#[cfg(all(
+    feature = "allocator",
+    not(target_arch = "arm"),
+    not(target_os = "freebsd"),
+    not(target_family = "wasm")
+))]
 #[global_allocator]
 static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   ],
   "scripts": {
     "test": "vitest run -r ./napi",
-    "build": "napi build --platform --release --manifest-path napi/Cargo.toml",
     "build:debug": "napi build --platform --manifest-path napi/Cargo.toml",
-    "postbuild": "node napi/patch.mjs"
+    "build": "pnpm run build:debug --features allocator --release",
+    "postbuild:debug": "node napi/patch.mjs"
   },
   "devDependencies": {
     "@napi-rs/cli": "3.0.0-alpha.78",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated build scripts to allow optional use of a custom memory allocator, requiring explicit opt-in.
	- Adjusted internal configuration to make the memory allocator feature optional by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->