### PR TITLE
feat: add `yarn_pnp` logic to `FileSystem`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: ./.github/actions/pnpm
       - run: cargo check --all-features --locked
       - run: cargo test --doc
+      - run: cargo test # without features
       - run: cargo test --all-features
       - run: pnpm run build:debug && pnpm run test
         if: ${{ matrix.os  != 'windows-latest' }}

--- a/justfile
+++ b/justfile
@@ -54,6 +54,7 @@ check:
 
 # Run all the tests
 test:
+  cargo test
   cargo test --all-features
   node --run build
   node --run test

--- a/src/tests/memory_fs.rs
+++ b/src/tests/memory_fs.rs
@@ -42,6 +42,16 @@ impl MemoryFS {
 }
 
 impl FileSystem for MemoryFS {
+    #[cfg(not(feature = "yarn_pnp"))]
+    fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(feature = "yarn_pnp")]
+    fn new(_yarn_pnp: bool) -> Self {
+        Self::default()
+    }
+
     fn read_to_string(&self, path: &Path) -> io::Result<String> {
         use vfs::FileSystem;
         let mut file = self


### PR DESCRIPTION
Running fs operations through yarn pnp incurs significant performance cost, caused by running `VPath::from(path)` on every path.

Feature gate this through a runtime flag,
because a bundler can enable `yarn_pnp` feature but run the resolver without presence of `yarn`.