### PR TITLE
Revert "refactor!: remove `modules` options (#484)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ See [index.d.ts](https://github.com/oxc-project/oxc-resolver/blob/main/napi/inde
 | fullySpecified   | false                     | Request passed to resolve is already fully specified and extensions or main files are not resolved for it (they are still resolved for internal requests) |
 | mainFields       | ["main"]                  | A list of main fields in description files                                                                                                                |
 | mainFiles        | ["index"]                 | A list of main files in directories                                                                                                                       |
+| modules          | ["node_modules"]          | A list of directories to resolve modules from, can be absolute path or folder name                                                                        |
 | resolveToContext | false                     | Resolve to a context instead of a file                                                                                                                    |
 | preferRelative   | false                     | Prefer to resolve module requests as relative request and fallback to resolving as module                                                                 |
 | preferAbsolute   | false                     | Prefer to resolve server-relative urls as absolute paths before falling back to resolve in roots                                                          |
@@ -190,7 +191,6 @@ See [index.d.ts](https://github.com/oxc-project/oxc-resolver/blob/main/napi/inde
 | Field            | Default                     | Description                                                                                                                                   |
 | ---------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | descriptionFiles | ["package.json"]            | A list of description files to read from                                                                                                      |
-| modules          | ["node_modules"]            | A list of directories to resolve modules from, can be absolute path or folder name                                                            |
 | cachePredicate   | function() { return true }; | A function which decides whether a request should be cached or not. An object is passed to the function with `path` and `request` properties. |
 | cacheWithContext | true                        | If unsafe cache is enabled, includes `request.context` in the cache key                                                                       |
 | plugins          | []                          | A list of additional resolve plugins which should be applied                                                                                  |

--- a/napi/index.d.ts
+++ b/napi/index.d.ts
@@ -126,6 +126,12 @@ export interface NapiResolveOptions {
    */
   mainFiles?: Array<string>
   /**
+   * A list of directories to resolve modules from, can be absolute path or folder name.
+   *
+   * Default `["node_modules"]`
+   */
+  modules?: string | string[]
+  /**
    * Resolve to a context instead of a file.
    *
    * Default `false`

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -202,6 +202,7 @@ impl ResolverFactory {
                 .map(|o| StrOrStrList(o).into())
                 .unwrap_or(default.main_fields),
             main_files: op.main_files.unwrap_or(default.main_files),
+            modules: op.modules.map(|o| StrOrStrList(o).into()).unwrap_or(default.modules),
             resolve_to_context: op.resolve_to_context.unwrap_or(default.resolve_to_context),
             prefer_relative: op.prefer_relative.unwrap_or(default.prefer_relative),
             prefer_absolute: op.prefer_absolute.unwrap_or(default.prefer_absolute),

--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -100,6 +100,12 @@ pub struct NapiResolveOptions {
     /// Default `["index"]`
     pub main_files: Option<Vec<String>>,
 
+    /// A list of directories to resolve modules from, can be absolute path or folder name.
+    ///
+    /// Default `["node_modules"]`
+    #[napi(ts_type = "string | string[]")]
+    pub modules: Option<StrOrStrListType>,
+
     /// Resolve to a context instead of a file.
     ///
     /// Default `false`

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -66,6 +66,15 @@ pub trait CachedPath: Sized {
 
     fn inside_node_modules(&self) -> bool;
 
+    fn module_directory<C: Cache<Cp = Self>>(
+        &self,
+        module_name: &str,
+        cache: &C,
+        ctx: &mut Ctx,
+    ) -> Option<Self>;
+
+    fn cached_node_modules<C: Cache<Cp = Self>>(&self, cache: &C, ctx: &mut Ctx) -> Option<Self>;
+
     /// Find package.json of a path by traversing parent directories.
     #[allow(clippy::type_complexity)]
     fn find_package_json<C: Cache<Cp = Self>>(

--- a/src/fs_cache.rs
+++ b/src/fs_cache.rs
@@ -272,6 +272,7 @@ pub struct CachedPathImpl {
     meta: OnceLock<Option<FileMetadata>>,
     canonicalized: OnceLock<Result<FsCachedPath, ResolveError>>,
     canonicalizing: AtomicU64,
+    node_modules: OnceLock<Option<FsCachedPath>>,
     package_json: OnceLock<Option<(FsCachedPath, Arc<PackageJsonSerde>)>>,
 }
 
@@ -292,6 +293,7 @@ impl CachedPathImpl {
             meta: OnceLock::new(),
             canonicalized: OnceLock::new(),
             canonicalizing: AtomicU64::new(0),
+            node_modules: OnceLock::new(),
             package_json: OnceLock::new(),
         }
     }
@@ -324,6 +326,20 @@ impl CachedPath for FsCachedPath {
 
     fn inside_node_modules(&self) -> bool {
         self.inside_node_modules
+    }
+
+    fn module_directory<C: Cache<Cp = Self>>(
+        &self,
+        module_name: &str,
+        cache: &C,
+        ctx: &mut Ctx,
+    ) -> Option<Self> {
+        let cached_path = cache.value(&self.path.join(module_name));
+        cache.is_dir(&cached_path, ctx).then_some(cached_path)
+    }
+
+    fn cached_node_modules<C: Cache<Cp = Self>>(&self, cache: &C, ctx: &mut Ctx) -> Option<Self> {
+        self.node_modules.get_or_init(|| self.module_directory("node_modules", cache, ctx)).clone()
     }
 
     /// Find package.json of a path by traversing parent directories.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,63 +762,72 @@ impl<C: Cache> ResolverGeneric<C> {
 
         // 1. let DIRS = NODE_MODULES_PATHS(START)
         // 2. for each DIR in DIRS:
-        for cached_path in std::iter::successors(Some(cached_path), |p| p.parent()) {
-            // Skip if /path/to/node_modules does not exist
-            let cached_path = cached_path.normalize_with("node_modules", self.cache.as_ref());
-            if !self.cache.is_dir(&cached_path, ctx) {
-                continue;
-            }
-            // Optimize node_modules lookup by inspecting whether the package exists
-            // From LOAD_PACKAGE_EXPORTS(X, DIR)
-            // 1. Try to interpret X as a combination of NAME and SUBPATH where the name
-            //    may have a @scope/ prefix and the subpath begins with a slash (`/`).
-            if !package_name.is_empty() {
-                let cached_path = cached_path.normalize_with(package_name, self.cache.as_ref());
-                // Try foo/node_modules/package_name
-                if self.cache.is_dir(&cached_path, ctx) {
-                    // a. LOAD_PACKAGE_EXPORTS(X, DIR)
-                    if let Some(path) =
-                        self.load_package_exports(specifier, subpath, &cached_path, ctx)?
-                    {
-                        return Ok(Some(path));
-                    }
-                } else {
-                    // foo/node_modules/package_name is not a directory, so useless to check inside it
-                    if !subpath.is_empty() {
-                        continue;
-                    }
-                    // Skip if the directory lead to the scope package does not exist
-                    // i.e. `foo/node_modules/@scope` is not a directory for `foo/node_modules/@scope/package`
-                    if package_name.starts_with('@') {
-                        if let Some(path) = cached_path.parent() {
-                            if !self.cache.is_dir(path, ctx) {
-                                continue;
+        for module_name in &self.options.modules {
+            for cached_path in std::iter::successors(Some(cached_path), |p| p.parent()) {
+                // Skip if /path/to/node_modules does not exist
+                if !self.cache.is_dir(cached_path, ctx) {
+                    continue;
+                }
+
+                let Some(cached_path) = self.get_module_directory(cached_path, module_name, ctx)
+                else {
+                    continue;
+                };
+                // Optimize node_modules lookup by inspecting whether the package exists
+                // From LOAD_PACKAGE_EXPORTS(X, DIR)
+                // 1. Try to interpret X as a combination of NAME and SUBPATH where the name
+                //    may have a @scope/ prefix and the subpath begins with a slash (`/`).
+                if !package_name.is_empty() {
+                    let cached_path = cached_path.normalize_with(package_name, self.cache.as_ref());
+                    // Try foo/node_modules/package_name
+                    if self.cache.is_dir(&cached_path, ctx) {
+                        // a. LOAD_PACKAGE_EXPORTS(X, DIR)
+                        if let Some(path) =
+                            self.load_package_exports(specifier, subpath, &cached_path, ctx)?
+                        {
+                            return Ok(Some(path));
+                        }
+                    } else {
+                        // foo/node_modules/package_name is not a directory, so useless to check inside it
+                        if !subpath.is_empty() {
+                            continue;
+                        }
+                        // Skip if the directory lead to the scope package does not exist
+                        // i.e. `foo/node_modules/@scope` is not a directory for `foo/node_modules/@scope/package`
+                        if package_name.starts_with('@') {
+                            if let Some(path) = cached_path.parent() {
+                                if !self.cache.is_dir(path, ctx) {
+                                    continue;
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            // Try as file or directory for all other cases
-            // b. LOAD_AS_FILE(DIR/X)
-            // c. LOAD_AS_DIRECTORY(DIR/X)
+                // Try as file or directory for all other cases
+                // b. LOAD_AS_FILE(DIR/X)
+                // c. LOAD_AS_DIRECTORY(DIR/X)
 
-            let cached_path = cached_path.normalize_with(specifier, self.cache.as_ref());
+                let cached_path = cached_path.normalize_with(specifier, self.cache.as_ref());
 
-            // Perf: try the directory first for package specifiers.
-            if self.options.resolve_to_context {
-                return Ok(self.cache.is_dir(&cached_path, ctx).then(|| cached_path.clone()));
-            }
-            if self.cache.is_dir(&cached_path, ctx) {
-                if let Some(path) = self.load_browser_field_or_alias(&cached_path, ctx)? {
+                // Perf: try the directory first for package specifiers.
+                if self.options.resolve_to_context {
+                    return Ok(self.cache.is_dir(&cached_path, ctx).then(|| cached_path.clone()));
+                }
+                if self.cache.is_dir(&cached_path, ctx) {
+                    if let Some(path) = self.load_browser_field_or_alias(&cached_path, ctx)? {
+                        return Ok(Some(path));
+                    }
+                    if let Some(path) = self.load_as_directory(&cached_path, ctx)? {
+                        return Ok(Some(path));
+                    }
+                }
+                if let Some(path) = self.load_as_file(&cached_path, ctx)? {
                     return Ok(Some(path));
                 }
                 if let Some(path) = self.load_as_directory(&cached_path, ctx)? {
                     return Ok(Some(path));
                 }
-            }
-            if let Some(path) = self.load_as_file(&cached_path, ctx)? {
-                return Ok(Some(path));
             }
         }
         Ok(None)
@@ -860,6 +869,23 @@ impl<C: Cache> ResolverGeneric<C> {
                 // Todo: Add a ResolveError::Pnp variant?
                 Err(ResolveError::NotFound(specifier.to_string()))
             }
+        }
+    }
+
+    fn get_module_directory(
+        &self,
+        cached_path: &C::Cp,
+        module_name: &str,
+        ctx: &mut Ctx,
+    ) -> Option<C::Cp> {
+        if module_name == "node_modules" {
+            cached_path.cached_node_modules(self.cache.as_ref(), ctx)
+        } else if cached_path.path().components().next_back()
+            == Some(Component::Normal(OsStr::new(module_name)))
+        {
+            Some(cached_path.clone())
+        } else {
+            cached_path.module_directory(module_name, self.cache.as_ref(), ctx)
         }
     }
 
@@ -1304,49 +1330,51 @@ impl<C: Cache> ResolverGeneric<C> {
         self.require_core(package_name)?;
 
         // 11. While parentURL is not the file system root,
-        for cached_path in std::iter::successors(Some(cached_path), |p| p.parent()) {
-            // 1. Let packageURL be the URL resolution of "node_modules/" concatenated with packageSpecifier, relative to parentURL.
-            let cached_path = cached_path.normalize_with("node_modules", self.cache.as_ref());
-            if !self.cache.is_dir(&cached_path, ctx) {
-                continue;
-            }
-            // 2. Set parentURL to the parent folder URL of parentURL.
-            let cached_path = cached_path.normalize_with(package_name, self.cache.as_ref());
-            // 3. If the folder at packageURL does not exist, then
-            //   1. Continue the next loop iteration.
-            if self.cache.is_dir(&cached_path, ctx) {
-                // 4. Let pjson be the result of READ_PACKAGE_JSON(packageURL).
-                if let Some((_, package_json)) =
-                    self.cache.get_package_json(&cached_path, &self.options, ctx)?
-                {
-                    // 5. If pjson is not null and pjson.exports is not null or undefined, then
-                    // 1. Return the result of PACKAGE_EXPORTS_RESOLVE(packageURL, packageSubpath, pjson.exports, defaultConditions).
-                    for exports in package_json.exports_fields(&self.options.exports_fields) {
-                        if let Some(path) = self.package_exports_resolve(
-                            &cached_path,
-                            &format!(".{subpath}"),
-                            &exports,
-                            ctx,
-                        )? {
-                            return Ok(Some(path));
+        for module_name in &self.options.modules {
+            for cached_path in std::iter::successors(Some(cached_path), |p| p.parent()) {
+                // 1. Let packageURL be the URL resolution of "node_modules/" concatenated with packageSpecifier, relative to parentURL.
+                let Some(cached_path) = self.get_module_directory(cached_path, module_name, ctx)
+                else {
+                    continue;
+                };
+                // 2. Set parentURL to the parent folder URL of parentURL.
+                let cached_path = cached_path.normalize_with(package_name, self.cache.as_ref());
+                // 3. If the folder at packageURL does not exist, then
+                //   1. Continue the next loop iteration.
+                if self.cache.is_dir(&cached_path, ctx) {
+                    // 4. Let pjson be the result of READ_PACKAGE_JSON(packageURL).
+                    if let Some((_, package_json)) =
+                        self.cache.get_package_json(&cached_path, &self.options, ctx)?
+                    {
+                        // 5. If pjson is not null and pjson.exports is not null or undefined, then
+                        // 1. Return the result of PACKAGE_EXPORTS_RESOLVE(packageURL, packageSubpath, pjson.exports, defaultConditions).
+                        for exports in package_json.exports_fields(&self.options.exports_fields) {
+                            if let Some(path) = self.package_exports_resolve(
+                                &cached_path,
+                                &format!(".{subpath}"),
+                                &exports,
+                                ctx,
+                            )? {
+                                return Ok(Some(path));
+                            }
                         }
-                    }
-                    // 6. Otherwise, if packageSubpath is equal to ".", then
-                    if subpath == "." {
-                        // 1. If pjson.main is a string, then
-                        for main_field in package_json.main_fields(&self.options.main_fields) {
-                            // 1. Return the URL resolution of main in packageURL.
-                            let cached_path =
-                                cached_path.normalize_with(main_field, self.cache.as_ref());
-                            if self.cache.is_file(&cached_path, ctx) {
-                                return Ok(Some(cached_path));
+                        // 6. Otherwise, if packageSubpath is equal to ".", then
+                        if subpath == "." {
+                            // 1. If pjson.main is a string, then
+                            for main_field in package_json.main_fields(&self.options.main_fields) {
+                                // 1. Return the URL resolution of main in packageURL.
+                                let cached_path =
+                                    cached_path.normalize_with(main_field, self.cache.as_ref());
+                                if self.cache.is_file(&cached_path, ctx) {
+                                    return Ok(Some(cached_path));
+                                }
                             }
                         }
                     }
+                    let subpath = format!(".{subpath}");
+                    ctx.with_fully_specified(false);
+                    return self.require(&cached_path, &subpath, ctx).map(Some);
                 }
-                let subpath = format!(".{subpath}");
-                ctx.with_fully_specified(false);
-                return self.require(&cached_path, &subpath, ctx).map(Some);
             }
         }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -108,6 +108,11 @@ pub struct ResolveOptions {
     /// Default `["index"]`
     pub main_files: Vec<String>,
 
+    /// A list of directories to resolve modules from, can be absolute path or folder name.
+    ///
+    /// Default `["node_modules"]`
+    pub modules: Vec<String>,
+
     /// A manifest loaded from pnp::load_pnp_manifest.
     ///
     /// Default `None`
@@ -318,6 +323,22 @@ impl ResolveOptions {
         self
     }
 
+    /// Adds a module to [ResolveOptions::modules]
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use oxc_resolver::{ResolveOptions};
+    ///
+    /// let options = ResolveOptions::default().with_module("module");
+    /// assert!(options.modules.contains(&"module".to_string()));
+    /// ```
+    #[must_use]
+    pub fn with_module<M: Into<String>>(mut self, module: M) -> Self {
+        self.modules.push(module.into());
+        self
+    }
+
     /// Adds a main file to [ResolveOptions::main_files]
     ///
     /// ## Examples
@@ -447,6 +468,7 @@ impl Default for ResolveOptions {
             fully_specified: false,
             main_fields: vec!["main".into()],
             main_files: vec!["index".into()],
+            modules: vec!["node_modules".into()],
             #[cfg(feature = "yarn_pnp")]
             pnp_manifest: None,
             resolve_to_context: false,
@@ -501,6 +523,9 @@ impl fmt::Display for ResolveOptions {
         }
         if !self.main_files.is_empty() {
             write!(f, "main_files:{:?},", self.main_files)?;
+        }
+        if !self.modules.is_empty() {
+            write!(f, "modules:{:?},", self.modules)?;
         }
         if self.resolve_to_context {
             write!(f, "resolve_to_context:{:?},", self.resolve_to_context)?;
@@ -576,7 +601,7 @@ mod test {
             ..ResolveOptions::default()
         };
 
-        let expected = r#"tsconfig:TsconfigOptions { config_file: "tsconfig.json", references: Auto },alias:[("a", [Ignore])],alias_fields:[["browser"]],condition_names:["require"],enforce_extension:Enabled,exports_fields:[["exports"]],imports_fields:[["imports"]],extension_alias:[(".js", [".ts"])],extensions:[".js", ".json", ".node"],fallback:[("fallback", [Ignore])],fully_specified:true,main_fields:["main"],main_files:["index"],resolve_to_context:true,prefer_relative:true,prefer_absolute:true,restrictions:[Path("restrictions")],roots:["roots"],symlinks:true,builtin_modules:true,"#;
+        let expected = r#"tsconfig:TsconfigOptions { config_file: "tsconfig.json", references: Auto },alias:[("a", [Ignore])],alias_fields:[["browser"]],condition_names:["require"],enforce_extension:Enabled,exports_fields:[["exports"]],imports_fields:[["imports"]],extension_alias:[(".js", [".ts"])],extensions:[".js", ".json", ".node"],fallback:[("fallback", [Ignore])],fully_specified:true,main_fields:["main"],main_files:["index"],modules:["node_modules"],resolve_to_context:true,prefer_relative:true,prefer_absolute:true,restrictions:[Path("restrictions")],roots:["roots"],symlinks:true,builtin_modules:true,"#;
         assert_eq!(format!("{options}"), expected);
 
         let options = ResolveOptions {
@@ -593,6 +618,7 @@ mod test {
             imports_fields: vec![],
             main_fields: vec![],
             main_files: vec![],
+            modules: vec![],
             #[cfg(feature = "yarn_pnp")]
             pnp_manifest: None,
             prefer_absolute: false,

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -12,7 +12,7 @@ mod windows {
             ("/a/b/node_modules/some-module/index.js", ""),
             ("/a/node_modules/module/package.json", r#"{"main":"entry.js"}"#),
             ("/a/node_modules/module/file.js", r#"{"main":"entry.js"}"#),
-            ("/node_modules/other-module/file.js", ""),
+            ("/modules/other-module/file.js", ""),
         ])
     }
 
@@ -24,6 +24,7 @@ mod windows {
             Arc::new(FsCache::new(file_system)),
             ResolveOptions {
                 extensions: vec![".json".into(), ".js".into()],
+                modules: vec!["/modules".into(), "node_modules".into()],
                 ..ResolveOptions::default()
             },
         );
@@ -48,40 +49,44 @@ mod windows {
                 ],
                 vec![
                     // missing package.jsons
-                    "/package.json",
-                    "/a/package.json",
-                    "/a/node_modules/module/file",
+                    // "/a/b/c/package.json",
                     "/a/b/package.json",
-                    "/a/b/node_modules/module",
-                    "/a/node_modules/module/file.json",
-                    "/a/b/c/node_modules",
+                    "/a/package.json",
+                    "/package.json",
+                    // missing modules directories
                     "/a/b/c",
+                    // "/a/b/c/node_modules",
+                    // missing single file modules
+                    "/modules/module",
+                    "/a/b/node_modules/module",
+                    // missing files with alternative extensions
+                    "/a/node_modules/module/file",
+                    "/a/node_modules/module/file.json",
                 ],
             ),
             (
                 "fast found module",
                 "/a/b/c",
                 "other-module/file.js",
-                "/node_modules/other-module/file.js",
+                "/modules/other-module/file.js",
                 // These dependencies are different from enhanced-resolve due to different code path to
                 // querying the file system
                 vec![
                     // symlink checks
-                    "/node_modules/other-module/file.js",
+                    "/modules/other-module/file.js",
                     // "/modules/other-module",
                     // "/modules",
                     // "/",
                 ],
                 vec![
                     // missing package.jsons
-                    "/package.json",
-                    "/a/package.json",
-                    "/a/node_modules/other-module",
-                    "/a/b/package.json",
-                    "/a/b/node_modules/other-module",
-                    "/node_modules/other-module/package.json",
-                    "/a/b/c/node_modules",
+                    // "/a/b/c/package.json",
                     "/a/b/c",
+                    "/a/b/package.json",
+                    "/a/package.json",
+                    "/package.json",
+                    "/modules/other-module/package.json",
+                    "/modules/package.json",
                 ],
             ),
         ];

--- a/src/tests/fallback.rs
+++ b/src/tests/fallback.rs
@@ -14,21 +14,21 @@ fn fallback() {
     let f = Path::new("/");
 
     let file_system = MemoryFS::new(&[
-        ("/node_modules/a/index", ""),
-        ("/node_modules/a/dir/index", ""),
-        ("/node_modules/recursive/index", ""),
-        ("/node_modules/recursive/dir/index", ""),
-        ("/node_modules/recursive/dir/file", ""),
-        ("/node_modules/recursive/dir/dir/index", ""),
-        ("/node_modules/b/index", ""),
-        ("/node_modules/b/dir/index", ""),
-        ("/node_modules/c/index", ""),
-        ("/node_modules/c/dir/index", ""),
-        ("/node_modules/d/index.js", ""),
-        ("/node_modules/d/dir/.empty", ""),
-        ("/node_modules/e/index", ""),
-        ("/node_modules/e/anotherDir/index", ""),
-        ("/node_modules/e/dir/file", ""),
+        ("/a/index", ""),
+        ("/a/dir/index", ""),
+        ("/recursive/index", ""),
+        ("/recursive/dir/index", ""),
+        ("/recursive/dir/file", ""),
+        ("/recursive/dir/dir/index", ""),
+        ("/b/index", ""),
+        ("/b/dir/index", ""),
+        ("/c/index", ""),
+        ("/c/dir/index", ""),
+        ("/d/index.js", ""),
+        ("/d/dir/.empty", ""),
+        ("/e/index", ""),
+        ("/e/anotherDir/index", ""),
+        ("/e/dir/file", ""),
     ]);
 
     let resolver = ResolverGeneric::new_with_cache(
@@ -36,8 +36,8 @@ fn fallback() {
         ResolveOptions {
             fallback: vec![
                 ("aliasA".into(), vec![AliasValue::Path("a".into())]),
-                ("b$".into(), vec![AliasValue::Path("node_modules/a/index".into())]),
-                ("c$".into(), vec![AliasValue::Path("node_modules/a/index".into())]),
+                ("b$".into(), vec![AliasValue::Path("a/index".into())]),
+                ("c$".into(), vec![AliasValue::Path("/a/index".into())]),
                 (
                     "multiAlias".into(),
                     vec![
@@ -49,46 +49,46 @@ fn fallback() {
                     ],
                 ),
                 ("recursive".into(), vec![AliasValue::Path("recursive/dir".into())]),
-                ("/d/dir".into(), vec![AliasValue::Path("/node_modules/c/dir".into())]),
-                ("/d/index.js".into(), vec![AliasValue::Path("/node_modules/c/index".into())]),
+                ("/d/dir".into(), vec![AliasValue::Path("/c/dir".into())]),
+                ("/d/index.js".into(), vec![AliasValue::Path("/c/index".into())]),
                 ("ignored".into(), vec![AliasValue::Ignore]),
                 ("node:path".into(), vec![AliasValue::Ignore]),
             ],
+            modules: vec!["/".into()],
             ..ResolveOptions::default()
         },
     );
 
     #[rustfmt::skip]
     let pass = [
-        ("should resolve a not aliased module 1", "a", "a/index"),
-        ("should resolve a not aliased module 2", "a/index", "a/index"),
-        ("should resolve a not aliased module 3", "a/dir", "a/dir/index"),
-        ("should resolve a not aliased module 4", "a/dir/index", "a/dir/index"),
-        ("should resolve an fallback module 1", "aliasA", "a/index"),
-        ("should resolve an fallback module 2", "aliasA/index", "a/index"),
-        ("should resolve an fallback module 3", "aliasA/dir", "a/dir/index"),
-        ("should resolve an fallback module 4", "aliasA/dir/index", "a/dir/index"),
-        ("should resolve a recursive aliased module 1", "recursive", "recursive/index"),
-        ("should resolve a recursive aliased module 2", "recursive/index", "recursive/index"),
-        ("should resolve a recursive aliased module 3", "recursive/dir", "recursive/dir/index"),
-        ("should resolve a recursive aliased module 4", "recursive/dir/index", "recursive/dir/index"),
-        ("should resolve a recursive aliased module 5", "recursive/file", "recursive/dir/file"),
-        ("should resolve a file aliased module with a query 1", "b?query", "b/index?query"),
-        ("should resolve a file aliased module with a query 2", "c?query", "c/index?query"),
-        ("should resolve a path in a file aliased module 1", "b/index", "b/index"),
-        ("should resolve a path in a file aliased module 2", "b/dir", "b/dir/index"),
-        ("should resolve a path in a file aliased module 3", "b/dir/index", "b/dir/index"),
-        ("should resolve a path in a file aliased module 4", "c/index", "c/index"),
-        ("should resolve a path in a file aliased module 5", "c/dir", "c/dir/index"),
-        ("should resolve a path in a file aliased module 6", "c/dir/index", "c/dir/index"),
-        ("should resolve a file in multiple aliased dirs 1", "multiAlias/dir/file", "e/dir/file"),
-        ("should resolve a file in multiple aliased dirs 2", "multiAlias/anotherDir", "e/anotherDir/index"),
+        ("should resolve a not aliased module 1", "a", "/a/index"),
+        ("should resolve a not aliased module 2", "a/index", "/a/index"),
+        ("should resolve a not aliased module 3", "a/dir", "/a/dir/index"),
+        ("should resolve a not aliased module 4", "a/dir/index", "/a/dir/index"),
+        ("should resolve an fallback module 1", "aliasA", "/a/index"),
+        ("should resolve an fallback module 2", "aliasA/index", "/a/index"),
+        ("should resolve an fallback module 3", "aliasA/dir", "/a/dir/index"),
+        ("should resolve an fallback module 4", "aliasA/dir/index", "/a/dir/index"),
+        ("should resolve a recursive aliased module 1", "recursive", "/recursive/index"),
+        ("should resolve a recursive aliased module 2", "recursive/index", "/recursive/index"),
+        ("should resolve a recursive aliased module 3", "recursive/dir", "/recursive/dir/index"),
+        ("should resolve a recursive aliased module 4", "recursive/dir/index", "/recursive/dir/index"),
+        ("should resolve a recursive aliased module 5", "recursive/file", "/recursive/dir/file"),
+        ("should resolve a file aliased module with a query 1", "b?query", "/b/index?query"),
+        ("should resolve a file aliased module with a query 2", "c?query", "/c/index?query"),
+        ("should resolve a path in a file aliased module 1", "b/index", "/b/index"),
+        ("should resolve a path in a file aliased module 2", "b/dir", "/b/dir/index"),
+        ("should resolve a path in a file aliased module 3", "b/dir/index", "/b/dir/index"),
+        ("should resolve a path in a file aliased module 4", "c/index", "/c/index"),
+        ("should resolve a path in a file aliased module 5", "c/dir", "/c/dir/index"),
+        ("should resolve a path in a file aliased module 6", "c/dir/index", "/c/dir/index"),
+        ("should resolve a file in multiple aliased dirs 1", "multiAlias/dir/file", "/e/dir/file"),
+        ("should resolve a file in multiple aliased dirs 2", "multiAlias/anotherDir", "/e/anotherDir/index"),
     ];
 
     for (comment, request, expected) in pass {
         let resolved_path = resolver.resolve(f, request).map(|r| r.full_path());
-        let expected = PathBuf::from("/node_modules").join(expected);
-        assert_eq!(resolved_path, Ok(expected), "{comment} {request}");
+        assert_eq!(resolved_path, Ok(PathBuf::from(expected)), "{comment} {request}");
     }
 
     #[rustfmt::skip]

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -65,6 +65,19 @@ fn resolve() {
 }
 
 #[test]
+fn issue238_resolve() {
+    let f = super::fixture().join("issue-238");
+    let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".js".into(), ".jsx".into(), ".ts".into(), ".tsx".into()],
+        modules: vec!["src/a".into(), "src/b".into(), "src/common".into(), "node_modules".into()],
+        ..ResolveOptions::default()
+    });
+    let resolved_path =
+        resolver.resolve(f.join("src/common"), "config/myObjectFile").map(|r| r.full_path());
+    assert_eq!(resolved_path, Ok(f.join("src/common/config/myObjectFile.js")),);
+}
+
+#[test]
 fn prefer_relative() {
     let f = super::fixture();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -108,6 +108,7 @@ fn options_api() {
         .with_fully_specified(true)
         .with_main_field("asdf")
         .with_main_file("main")
+        .with_module("module")
         .with_prefer_absolute(true)
         .with_prefer_relative(true)
         .with_root(PathBuf::new())


### PR DESCRIPTION
This reverts commit f64911c71096199ce32ee8282e9e6f7d9fd25c9b.

closes #502
closes #493

I don't have have a clear understanding of how .d.ts resolution works so reverting the previous commit.