### PR TITLE
chore: publish `oxc_napi_resolver`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxc_napi_resolver"
-version = "0.0.0"
+version = "8.0.0"
 dependencies = [
  "mimalloc-safe",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,7 @@
 members = ["napi"]
 resolver = "2"
 
-[package]
-name = "oxc_resolver"
-version = "8.0.0"
+[workspace.package]
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = ["development-tools"]
 edition = "2024"
@@ -16,6 +14,21 @@ readme = "README.md"
 repository = "https://github.com/oxc-project/oxc-resolver"
 rust-version = "1.85.0"
 description = "ESM / CJS module resolution"
+
+[package]
+name = "oxc_resolver"
+version = "8.0.0"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+include.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description.workspace = true
 
 [lib]
 doctest = false

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -1,9 +1,18 @@
 [package]
 name = "oxc_napi_resolver"
-version = "0.0.0"
-edition = "2024"
-publish = false
-rust-version = "1.85.0"
+version = "8.0.0"
+publish = true
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+include.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description.workspace = true
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
closes #494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the package version to 8.0.0.
  - Enabled publishing for the package.
  - Centralized package metadata configuration to streamline management across the workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->