### PR TITLE
feat(resolver): rework yarn manifest file look up

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ See https://stackblitz.com/edit/oxc-resolver for usage example.
 
 See [docs.rs/oxc_resolver](https://docs.rs/oxc_resolver/latest/oxc_resolver).
 
+### [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp)
+
+- For node.js, yarn pnp should work without any configuration, given the following conditions:
+  - the program is called with the `yarn` command, where the value [`process.versions.pnp`](https://yarnpkg.com/advanced/pnpapi#processversionspnp) is set.
+  - `.pnp.cjs` manifest file exists in the closest directory, searched from the current working directory,
+  - no multi-project setup, per second bullet point in [FIND_PNP_MANIFEST](https://yarnpkg.com/advanced/pnp-spec#find_pnp_manifest)
+
 ## Terminology
 
 ### `directory`

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -39,7 +39,7 @@ mimalloc-safe = { version = "0.1.52", optional = true, features = ["skip_collect
 napi-build = "2.2.1"
 
 [features]
-default = ["tracing-subscriber"]
+default = ["tracing-subscriber", "yarn_pnp"]
 allocator = ["dep:mimalloc-safe"]
 tracing-subscriber = ["dep:tracing-subscriber"]
 yarn_pnp = ["oxc_resolver/yarn_pnp"]

--- a/napi/index.d.ts
+++ b/napi/index.d.ts
@@ -57,8 +57,6 @@ export interface NapiResolveOptions {
    * Default `None`
    */
   tsconfig?: TsconfigOptions
-  /** Enable Yarn Plug'n'Play */
-  yarnPnp?: boolean
   /**
    * Alias for [ResolveOptions::alias] and [ResolveOptions::fallback].
    *

--- a/napi/index.js
+++ b/napi/index.js
@@ -387,3 +387,7 @@ module.exports.ResolverFactory = nativeBinding.ResolverFactory
 module.exports.EnforceExtension = nativeBinding.EnforceExtension
 module.exports.ModuleType = nativeBinding.ModuleType
 module.exports.sync = nativeBinding.sync
+
+if (process.versions.pnp) {
+  process.env.OXC_RESOLVER_YARN_PNP = '1'
+}

--- a/napi/patch.mjs
+++ b/napi/patch.mjs
@@ -15,4 +15,9 @@ if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
 }
 ` + s,
 );
+data = data + `
+if (process.versions.pnp) {
+  process.env.OXC_RESOLVER_YARN_PNP = '1'
+}
+`
 fs.writeFileSync(filename, data);

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -151,8 +151,7 @@ impl ResolverFactory {
     #[napi]
     #[allow(clippy::should_implement_trait)]
     pub fn default() -> Self {
-        let default_options = ResolveOptions::default();
-        Self { resolver: Arc::new(Resolver::new(default_options)) }
+        Self { resolver: Arc::new(Resolver::new(ResolveOptions::default())) }
     }
 
     /// Clone the resolver using the same underlying cache.
@@ -190,6 +189,7 @@ impl ResolverFactory {
         let default = ResolveOptions::default();
         // merging options
         ResolveOptions {
+            cwd: None,
             tsconfig: op.tsconfig.map(|tsconfig| tsconfig.into()),
             alias: op
                 .alias
@@ -279,7 +279,7 @@ impl ResolverFactory {
                 .allow_package_exports_in_directory_resolve
                 .unwrap_or(default.allow_package_exports_in_directory_resolve),
             #[cfg(feature = "yarn_pnp")]
-            yarn_pnp: op.yarn_pnp.unwrap_or(default.yarn_pnp),
+            yarn_pnp: default.yarn_pnp,
         }
     }
 }

--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -16,9 +16,6 @@ pub struct NapiResolveOptions {
     /// Default `None`
     pub tsconfig: Option<TsconfigOptions>,
 
-    /// Enable Yarn Plug'n'Play
-    pub yarn_pnp: Option<bool>,
-
     /// Alias for [ResolveOptions::alias] and [ResolveOptions::fallback].
     ///
     /// For the second value of the tuple, `None -> AliasValue::Ignore`, Some(String) ->

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -52,6 +52,9 @@ pub trait Cache: Sized {
         path: &Path,
         callback: F,
     ) -> Result<Arc<Self::Tc>, ResolveError>;
+
+    #[cfg(feature = "yarn_pnp")]
+    fn get_yarn_pnp_manifest(&self, cwd: Option<&Path>) -> Result<&pnp::Manifest, ResolveError>;
 }
 
 #[allow(clippy::missing_errors_doc)] // trait impls should be free to return any typesafe error

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt,
+    env, fmt,
     path::{Path, PathBuf},
 };
 
@@ -11,6 +11,9 @@ use std::{
 #[expect(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub struct ResolveOptions {
+    /// Current working directory, used for testing purposes.
+    pub cwd: Option<PathBuf>,
+
     /// Path to TypeScript configuration file.
     ///
     /// Default `None`
@@ -113,12 +116,6 @@ pub struct ResolveOptions {
     /// Default `["node_modules"]`
     pub modules: Vec<String>,
 
-    /// Whether the resolver should check for the presence of a .pnp.cjs file up the dependency tree.
-    ///
-    /// Default `true`
-    #[cfg(feature = "yarn_pnp")]
-    pub yarn_pnp: bool,
-
     /// Resolve to a context instead of a file.
     ///
     /// Default `false`
@@ -172,6 +169,14 @@ pub struct ResolveOptions {
     ///
     /// Default: `false`
     pub allow_package_exports_in_directory_resolve: bool,
+
+    /// Enable Yarn Plug'n'Play?.
+    ///
+    /// Pass in `!!process.versions.pnp` if called from node.js.
+    ///
+    /// Default: when env var `OXC_RESOLVER_YARN_PNP` is set.
+    #[cfg(feature = "yarn_pnp")]
+    pub yarn_pnp: bool,
 }
 
 impl ResolveOptions {
@@ -470,6 +475,7 @@ pub enum TsconfigReferences {
 impl Default for ResolveOptions {
     fn default() -> Self {
         Self {
+            cwd: None,
             tsconfig: None,
             alias: vec![],
             alias_fields: vec![],
@@ -484,8 +490,6 @@ impl Default for ResolveOptions {
             main_fields: vec!["main".into()],
             main_files: vec!["index".into()],
             modules: vec!["node_modules".into()],
-            #[cfg(feature = "yarn_pnp")]
-            yarn_pnp: true,
             resolve_to_context: false,
             prefer_relative: false,
             prefer_absolute: false,
@@ -495,6 +499,8 @@ impl Default for ResolveOptions {
             builtin_modules: false,
             module_type: false,
             allow_package_exports_in_directory_resolve: false,
+            #[cfg(feature = "yarn_pnp")]
+            yarn_pnp: env::var("OXC_RESOLVER_YARN_PNP").is_ok(),
         }
     }
 }
@@ -630,6 +636,7 @@ mod test {
         assert_eq!(format!("{options}"), expected);
 
         let options = ResolveOptions {
+            cwd: None,
             alias: vec![],
             alias_fields: vec![],
             builtin_modules: false,
@@ -645,7 +652,7 @@ mod test {
             main_files: vec![],
             modules: vec![],
             #[cfg(feature = "yarn_pnp")]
-            yarn_pnp: true,
+            yarn_pnp: false,
             prefer_absolute: false,
             prefer_relative: false,
             resolve_to_context: false,

--- a/src/tests/pnp.rs
+++ b/src/tests/pnp.rs
@@ -11,6 +11,8 @@ fn pnp_basic() {
     let fixture = super::fixture_root().join("pnp");
 
     let resolver = Resolver::new(ResolveOptions {
+        cwd: Some(fixture.clone()),
+        yarn_pnp: true,
         extensions: vec![".js".into()],
         condition_names: vec!["import".into()],
         ..ResolveOptions::default()
@@ -76,6 +78,8 @@ fn resolve_in_pnp_linked_folder() {
     let fixture = super::fixture_root().join("pnp");
 
     let resolver = Resolver::new(ResolveOptions {
+        cwd: Some(fixture.clone()),
+        yarn_pnp: true,
         extensions: vec![".js".into()],
         condition_names: vec!["import".into()],
         ..ResolveOptions::default()
@@ -91,7 +95,7 @@ fn resolve_in_pnp_linked_folder() {
 fn resolve_pnp_pkg_should_failed_while_disable_pnp_mode() {
     let fixture = super::fixture_root().join("pnp");
 
-    let resolver = Resolver::new(ResolveOptions { yarn_pnp: false, ..ResolveOptions::default() });
+    let resolver = Resolver::default();
 
     assert_eq!(
         resolver.resolve(&fixture, "is-even").map(|r| r.full_path()),
@@ -103,7 +107,11 @@ fn resolve_pnp_pkg_should_failed_while_disable_pnp_mode() {
 fn resolve_package_deep_link() {
     let fixture = super::fixture_root().join("pnp");
 
-    let resolver = Resolver::new(ResolveOptions::default());
+    let resolver = Resolver::new(ResolveOptions {
+        cwd: Some(fixture.clone()),
+        yarn_pnp: true,
+        ..ResolveOptions::default()
+    });
 
     assert_eq!(
         resolver.resolve(fixture.join("shared"), "beachball/lib/commands/bump.js").map(|r| r.full_path()),
@@ -117,11 +125,11 @@ fn resolve_package_deep_link() {
 fn resolve_pnp_nested_package_json() {
     let fixture = super::fixture_root().join("pnp");
 
-    let resolver = Resolver::new({
-        ResolveOptions {
-            main_fields: vec!["module".into(), "main".into()],
-            ..ResolveOptions::default()
-        }
+    let resolver = Resolver::new(ResolveOptions {
+        cwd: Some(fixture.clone()),
+        yarn_pnp: true,
+        main_fields: vec!["module".into(), "main".into()],
+        ..ResolveOptions::default()
     });
 
     assert_eq!(
@@ -136,7 +144,11 @@ fn resolve_pnp_nested_package_json() {
 fn resolve_npm_protocol_alias() {
     let fixture = super::fixture_root().join("pnp");
 
-    let resolver = Resolver::default();
+    let resolver = Resolver::new(ResolveOptions {
+        cwd: Some(fixture.clone()),
+        yarn_pnp: true,
+        ..ResolveOptions::default()
+    });
 
     assert_eq!(
         resolver.resolve(&fixture, "custom-minimist").map(|r| r.full_path()),
@@ -172,8 +184,10 @@ fn resolve_global_cache() {
     #[cfg(not(windows))]
     let global_cache = home_dir.join(".yarn/berry/cache");
 
+    let fixture = super::fixture_root().join("global-pnp");
     let resolver = Resolver::new(ResolveOptions {
-        roots: vec![super::fixture_root().join("global-pnp")],
+        cwd: Some(fixture),
+        yarn_pnp: true,
         ..ResolveOptions::default()
     });
 


### PR DESCRIPTION
The current manifest file (`.pnp.cjs`) lookup technique does not work when `enableGlobalCache` is set to `true`, which is the default behavior for yarn.

Instead, we try and find the closest pnp maniest from cwd.

This will break the multi-project case mentioned in https://yarnpkg.com/advanced/pnp-spec#find_pnp_manifest, but I think this is an acceptable trade off.

For napi, I set `process.env.OXC_RESOLVER_YARN_PNP` in `napi/index.js` so the Rust side can enable yarn pnp accordingly.