### PR TITLE
Revert "perf: use `memmap` to speed up file reading"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,15 +646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
-name = "memmap2"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "mimalloc-safe"
 version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,7 +792,6 @@ dependencies = [
  "fancy-regex",
  "indexmap",
  "json-strip-comments",
- "memmap2",
  "normalize-path",
  "once_cell",
  "papaya",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,9 +94,6 @@ pnp = { version = "0.12.2", optional = true }
 
 document-features = { version = "0.2.11", optional = true }
 
-[target.'cfg(not(any(target_family = "wasm", target_os = "wasi")))'.dependencies]
-memmap2 = "0.9"
-
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62.0", features = ["Win32_Storage_FileSystem"] }
 

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -4,8 +4,6 @@ use std::{
 };
 
 use cfg_if::cfg_if;
-#[cfg(not(any(target_family = "wasm", target_os = "wasi")))]
-use memmap2::Mmap;
 #[cfg(feature = "yarn_pnp")]
 use pnp::fs::{LruZipCache, VPath, VPathInfo, ZipCache};
 
@@ -126,17 +124,13 @@ pub struct FileSystemOs {
 }
 
 impl FileSystemOs {
-    /// Memory-mapped file reading threshold in bytes
-    #[cfg(not(any(target_family = "wasm", target_os = "wasi")))]
-    const MMAP_THRESHOLD: u64 = 4096;
-
-    /// Validates UTF-8 encoding and converts bytes to String
-    ///
     /// # Errors
     ///
-    /// Returns an error if the bytes are not valid UTF-8
-    fn validate_and_convert_utf8(bytes: &[u8]) -> io::Result<String> {
-        if simdutf8::basic::from_utf8(bytes).is_err() {
+    /// See [std::fs::read_to_string]
+    pub fn read_to_string(path: &Path) -> io::Result<String> {
+        // `simdutf8` is faster than `std::str::from_utf8` which `fs::read_to_string` uses internally
+        let bytes = std::fs::read(path)?;
+        if simdutf8::basic::from_utf8(&bytes).is_err() {
             // Same error as `fs::read_to_string` produces (`io::Error::INVALID_UTF8`)
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -144,49 +138,7 @@ impl FileSystemOs {
             ));
         }
         // SAFETY: `simdutf8` has ensured it's a valid UTF-8 string
-        Ok(unsafe { std::str::from_utf8_unchecked(bytes) }.to_string())
-    }
-
-    /// # Errors
-    ///
-    /// See [std::fs::read_to_string]
-    pub fn read_to_string(path: &Path) -> io::Result<String> {
-        #[cfg(not(any(target_family = "wasm", target_os = "wasi")))]
-        {
-            let file = std::fs::File::open(path)?;
-            let metadata = file.metadata()?;
-
-            // Use memory mapping for files >= 4KB, standard read for smaller files
-            if metadata.len() >= Self::MMAP_THRESHOLD {
-                return Self::read_to_string_mmap(&file);
-            }
-        }
-        Self::read_to_string_standard(path)
-    }
-
-    /// Standard file reading implementation using std::fs::read
-    ///
-    /// # Errors
-    ///
-    /// See [std::fs::read_to_string]
-    pub fn read_to_string_standard(path: &Path) -> io::Result<String> {
-        // `simdutf8` is faster than `std::str::from_utf8` which `fs::read_to_string` uses internally
-        let bytes = std::fs::read(path)?;
-        Self::validate_and_convert_utf8(&bytes)
-    }
-
-    /// Memory-mapped file reading implementation
-    ///
-    /// # Errors
-    ///
-    /// See [std::fs::read_to_string] and [memmap2::Mmap::map]
-    #[cfg(not(any(target_family = "wasm", target_os = "wasi")))]
-    fn read_to_string_mmap(file: &std::fs::File) -> io::Result<String> {
-        // SAFETY: memmap2::Mmap::map requires that the file remains valid and unmutated
-        // for the lifetime of the mmap. Since we're doing read-only access and the file
-        // won't be modified during this function's execution, this is safe.
-        let mmap = unsafe { Mmap::map(file)? };
-        Self::validate_and_convert_utf8(&mmap[..])
+        Ok(unsafe { String::from_utf8_unchecked(bytes) })
     }
 
     /// # Errors


### PR DESCRIPTION
Reverts oxc-project/oxc-resolver#696

Performance regression shown in 

* https://github.com/rolldown/rolldown/pull/6224