### PR TITLE
perf: mark error path functions as #[cold] for better optimization

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -125,6 +125,7 @@ impl ResolveError {
         matches!(self, Self::Ignored(_))
     }
 
+    #[cold]
     #[must_use]
     pub fn from_serde_json_error(path: PathBuf, error: &serde_json::Error) -> Self {
         Self::Json(JSONError {
@@ -163,6 +164,7 @@ impl PartialEq for IOError {
 }
 
 impl From<IOError> for io::Error {
+    #[cold]
     fn from(error: IOError) -> Self {
         let io_error = error.0.as_ref();
         Self::new(io_error.kind(), io_error.to_string())
@@ -170,6 +172,7 @@ impl From<IOError> for io::Error {
 }
 
 impl From<io::Error> for ResolveError {
+    #[cold]
     fn from(err: io::Error) -> Self {
         Self::IOError(IOError(Arc::new(err)))
     }
@@ -191,6 +194,7 @@ impl Display for CircularPathBufs {
 }
 
 impl From<Vec<PathBuf>> for CircularPathBufs {
+    #[cold]
     fn from(value: Vec<PathBuf>) -> Self {
         Self(value)
     }

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -144,10 +144,14 @@ impl FileSystemOs {
         // `simdutf8` is faster than `std::str::from_utf8` which `fs::read_to_string` uses internally
         if simdutf8::basic::from_utf8(&bytes).is_err() {
             // Same error as `fs::read_to_string` produces (`io::Error::INVALID_UTF8`)
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "stream did not contain valid UTF-8",
-            ));
+            #[cold]
+            fn invalid_utf8_error() -> io::Error {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "stream did not contain valid UTF-8",
+                )
+            }
+            return Err(invalid_utf8_error());
         }
         // SAFETY: `simdutf8` has ensured it's a valid UTF-8 string
         Ok(unsafe { String::from_utf8_unchecked(bytes) })

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -16,7 +16,11 @@ impl<'a> Specifier<'a> {
 
     pub fn parse(specifier: &'a str) -> Result<Self, SpecifierError> {
         if specifier.is_empty() {
-            return Err(SpecifierError::Empty(specifier.to_string()));
+            #[cold]
+            fn empty_specifier_error(specifier: &str) -> SpecifierError {
+                SpecifierError::Empty(specifier.to_string())
+            }
+            return Err(empty_specifier_error(specifier));
         }
         let offset = match specifier.as_bytes()[0] {
             b'/' | b'.' | b'#' => 1,
@@ -24,7 +28,11 @@ impl<'a> Specifier<'a> {
         };
         let (path, query, fragment) = Self::parse_query_fragment(specifier, offset);
         if path.is_empty() {
-            return Err(SpecifierError::Empty(specifier.to_string()));
+            #[cold]
+            fn empty_path_error(specifier: &str) -> SpecifierError {
+                SpecifierError::Empty(specifier.to_string())
+            }
+            return Err(empty_path_error(specifier));
         }
         Ok(Self { path, query, fragment })
     }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -33,7 +33,11 @@ pub fn strip_windows_prefix(path: PathBuf) -> Result<PathBuf, ResolveError> {
             // \\?\BootPartition\
             // It seems nodejs does not support DOS device paths with Volume GUIDs.
             // This can happen if the path points to a Mounted Volume without a drive letter.
-            return Err(ResolveError::PathNotSupported(path));
+            #[cold]
+            fn unsupported_path_error(path: PathBuf) -> ResolveError {
+                ResolveError::PathNotSupported(path)
+            }
+            return Err(unsupported_path_error(path));
         }
         // SAFETY: `as_encoded_bytes` ensures `p` is valid path bytes
         unsafe { PathBuf::from(std::ffi::OsStr::from_encoded_bytes_unchecked(p)) }


### PR DESCRIPTION
## Summary

This PR adds `#[cold]` attributes to error handling functions to improve performance by helping the compiler optimize for the common (non-error) path.

## Changes

- Added `#[cold]` attributes to error conversion functions in `src/error.rs`
- Extracted error creation into separate cold functions in:
  - `src/file_system.rs` - UTF-8 validation error
  - `src/specifier.rs` - Empty specifier errors
  - `src/windows/mod.rs` - Unsupported path error

## Benefits

The `#[cold]` attribute provides hints to the compiler that these functions are unlikely to be called, which enables:
- Better code layout for CPU instruction cache efficiency
- Reduced inline pressure in hot paths
- Improved branch prediction
- Overall better optimization of the happy path

## Test Plan

- [x] All existing tests pass
- [x] `cargo check` passes
- [x] `cargo clippy` shows no warnings

🤖 Generated with [Claude Code](https://claude.ai/code)