### PR TITLE
fix(napi): ensure `pnp_manifest` is included with `yarn_pnp` feature

### DIFF
--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -42,3 +42,4 @@ napi-build = "2.2.1"
 default = ["tracing-subscriber"]
 allocator = ["dep:mimalloc-safe"]
 tracing-subscriber = ["dep:tracing-subscriber"]
+yarn_pnp = ["oxc_resolver/yarn_pnp"]

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -250,6 +250,8 @@ impl ResolverFactory {
             symlinks: op.symlinks.unwrap_or(default.symlinks),
             builtin_modules: op.builtin_modules.unwrap_or(default.builtin_modules),
             module_type: op.module_type.unwrap_or(default.module_type),
+            #[cfg(feature = "yarn_pnp")]
+            pnp_manifest: default.pnp_manifest,
         }
     }
 }


### PR DESCRIPTION
`oxc_resolver` requires `pnp_manifest` when the `yarn_pnp` feature is enabled,
but it was missing in the napi crate. This patch provides a default to fix the build failure.

```
Compiling oxc_resolver_napi v11.2.0
error[E0063]: missing field `pnp_manifest` in initializer of `ResolveOptions`
   --> /Users/geunhyeok.lee/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/oxc_resolver_napi-11.2.0/src/lib.rs:167:9
    |
167 |         ResolveOptions {
    |         ^^^^^^^^^^^^^^ missing `pnp_manifest`

   Compiling rolldown_plugin v0.1.0 (/Users/geunhyeok.lee/workspace/external/rolldown-ghlee/crates/rolldown_plugin)
For more information about this error, try `rustc --explain E0063`.
error: could not compile `oxc_resolver_napi` (lib) due to 1 previous error
```
