### PR TITLE
perf: use `GetFileAttributesExW` for symlink metadata lookup on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "tracing",
  "url",
  "vfs",
+ "windows",
  "windows-sys 0.61.0",
 ]
 
@@ -1341,6 +1342,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9579d0e6970fd5250aa29aba5994052385ff55cf7b28a059e484bb79ea842e42"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link 0.2.0",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90dd7a7b86859ec4cdf864658b311545ef19dbcf17a672b52ab7cefe80c336f"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2194dee901458cb79e1148a4e9aac2b164cc95fa431891e7b296ff0b2f1d8a6"
+dependencies = [
+ "windows-core",
+ "windows-link 0.2.0",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1420,34 @@ name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce3498fe0aba81e62e477408383196b4b0363db5e0c27646f932676283b43d8"
+dependencies = [
+ "windows-core",
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1419,6 +1516,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab47f085ad6932defa48855254c758cdd0e2f2d48e62a34118a268d8f345e118"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,9 @@ pnp = { version = "0.12.2", optional = true }
 
 document-features = { version = "0.2.11", optional = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.62.0", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 criterion2 = { version = "3.0.2", default-features = false }
 dirs = { version = "6.0.0" }

--- a/deny.toml
+++ b/deny.toml
@@ -95,6 +95,7 @@ allow = [
   "Apache-2.0",
   "Unicode-3.0",
   "BSD-2-Clause",
+  "MPL-2.0",
   # "Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.

--- a/src/windows/metadata.rs
+++ b/src/windows/metadata.rs
@@ -1,0 +1,209 @@
+use std::{ffi::OsStr, io, path::Path};
+
+// Some functions are copied and adapted from Rust standard library.
+// License: https://github.com/rust-lang/rust/blob/1.89.0/LICENSE-MIT, https://github.com/rust-lang/rust/blob/1.89.0/LICENSE-APACHE
+
+pub struct SymlinkMetadata {
+    pub is_symlink: bool,
+    pub is_dir: bool,
+    pub is_file: bool,
+}
+
+/// Optimized version of [std::fs::symlink_metadata] for Windows.
+///
+/// [std::fs::symlink_metadata] implementation uses `GetFileInformationByHandle` on Windows, which is known to be slow [^1].
+/// This function uses `GetFileAttributesExW` instead which is faster.
+///
+/// [^1]: https://github.com/gradle/native-platform/issues/203, https://github.com/dotnet/msbuild/issues/2052.
+pub fn symlink_metadata(path: &Path) -> io::Result<SymlinkMetadata> {
+    use windows::{
+        Win32::Storage::FileSystem::{
+            FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAGS_AND_ATTRIBUTES,
+            GetFileAttributesExW, GetFileExInfoStandard,
+        },
+        core::HSTRING,
+    };
+
+    let verbatim_path = maybe_verbatim(path)?;
+    let lpfilename = HSTRING::from_wide(&verbatim_path);
+    let finfolevelid = GetFileExInfoStandard;
+    let mut file_info = std::mem::MaybeUninit::<
+        windows::Win32::Storage::FileSystem::WIN32_FILE_ATTRIBUTE_DATA,
+    >::uninit();
+
+    // SAFETY: `lpfileinformation` is a valid pointer to a `WIN32_FILE_ATTRIBUTE_DATA` struct.
+    unsafe { GetFileAttributesExW(&lpfilename, finfolevelid, (&raw mut file_info).cast()) }?;
+    // SAFETY: `file_info` has been initialized by `GetFileAttributesExW`.
+    let file_info = unsafe { file_info.assume_init() };
+
+    let file_attrs = FILE_FLAGS_AND_ATTRIBUTES(file_info.dwFileAttributes);
+    let is_directory = file_attrs.contains(FILE_ATTRIBUTE_DIRECTORY);
+    // NOTE: this does not handle `is_reparse_tag_name_surrogate` which is handled by std lib
+    // https://github.com/rust-lang/rust/blob/1.89.0/library/std/src/sys/fs/windows.rs#L1122-L1124
+    let is_symlink = file_attrs.contains(FILE_ATTRIBUTE_REPARSE_POINT);
+    Ok(SymlinkMetadata {
+        is_dir: !is_symlink && is_directory,
+        is_file: !is_symlink && !is_directory,
+        is_symlink,
+    })
+}
+
+/// Returns a UTF-16 encoded path capable of bypassing the legacy `MAX_PATH` limits.
+///
+/// This path may or may not have a verbatim prefix.
+///
+/// Based on <https://github.com/rust-lang/rust/blob/1.89.0/library/std/src/sys/path/windows.rs#L82-L88>
+fn maybe_verbatim(path: &Path) -> io::Result<Vec<u16>> {
+    let path = to_u16s(path)?;
+    get_long_path(path)
+}
+
+/// Gets a normalized absolute path that can bypass path length limits.
+///
+/// Based on <https://github.com/rust-lang/rust/blob/1.89.0/library/std/src/sys/path/windows.rs#L90-L186> and <https://github.com/microsoft/sudo/blob/9f50d79704a9d4d468bc59f725993714762981ca/sudo/src/helpers.rs#L514>
+///
+/// License of sudo: <https://github.com/microsoft/sudo/blob/9f50d79704a9d4d468bc59f725993714762981ca/LICENSE>
+fn get_long_path(mut path: Vec<u16>) -> io::Result<Vec<u16>> {
+    use windows::Win32::Storage::FileSystem::GetFullPathNameW;
+    use windows::core::HSTRING;
+
+    // Normally the MAX_PATH is 260 UTF-16 code units (including the NULL).
+    // However, for APIs such as CreateDirectory[1], the limit is 248.
+    //
+    // [1]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createdirectorya#parameters
+    const LEGACY_MAX_PATH: usize = 248;
+    // UTF-16 encoded code points, used in parsing and building UTF-16 paths.
+    // All of these are in the ASCII range so they can be cast directly to `u16`.
+    const SEP: u16 = b'\\' as _;
+    const ALT_SEP: u16 = b'/' as _;
+    const QUERY: u16 = b'?' as _;
+    const COLON: u16 = b':' as _;
+    const DOT: u16 = b'.' as _;
+    const U: u16 = b'U' as _;
+    const N: u16 = b'N' as _;
+    const C: u16 = b'C' as _;
+
+    // \\?\
+    const VERBATIM_PREFIX: &[u16] = &[SEP, SEP, QUERY, SEP];
+    // \??\
+    const NT_PREFIX: &[u16] = &[SEP, QUERY, QUERY, SEP];
+    // \\?\UNC\
+    const UNC_PREFIX: &[u16] = &[SEP, SEP, QUERY, SEP, U, N, C, SEP];
+
+    if path.starts_with(VERBATIM_PREFIX) || path.starts_with(NT_PREFIX) || path == [0] {
+        // Early return for paths that are already verbatim or empty.
+        return Ok(path);
+    } else if path.len() < LEGACY_MAX_PATH {
+        // Early return if an absolute path is less < 260 UTF-16 code units.
+        // This is an optimization to avoid calling `GetFullPathNameW` unnecessarily.
+        match path.as_slice() {
+            // Starts with `D:`, `D:\`, `D:/`, etc.
+            // Does not match if the path starts with a `\` or `/`.
+            [drive, COLON, 0] | [drive, COLON, SEP | ALT_SEP, ..]
+                if *drive != SEP && *drive != ALT_SEP =>
+            {
+                return Ok(path);
+            }
+            // Starts with `\\`, `//`, etc
+            [SEP | ALT_SEP, SEP | ALT_SEP, ..] => return Ok(path),
+            _ => {}
+        }
+    }
+
+    let lpfilename = HSTRING::from_wide(&path);
+    let mut buffer = vec![0u16; LEGACY_MAX_PATH * 2];
+    loop {
+        // SAFETY: ???
+        let res = unsafe { GetFullPathNameW(&lpfilename, Some(buffer.as_mut_slice()), None) };
+        // GetFullPathNameW will return the required buffer size if the buffer is too small.
+        match res as usize {
+            0 => return Err(io::Error::last_os_error()),
+            len if len <= buffer.len() => {
+                let mut buffer = &buffer[..len];
+
+                // Secondly, add the verbatim prefix. This is easier here because we know the
+                // path is now absolute and fully normalized (e.g. `/` has been changed to `\`).
+                let prefix = match buffer {
+                    // C:\ => \\?\C:\
+                    [_, COLON, SEP, ..] => VERBATIM_PREFIX,
+                    // \\.\ => \\?\
+                    [SEP, SEP, DOT, SEP, ..] => {
+                        buffer = &buffer[4..];
+                        VERBATIM_PREFIX
+                    }
+                    // Leave \\?\ and \??\ as-is.
+                    [SEP, SEP | QUERY, QUERY, SEP, ..] => &[],
+                    // \\ => \\?\UNC\
+                    [SEP, SEP, ..] => {
+                        buffer = &buffer[2..];
+                        UNC_PREFIX
+                    }
+                    // Anything else we leave alone.
+                    _ => &[],
+                };
+
+                path.clear();
+                path.reserve_exact(prefix.len() + buffer.len() + 1);
+                path.extend_from_slice(prefix);
+                path.extend_from_slice(buffer);
+                path.push(0);
+                return Ok(path);
+            }
+            new_len => buffer.resize(new_len, 0),
+        }
+    }
+}
+
+/// Copied from <https://github.com/rust-lang/rust/blob/1.89.0/library/std/src/sys/pal/windows/mod.rs#L169-L188>
+fn to_u16s<S: AsRef<OsStr>>(s: S) -> io::Result<Vec<u16>> {
+    fn inner(s: &OsStr) -> io::Result<Vec<u16>> {
+        // Most paths are ASCII, so reserve capacity for as much as there are bytes
+        // in the OsStr plus one for the null-terminating character. We are not
+        // wasting bytes here as paths created by this function are primarily used
+        // in an ephemeral fashion.
+
+        use std::os::windows::ffi::OsStrExt;
+        let mut maybe_result = Vec::with_capacity(s.len() + 1);
+        maybe_result.extend(s.encode_wide());
+
+        if unrolled_find_u16s(0, &maybe_result).is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "strings passed to WinAPI cannot contain NULs",
+            ));
+        }
+        maybe_result.push(0);
+        Ok(maybe_result)
+    }
+    inner(s.as_ref())
+}
+
+/// Copied from <https://github.com/rust-lang/rust/blob/1.89.0/library/std/src/sys/pal/windows/mod.rs#L140-L167>
+fn unrolled_find_u16s(needle: u16, haystack: &[u16]) -> Option<usize> {
+    let ptr = haystack.as_ptr();
+    let mut start = haystack;
+
+    // For performance reasons unfold the loop eight times.
+    while start.len() >= 8 {
+        macro_rules! if_return {
+            ($($n:literal,)+) => {
+                $(
+                    if start[$n] == needle {
+                        return Some(((&raw const start[$n]).addr() - ptr.addr()) / 2);
+                    }
+                )+
+            }
+        }
+
+        if_return!(0, 1, 2, 3, 4, 5, 6, 7,);
+
+        start = &start[8..];
+    }
+
+    for c in start {
+        if *c == needle {
+            return Some((std::ptr::from_ref::<u16>(c).addr() - ptr.addr()) / 2);
+        }
+    }
+    None
+}

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,5 +1,9 @@
 use std::path::PathBuf;
 
+mod metadata;
+
+pub use metadata::{SymlinkMetadata, symlink_metadata};
+
 use crate::ResolveError;
 
 /// When applicable, converts a [DOS device path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths)


### PR DESCRIPTION
[`std::fs::symlink_metadata`](https://doc.rust-lang.org/beta/std/fs/fn.symlink_metadata.html) implementation uses `GetFileInformationByHandle` on Windows, which seems to be known as slow [^1].

This PR adds a function that uses `GetFileAttributesExW` instead of it, which is faster than `GetFileInformationByHandle`.

## Benchmarks

I tested this PR with [rolldown/benchmarks](https://github.com/rolldown/benchmarks). It improved the build time by ~10%
I took the following results with `hyperfine 'node --run build:rolldown'`

### rome
**Before**
```
Benchmark 1: node --run build:rolldown
  Time (mean ± σ):     237.7 ms ±   3.7 ms    [User: 513.1 ms, System: 495.2 ms]
  Range (min … max):   233.1 ms … 243.5 ms    12 runs
```

**After**
```
Benchmark 1: node --run build:rolldown
  Time (mean ± σ):     210.4 ms ±   5.3 ms    [User: 422.1 ms, System: 443.5 ms]
  Range (min … max):   204.1 ms … 223.1 ms    13 runs
```

**Result**: -27.3ms (-11.5%)

### three10x
**Before**
```
Benchmark 1: node --run build:rolldown
  Time (mean ± σ):     367.7 ms ±   5.1 ms    [User: 1313.1 ms, System: 1283.1 ms]
  Range (min … max):   359.7 ms … 374.5 ms    10 runs
```

**After**
```
Benchmark 1: node --run build:rolldown
  Time (mean ± σ):     334.3 ms ±   7.5 ms    [User: 1094.7 ms, System: 1019.1 ms]
  Range (min … max):   324.1 ms … 346.6 ms    10 runs
```

**Result**: -33.4ms (-9.1%)

### apps/10000
**Before**
```
Benchmark 1: node --run build:rolldown
  Time (mean ± σ):      2.459 s ±  0.042 s    [User: 3.858 s, System: 5.627 s]
  Range (min … max):    2.401 s …  2.509 s    10 runs
```

**After**
```
Benchmark 1: node --run build:rolldown
  Time (mean ± σ):      1.744 s ±  0.017 s    [User: 3.300 s, System: 3.796 s]
  Range (min … max):    1.720 s …  1.771 s    10 runs
```

**Result**: -0.72s (-29.1%)


[^1]: https://github.com/gradle/native-platform/issues/203, https://github.com/dotnet/msbuild/issues/2052.
