### PR TITLE
feat: only resolve file:// protocol on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,13 @@ on:
     types:
       - opened
       - synchronize
-    paths-ignore:
+    paths-ignore: &paths-ignore
       - "**/*.md"
       - "!.github/workflows/ci.yml"
   push:
     branches:
       - main
-    paths-ignore:
-      - "**/*.md"
-      - "!.github/workflows/ci.yml"
+    paths-ignore: *paths-ignore
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,21 +60,37 @@ jobs:
         with:
           files: .
 
-  wasm:
-    name: Check Wasm
+  wasm32-wasip1:
+    name: Check wasm32-wasip1
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
 
       - uses: oxc-project/setup-rust@f78b3964e121f889426634f0eaeeb09fccecac08 # v1.0.6
         with:
-          cache-key: wasm
+          cache-key: wasm32-wasip1
           save-cache: ${{ github.ref_name == 'main' }}
 
       - name: Check
         run: |
           rustup target add wasm32-wasip1
           cargo check --all-features --target wasm32-wasip1
+
+  wasm32-unknown-unknown:
+    name: Check wasm32-unknown-unknown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
+
+      - uses: oxc-project/setup-rust@f78b3964e121f889426634f0eaeeb09fccecac08 # v1.0.6
+        with:
+          cache-key: wasm32-unknown-unknown
+          save-cache: ${{ github.ref_name == 'main' }}
+
+      - name: Check
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo check --all-features --target wasm32-unknown-unknown
 
   wasi:
     name: Test wasi target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,6 @@ serde_json = { version = "1", features = ["preserve_order"] } # preserve_order: 
 simdutf8 = { version = "0.1" }
 thiserror = "2"
 tracing = "0.1"
-url = "2"
 
 pnp = { version = "0.12.2", optional = true }
 
@@ -99,6 +98,7 @@ libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62.0", features = ["Win32_Storage_FileSystem"] }
+url = "2"
 
 [dev-dependencies]
 criterion2 = { version = "3.0.2", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,17 +65,6 @@ mod windows;
 #[cfg(test)]
 mod tests;
 
-use rustc_hash::FxHashSet;
-use std::{
-    borrow::Cow,
-    cmp::Ordering,
-    ffi::OsStr,
-    fmt, iter,
-    path::{Component, Path, PathBuf},
-    sync::Arc,
-};
-use url::Url;
-
 pub use crate::{
     builtins::NODEJS_BUILTINS,
     cache::{Cache, CachedPath},
@@ -98,6 +87,15 @@ pub use crate::{
 use crate::{
     context::ResolveContext as Ctx, path::SLASH_START, specifier::Specifier,
     tsconfig_context::TsconfigResolveContext,
+};
+use rustc_hash::FxHashSet;
+use std::{
+    borrow::Cow,
+    cmp::Ordering,
+    ffi::OsStr,
+    fmt, iter,
+    path::{Component, Path, PathBuf},
+    sync::Arc,
 };
 
 type ResolveResult = Result<Option<CachedPath>, ResolveError>;
@@ -361,24 +359,9 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             return Ok(path);
         }
 
-        #[allow(unused_assignments)]
-        let mut specifier_owned: Option<String> = None;
-        let mut specifier = specifier;
+        let specifier = resolve_file_protocol(specifier);
 
-        if specifier.starts_with("file://") {
-            let unsupported_error = ResolveError::PathNotSupported(specifier.into());
-
-            let path = Url::parse(specifier)
-                .map_err(|_| unsupported_error.clone())?
-                .to_file_path()
-                .map_err(|()| unsupported_error)?;
-
-            let owned = path.to_string_lossy().into_owned();
-            specifier_owned = Some(owned);
-            specifier = specifier_owned.as_deref().unwrap();
-        }
-
-        let result = match Path::new(specifier).components().next() {
+        let result = match Path::new(&specifier).components().next() {
             // 2. If X begins with '/'
             Some(Component::RootDir | Component::Prefix(_)) => {
                 self.require_absolute(cached_path, specifier, ctx)
@@ -2102,4 +2085,22 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             _ => Ok(None),
         }
     }
+}
+
+#[cfg(target_os = "windows")]
+fn resolve_file_protocol(specifier: &str) -> Cow<'_, str> {
+    if specifier.starts_with("file://") {
+        url::Url::parse(&specifier)
+            .map_err(|_| ())
+            .and_then(|p| p.to_file_path())
+            .map(|path| Cow::Owned(path.to_string_lossy().to_string()))
+            .map_err(|_| ResolveError::PathNotSupported(PathBuf::from(specifier.as_ref())))?;
+    } else {
+        Cow::Borrowed(specifier)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn resolve_file_protocol(specifier: &str) -> &str {
+    specifier
 }


### PR DESCRIPTION
fixes #716

In https://github.com/unrs/unrs-resolver/issues/127, the original issue statement was "file: protocol is required to be used on Windows for import statement."

There are no integrations for such cases and only 1 unit test, so limit it to windows.