### PR TITLE
refactor: remove normalize-path dependency, use internal PathUtil

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,12 +750,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
-name = "normalize-path"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,7 +788,6 @@ dependencies = [
  "indexmap",
  "json-strip-comments",
  "libc",
- "normalize-path",
  "once_cell",
  "papaya",
  "pico-args",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,6 @@ url = "2"
 criterion2 = { version = "3.0.2", default-features = false }
 dirs = { version = "6.0.0" }
 fancy-regex = { version = "^0.16.1", default-features = false, features = ["std"] }
-normalize-path = { version = "0.2.1" }
 pico-args = "0.5.0"
 rayon = { version = "1.10.0" }
 vfs = "0.12.2" # for testing with in memory file system

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -2,9 +2,9 @@
 
 use std::path::Path;
 
-use normalize_path::NormalizePath;
-
-use crate::{AliasValue, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver};
+use crate::{
+    AliasValue, PathUtil, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver,
+};
 
 #[allow(clippy::too_many_lines)]
 #[test]

--- a/src/tests/missing.rs
+++ b/src/tests/missing.rs
@@ -1,8 +1,6 @@
 //! https://github.com/webpack/enhanced-resolve/blob/main/test/missing.test.js
 
-use normalize_path::NormalizePath;
-
-use crate::{AliasValue, ResolveContext, ResolveOptions, Resolver};
+use crate::{AliasValue, PathUtil, ResolveContext, ResolveOptions, Resolver};
 
 #[test]
 fn test() {

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -255,7 +255,7 @@ fn abnormal_relative() {
 #[cfg(windows)]
 #[test]
 fn resolve_normalized_on_windows() {
-    use normalize_path::NormalizePath;
+    use crate::PathUtil;
 
     let f = super::fixture();
     let absolute = f.join("./foo/index.js").normalize();

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "windows")]
-use crate::tests::windows::get_dos_device_path;
+use crate::PathUtil;
 #[cfg(target_os = "windows")]
-use normalize_path::NormalizePath;
+use crate::tests::windows::get_dos_device_path;
 use std::path::PathBuf;
 use std::{fs, io, path::Path};
 


### PR DESCRIPTION
Replace the external normalize-path crate with the internal PathUtil trait which provides the same .normalize() functionality. This reduces external dependencies and ensures consistent path normalization throughout the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)