### PR TITLE
fix(tsconfig): respect Yarn PnP when resolving `extends` paths

### DIFF
--- a/fixtures/pnp/shared/tsconfig.base.json
+++ b/fixtures/pnp/shared/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "esnext"
+  }
+}

--- a/fixtures/pnp/tsconfig.json
+++ b/fixtures/pnp/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "lib/tsconfig.base.json"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1502,6 +1502,10 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 .clone_with_options(ResolveOptions {
                     extensions: vec![".json".into()],
                     main_files: vec!["tsconfig.json".into()],
+                    #[cfg(feature = "yarn_pnp")]
+                    yarn_pnp: self.options.yarn_pnp,
+                    #[cfg(feature = "yarn_pnp")]
+                    cwd: self.options.cwd.clone(),
                     ..ResolveOptions::default()
                 })
                 .load_package_self_or_node_modules(directory, specifier, &mut Ctx::default())

--- a/src/tests/pnp.rs
+++ b/src/tests/pnp.rs
@@ -209,3 +209,17 @@ fn resolve_global_cache() {
             .join("source-map.js")),
     );
 }
+
+#[test]
+fn test_resolve_tsconfig_extends_with_pnp() {
+    let fixture = super::fixture_root().join("pnp");
+    let resolver = Resolver::new(ResolveOptions {
+        cwd: Some(fixture.clone()),
+        yarn_pnp: true,
+        ..ResolveOptions::default()
+    });
+
+    let resolution = resolver.resolve_tsconfig(&fixture).expect("resolved");
+    let compiler_options = resolution.compiler_options();
+    assert_eq!(compiler_options.target, Some("esnext".to_string()));
+}


### PR DESCRIPTION
closes https://github.com/vitejs/rolldown-vite/issues/381