### PR TITLE
feat(tsconfig) support `allowJs` in `compilerOptions`

### DIFF
--- a/fixtures/tsconfig/cases/extends-compiler-options/base-tsconfig.json
+++ b/fixtures/tsconfig/cases/extends-compiler-options/base-tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "./src",
+    "allowJs": true,
     "emitDecoratorMetadata": true,
     "useDefineForClassFields": true,
     "rewriteRelativeImportExtensions": true

--- a/src/tests/tsconfig_extends.rs
+++ b/src/tests/tsconfig_extends.rs
@@ -24,6 +24,7 @@ fn test_extend_tsconfig_compiler_options() {
 
     // Should inherit compilerOptions from parent
     assert_eq!(compiler_options.base_url, Some(f.join("src")));
+    assert_eq!(compiler_options.allow_js, Some(true));
     assert_eq!(compiler_options.emit_decorator_metadata, Some(true));
     assert_eq!(compiler_options.use_define_for_class_fields, Some(true));
     assert_eq!(compiler_options.rewrite_relative_import_extensions, Some(true));

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -257,6 +257,12 @@ impl TsConfig {
                 compiler_options.set_module(module.to_string());
             }
         }
+
+        if compiler_options.allow_js().is_none() {
+            if let Some(allow_js) = tsconfig.compiler_options().allow_js() {
+                compiler_options.set_allow_js(*allow_js);
+            }
+        }
     }
     /// "Build" the root tsconfig, resolve:
     ///
@@ -449,6 +455,9 @@ pub struct CompilerOptions {
 
     /// <https://www.typescriptlang.org/tsconfig/#module>
     pub module: Option<String>,
+
+    /// <https://www.typescriptlang.org/tsconfig/#allowJs>
+    pub allow_js: Option<bool>,
 }
 
 impl CompilerOptions {
@@ -619,6 +628,16 @@ impl CompilerOptions {
     /// Sets the module.
     fn set_module(&mut self, module: String) {
         self.module = Some(module);
+    }
+
+    /// Whether to allow js.
+    fn allow_js(&self) -> Option<&bool> {
+        self.allow_js.as_ref()
+    }
+
+    /// Sets whether to allow js.
+    fn set_allow_js(&mut self, allow_js: bool) {
+        self.allow_js = Some(allow_js);
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/rolldown/rolldown/issues/5867

The extension checks for `include` and `exclude` paths need to take `allowJs` into account.