### PR TITLE
Expose the `ExtendsField` enum of TsConfig

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,9 @@ pub use crate::{
     },
     path::PathUtil,
     resolution::{ModuleType, Resolution},
-    tsconfig::{CompilerOptions, CompilerOptionsPathsMap, ProjectReference, TsConfig},
+    tsconfig::{
+        CompilerOptions, CompilerOptionsPathsMap, ExtendsField, ProjectReference, TsConfig,
+    },
 };
 use crate::{
     context::ResolveContext as Ctx, path::SLASH_START, specifier::Specifier,


### PR DESCRIPTION
Enables matching on the extends field of the tsconfig struct.

See https://github.com/oxc-project/oxc-resolver/issues/606