### PR TITLE
fix: avoid crash when encountering tsconfig circular extends

### DIFF
--- a/src/tsconfig_context.rs
+++ b/src/tsconfig_context.rs
@@ -1,0 +1,26 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Default)]
+pub struct TsconfigResolveContext {
+    extended_configs: Vec<PathBuf>,
+}
+
+impl TsconfigResolveContext {
+    pub fn with_extended_file<R, T: FnOnce(&mut Self) -> R>(&mut self, path: PathBuf, cb: T) -> R {
+        self.extended_configs.push(path);
+        let result = cb(self);
+        self.extended_configs.pop();
+        result
+    }
+
+    pub fn is_already_extended(&self, path: &Path) -> bool {
+        self.extended_configs.iter().any(|config| config == path)
+    }
+
+    pub fn get_extended_configs_with(&self, path: PathBuf) -> Vec<PathBuf> {
+        let mut new_vec = Vec::with_capacity(self.extended_configs.len() + 1);
+        new_vec.extend_from_slice(&self.extended_configs);
+        new_vec.push(path);
+        new_vec
+    }
+}

--- a/tests/tsconfig_circular_reference_a.json
+++ b/tests/tsconfig_circular_reference_a.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig_circular_reference_b.json"
+}

--- a/tests/tsconfig_circular_reference_b.json
+++ b/tests/tsconfig_circular_reference_b.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig_circular_reference_a.json"
+}

--- a/tests/tsconfig_self_reference.json
+++ b/tests/tsconfig_self_reference.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig_self_reference.json"
+}


### PR DESCRIPTION
When there's a circular `tsconfig` extends, oxc-resolver crashed with `Segmentation fault (core dumped)`.

This PR fixes that.

In this case, TypeScript outputs errors like:
```
$ pnpm tsc --noEmit -p tsconfig_self_reference.json
error TS18000: Circularity detected while resolving configuration: /home/green/workspace/oxc-resolver/tests/tsconfig_self_reference.json -> /home/green/workspace/oxc-resolver/tests/tsconfig_self_reference.json
$ pnpm tsc --noEmit -p tsconfig_circular_reference_a.json 
error TS18000: Circularity detected while resolving configuration: /home/green/workspace/oxc-resolver/tests/tsconfig_circular_reference_a.json -> /home/green/workspace/oxc-resolver/tests/tsconfig_circular_reference_b.json -> /home/green/workspace/oxc-resolver/tests/tsconfig_circular_reference_a.json
```


