### PR TITLE
fix: allow resolving `package?query#fragment` for packages with exports field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1609,17 +1609,6 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         // 2. If subpath is equal to ".", then
         // Note: subpath is not prepended with a dot when passed in.
         if subpath == "." {
-            // enhanced-resolve appends query and fragment when resolving exports field
-            // https://github.com/webpack/enhanced-resolve/blob/a998c7d218b7a9ec2461fc4fddd1ad5dd7687485/lib/ExportsFieldPlugin.js#L57-L62
-            // This is only need when querying the main export, otherwise ctx is passed through.
-            if ctx.query.is_some() || ctx.fragment.is_some() {
-                let query = ctx.query.clone().unwrap_or_default();
-                let fragment = ctx.fragment.clone().unwrap_or_default();
-                return Err(ResolveError::PackagePathNotExported(
-                    format!("./{}{query}{fragment}", subpath.trim_start_matches('.')),
-                    package_url.path().join("package.json"),
-                ));
-            }
             // 1. Let mainExport be undefined.
             let main_export = match exports.kind() {
                 // 2. If exports is a String or Array, or an Object containing no keys starting with ".", then

--- a/src/tests/exports_field.rs
+++ b/src/tests/exports_field.rs
@@ -38,6 +38,8 @@ fn test_simple() {
         // only test query and fragment.
         ("resolver should respect query parameters #1", f2.clone(), "exports-field/dist/main.js?foo", f2.join("node_modules/exports-field/lib/lib2/main.js?foo")),
         ("resolver should respect fragment parameters #1", f2.clone(), "exports-field/dist/main.js#foo", f2.join("node_modules/exports-field/lib/lib2/main.js#foo")),
+        ("resolver should respect query parameters #2. Direct matching", f2.clone(), "exports-field?foo", f2.join("node_modules/exports-field/index.js?foo")),
+        ("resolver should respect fragment parameters #2. Direct matching", f2.clone(), "exports-field#foo", f2.join("node_modules/exports-field/index.js#foo")),
         ("relative path should work, if relative path as request is used", f.clone(), "./node_modules/exports-field/lib/main.js", f.join("node_modules/exports-field/lib/main.js")),
         ("self-resolving root", f.clone(), "@exports-field/core", f.join("a.js")),
         ("should resolve with wildcard pattern #1", f5.clone(), "m/features/f.js", f5.join("node_modules/m/src/features/f.js")),
@@ -60,15 +62,12 @@ fn test_simple() {
     }
 
     let p = f.join("node_modules/exports-field/package.json");
-    let p2 = f2.join("node_modules/exports-field/package.json");
     let p4 = f4.join("node_modules/exports-field/package.json");
     let p5 = f5.join("node_modules/m/package.json");
 
     #[rustfmt::skip]
     let fail = [
         // ("throw error if extension not provided", f2.clone(), "exports-field/dist/main", ResolveError::NotFound(f2.join("node_modules/exports-field/lib/lib2/main"))),
-        ("resolver should respect query parameters #2. Direct matching", f2.clone(), "exports-field?foo", ResolveError::PackagePathNotExported("./?foo".into(), p2.clone())),
-        ("resolver should respect fragment parameters #2. Direct matching", f2, "exports-field#foo", ResolveError::PackagePathNotExported("./#foo".into(), p2)),
         ("relative path should not work with exports field", f.clone(), "./node_modules/exports-field/dist/main.js", ResolveError::NotFound("./node_modules/exports-field/dist/main.js".into())),
         ("backtracking should not work for request", f.clone(), "exports-field/dist/../../../a.js", ResolveError::InvalidPackageTarget("./lib/../../../a.js".to_string(), "./dist/".to_string(), p.clone())),
         ("backtracking should not work for exports field target", f.clone(), "exports-field/dist/a.js", ResolveError::InvalidPackageTarget("./../../a.js".to_string(), "./dist/a.js".to_string(), p.clone())),


### PR DESCRIPTION
Resolving `package?query#fragment` to packages with exports field is allowed in Vite to allow things like `css-package?url`, `wasm-package?init`. This was not allowed by oxc-resolver and this PR allows that.

The current behavior of oxc-resolver comes from this change in enhanced-resolve (https://github.com/webpack/enhanced-resolve/pull/225). This PR adds tests that disallows `pkg?foo` but allows `pkg/nested?foo`.
This current behavior doesn't make sense to me. Both `pkg?foo` and `pkg/nested?foo` are not allowed by Node and I don't find a reason to treat them differently.

fixes https://github.com/vitejs/rolldown-vite/issues/382
refs https://github.com/oxc-project/oxc-resolver/commit/97dfb1a3f81569b32c2477470ff6cc685ebb2a9d
