### PR TITLE
fix: ensure canonicalized paths remain accessible via strong references

### DIFF
--- a/src/tests/memory_leak.rs
+++ b/src/tests/memory_leak.rs
@@ -22,3 +22,62 @@ fn test_memory_leak_arc_cycles() {
     // All Arcs must be dropped, leaving the original count of 1.
     assert_eq!(Arc::strong_count(&path.0), 1);
 }
+
+/// Test to ensure canonicalized paths remain accessible after being stored
+#[test]
+fn test_canonicalized_path_not_dropped() {
+    use crate::ResolveOptions;
+
+    let f = super::fixture_root().join("misc");
+
+    let resolver = Resolver::new(ResolveOptions { symlinks: true, ..Default::default() });
+
+    // Create a path and canonicalize it
+    let path = resolver.cache.value(&f);
+
+    // This should work without "Canonicalized path was dropped" error
+    let canonicalized = resolver.cache.canonicalize(&path);
+    assert!(canonicalized.is_ok());
+
+    // Try canonicalizing again - should still work
+    let canonicalized2 = resolver.cache.canonicalize(&path);
+    assert!(canonicalized2.is_ok());
+    assert_eq!(canonicalized.unwrap(), canonicalized2.unwrap());
+}
+
+/// Test to ensure canonicalized paths that are not in cache remain accessible
+#[test]
+fn test_canonicalized_path_weak_reference() {
+    let f = super::fixture_root().join("misc");
+
+    let resolver = Resolver::default();
+
+    // Create a new path that's not previously in the cache
+    let new_path = f.join("some_unique_path");
+
+    // Get the cached path - this will be the only strong reference
+    let path = resolver.cache.value(&new_path);
+
+    // Canonicalize a path that doesn't exist in the cache's hashmap yet
+    // This might fail with "Canonicalized path was dropped" if the implementation is wrong
+    match resolver.cache.canonicalize(&path) {
+        Ok(_) => {
+            // If canonicalization succeeded, try again to ensure consistency
+            let result2 = resolver.cache.canonicalize(&path);
+            assert_eq!(
+                resolver.cache.canonicalize(&path).ok(),
+                result2.ok(),
+                "Canonicalization results should be consistent"
+            );
+        }
+        Err(e) => {
+            // It's okay if canonicalization fails for other reasons (e.g., path doesn't exist)
+            // but it should NOT fail with "Canonicalized path was dropped"
+            let error_msg = e.to_string();
+            assert!(
+                !error_msg.contains("Canonicalized path was dropped"),
+                "Should not fail with 'Canonicalized path was dropped' error, got: {error_msg}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #732 - "Canonicalized path was dropped" error that could occur in CI environments
- Ensures canonicalized paths have at least one strong reference in the cache to prevent premature dropping
- Adds comprehensive tests to prevent regression

## Problem

The resolver was experiencing "Canonicalized path was dropped" errors due to weak references being used without ensuring a strong reference existed. When `canonicalize_impl` stored only weak references to canonicalized paths, if those paths weren't already in the cache, the Arc would be immediately dropped, causing the weak reference to fail on upgrade.

## Solution

Modified `canonicalize_impl` in `src/cache/cache_impl.rs` to ensure canonicalized paths are added to the cache (if not already present) before downgrading to weak references. This maintains at least one strong reference while preserving the weak reference pattern needed to avoid memory leaks from circular references.

## Test Plan

- [x] Added `test_canonicalized_path_not_dropped` to verify canonicalization works correctly
- [x] Added `test_canonicalized_path_weak_reference` to ensure the error doesn't occur
- [x] All existing tests pass, including the memory leak test
- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.ai/code)