### PR TITLE
chore: release v11.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.9.0](https://github.com/oxc-project/oxc-resolver/compare/v11.8.4...v11.9.0) - 2025-10-01
+
+### <!-- 0 -->🚀 Features
+
+- only resolve file:// protocol on windows ([#737](https://github.com/oxc-project/oxc-resolver/pull/737)) (by @Boshen) - #737
+
+### <!-- 6 -->🧪 Testing
+
+- improve test coverage for edge cases ([#740](https://github.com/oxc-project/oxc-resolver/pull/740)) (by @Boshen) - #740
+- improve coverage for check_restrictions ([#739](https://github.com/oxc-project/oxc-resolver/pull/739)) (by @Boshen) - #739
+
+### Contributors
+
+* @Boshen
+
 ## [11.8.4](https://github.com/oxc-project/oxc-resolver/compare/v11.8.3...v11.8.4) - 2025-09-28
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,7 +784,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "oxc_resolver"
-version = "11.8.4"
+version = "11.9.0"
 dependencies = [
  "cfg-if",
  "criterion2",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver_napi"
-version = "11.8.4"
+version = "11.9.0"
 dependencies = [
  "fancy-regex",
  "mimalloc-safe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rust-version = "1.85.0"
 description = "ESM / CJS module resolution"
 
 [workspace.dependencies]
-oxc_resolver = { version = "11.8.4", path = "." }
+oxc_resolver = { version = "11.9.0", path = "." }
 
 [package]
 name = "oxc_resolver"
-version = "11.8.4"
+version = "11.9.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_resolver_napi"
-version = "11.8.4"
+version = "11.9.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `oxc_resolver`: 11.8.4 -> 11.9.0
* `oxc_resolver_napi`: 11.8.4 -> 11.9.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `oxc_resolver`

<blockquote>

## [11.9.0](https://github.com/oxc-project/oxc-resolver/compare/v11.8.4...v11.9.0) - 2025-10-01

### <!-- 0 -->🚀 Features

- only resolve file:// protocol on windows ([#737](https://github.com/oxc-project/oxc-resolver/pull/737)) (by @Boshen) - #737

### <!-- 6 -->🧪 Testing

- improve test coverage for edge cases ([#740](https://github.com/oxc-project/oxc-resolver/pull/740)) (by @Boshen) - #740
- improve coverage for check_restrictions ([#739](https://github.com/oxc-project/oxc-resolver/pull/739)) (by @Boshen) - #739

### Contributors

* @Boshen
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).