### PR TITLE
feat: add tsconfig discovery

### DIFF
--- a/examples/resolver.rs
+++ b/examples/resolver.rs
@@ -2,7 +2,9 @@
 
 use std::path::PathBuf;
 
-use oxc_resolver::{AliasValue, ResolveOptions, Resolver, TsconfigOptions, TsconfigReferences};
+use oxc_resolver::{
+    AliasValue, ResolveOptions, Resolver, TsconfigDiscovery, TsconfigOptions, TsconfigReferences,
+};
 use pico_args::Arguments;
 
 fn main() {
@@ -30,10 +32,15 @@ fn main() {
         condition_names: vec!["node".into(), "import".into()],
         // CJS
         // condition_names: vec!["node".into(), "require".into()],
-        tsconfig: tsconfig_path.map(|config_file| TsconfigOptions {
-            config_file,
-            references: TsconfigReferences::Auto,
-        }),
+        tsconfig: Some(tsconfig_path.map_or_else(
+            || TsconfigDiscovery::Auto,
+            |config_file| {
+                TsconfigDiscovery::Manual(TsconfigOptions {
+                    config_file,
+                    references: TsconfigReferences::Auto,
+                })
+            },
+        )),
         ..ResolveOptions::default()
     };
 
@@ -45,7 +52,7 @@ fn main() {
             println!("Resolution: {}", resolution.full_path().to_string_lossy());
             println!("Module Type: {:?}", resolution.module_type());
             println!(
-                "package json: {:?}",
+                "package.json: {:?}",
                 resolution.package_json().map(|p| p.path.to_string_lossy())
             );
         }

--- a/napi/index.d.ts
+++ b/napi/index.d.ts
@@ -52,11 +52,11 @@ export declare const enum ModuleType {
  */
 export interface NapiResolveOptions {
   /**
-   * Path to TypeScript configuration file.
+   * Discover tsconfig automatically or use the specified tsconfig.json path.
    *
    * Default `None`
    */
-  tsconfig?: TsconfigOptions
+  tsconfig?: 'auto' | TsconfigOptions
   /**
    * Alias for [ResolveOptions::alias] and [ResolveOptions::fallback].
    *

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -10,9 +10,9 @@ use std::{
     sync::Arc,
 };
 
-use napi::{Task, bindgen_prelude::AsyncTask};
+use napi::{Either, Task, bindgen_prelude::AsyncTask};
 use napi_derive::napi;
-use oxc_resolver::{ResolveError, ResolveOptions, Resolver};
+use oxc_resolver::{ResolveError, ResolveOptions, Resolver, TsconfigDiscovery, TsconfigOptions};
 
 use self::options::{NapiResolveOptions, StrOrStrList};
 
@@ -190,7 +190,10 @@ impl ResolverFactory {
         // merging options
         ResolveOptions {
             cwd: None,
-            tsconfig: op.tsconfig.map(|tsconfig| tsconfig.into()),
+            tsconfig: op.tsconfig.map(|value| match value {
+                Either::A(_) => TsconfigDiscovery::Auto,
+                Either::B(options) => TsconfigDiscovery::Manual(TsconfigOptions::from(options)),
+            }),
             alias: op
                 .alias
                 .map(|alias| {

--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -12,10 +12,11 @@ use napi_derive::napi;
 #[derive(Debug, Clone)]
 #[napi(object)]
 pub struct NapiResolveOptions {
-    /// Path to TypeScript configuration file.
+    /// Discover tsconfig automatically or use the specified tsconfig.json path.
     ///
     /// Default `None`
-    pub tsconfig: Option<TsconfigOptions>,
+    #[napi(ts_type = "'auto' | TsconfigOptions")]
+    pub tsconfig: Option<Either<String, TsconfigOptions>>,
 
     /// Alias for [ResolveOptions::alias] and [ResolveOptions::fallback].
     ///

--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -13,7 +13,7 @@ use once_cell::sync::OnceCell as OnceLock;
 use super::cache_impl::Cache;
 use super::thread_local::SCRATCH_PATH;
 use crate::{
-    FileMetadata, FileSystem, PackageJson, ResolveError, ResolveOptions,
+    FileMetadata, FileSystem, PackageJson, ResolveError, ResolveOptions, TsConfig,
     context::ResolveContext as Ctx,
 };
 
@@ -31,6 +31,7 @@ pub struct CachedPathImpl {
     pub canonicalizing: AtomicU64,
     pub node_modules: OnceLock<Option<Weak<CachedPathImpl>>>,
     pub package_json: OnceLock<Option<Arc<PackageJson>>>,
+    pub tsconfig: OnceLock<Option<Arc<TsConfig>>>,
 }
 
 impl CachedPathImpl {
@@ -52,6 +53,7 @@ impl CachedPathImpl {
             canonicalizing: AtomicU64::new(0),
             node_modules: OnceLock::new(),
             package_json: OnceLock::new(),
+            tsconfig: OnceLock::new(),
         }
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -15,10 +15,10 @@ pub struct ResolveOptions {
     /// Current working directory, used for testing purposes.
     pub cwd: Option<PathBuf>,
 
-    /// Path to TypeScript configuration file.
+    /// Discover tsconfig automatically or use the specified tsconfig.json path.
     ///
     /// Default `None`
-    pub tsconfig: Option<TsconfigOptions>,
+    pub tsconfig: Option<TsconfigDiscovery>,
 
     /// Create aliases to import or require certain modules more easily.
     ///
@@ -472,6 +472,12 @@ impl std::fmt::Debug for Restriction {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum TsconfigDiscovery {
+    Auto,
+    Manual(TsconfigOptions),
+}
+
 /// Tsconfig Options for [ResolveOptions::tsconfig]
 ///
 /// Derived from [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin#options)
@@ -612,8 +618,8 @@ mod test {
     use std::path::PathBuf;
 
     use super::{
-        AliasValue, EnforceExtension, ResolveOptions, Restriction, TsconfigOptions,
-        TsconfigReferences,
+        AliasValue, EnforceExtension, ResolveOptions, Restriction, TsconfigDiscovery,
+        TsconfigOptions, TsconfigReferences,
     };
 
     #[test]
@@ -634,10 +640,10 @@ mod test {
     #[test]
     fn display() {
         let options = ResolveOptions {
-            tsconfig: Some(TsconfigOptions {
+            tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
                 config_file: PathBuf::from("tsconfig.json"),
                 references: TsconfigReferences::Auto,
-            }),
+            })),
             alias: vec![("a".into(), vec![AliasValue::Ignore])],
             alias_fields: vec![vec!["browser".into()]],
             condition_names: vec!["require".into()],
@@ -657,7 +663,7 @@ mod test {
             ..ResolveOptions::default()
         };
 
-        let expected = r#"tsconfig:TsconfigOptions { config_file: "tsconfig.json", references: Auto },alias:[("a", [Ignore])],alias_fields:[["browser"]],condition_names:["require"],enforce_extension:Enabled,exports_fields:[["exports"]],imports_fields:[["imports"]],extension_alias:[(".js", [".ts"])],extensions:[".js", ".json", ".node"],fallback:[("fallback", [Ignore])],fully_specified:true,main_fields:["main"],main_files:["index"],modules:["node_modules"],resolve_to_context:true,prefer_relative:true,prefer_absolute:true,restrictions:[Path("restrictions")],roots:["roots"],symlinks:true,builtin_modules:true,allow_package_exports_in_directory_resolve:true,"#;
+        let expected = r#"tsconfig:Manual(TsconfigOptions { config_file: "tsconfig.json", references: Auto }),alias:[("a", [Ignore])],alias_fields:[["browser"]],condition_names:["require"],enforce_extension:Enabled,exports_fields:[["exports"]],imports_fields:[["imports"]],extension_alias:[(".js", [".ts"])],extensions:[".js", ".json", ".node"],fallback:[("fallback", [Ignore])],fully_specified:true,main_fields:["main"],main_files:["index"],modules:["node_modules"],resolve_to_context:true,prefer_relative:true,prefer_absolute:true,restrictions:[Path("restrictions")],roots:["roots"],symlinks:true,builtin_modules:true,allow_package_exports_in_directory_resolve:true,"#;
         assert_eq!(format!("{options}"), expected);
 
         let options = ResolveOptions {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -24,6 +24,7 @@ mod roots;
 mod scoped_packages;
 mod simple;
 mod symlink;
+mod tsconfig_discovery;
 mod tsconfig_extends;
 mod tsconfig_paths;
 mod tsconfig_project_references;

--- a/src/tests/tsconfig_discovery.rs
+++ b/src/tests/tsconfig_discovery.rs
@@ -1,0 +1,8 @@
+//! Tests for tsconfig discovery
+//!
+//! Tests that tsconfig.json can be auto-discovered when no explicit tsconfig option is provided.
+
+#[test]
+fn tsconfig_discovery() {
+    super::tsconfig_paths::tsconfig_resolve_impl(/* tsconfig_discovery */ true);
+}

--- a/src/tests/tsconfig_extends.rs
+++ b/src/tests/tsconfig_extends.rs
@@ -5,17 +5,19 @@
 
 use std::path::Path;
 
-use crate::{ResolveOptions, Resolver, TsConfig, TsconfigOptions, TsconfigReferences};
+use crate::{
+    ResolveOptions, Resolver, TsConfig, TsconfigDiscovery, TsconfigOptions, TsconfigReferences,
+};
 
 #[test]
 fn test_extend_tsconfig() {
     let f = super::fixture_root().join("tsconfig/cases/extends");
 
     let resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("tsconfig.json"),
             references: TsconfigReferences::Auto,
-        }),
+        })),
         ..ResolveOptions::default()
     });
 
@@ -44,10 +46,10 @@ fn test_extend_tsconfig_paths() {
     let f = super::fixture_root().join("tsconfig/cases/extends-paths-inheritance");
 
     let resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("tsconfig.json"),
             references: TsconfigReferences::Auto,
-        }),
+        })),
         extensions: vec![".ts".into(), ".js".into()],
         ..ResolveOptions::default()
     });
@@ -62,10 +64,10 @@ fn test_extend_tsconfig_override_behavior() {
     let f = super::fixture_root().join("tsconfig/cases/extends-override");
 
     let resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("tsconfig.json"),
             references: TsconfigReferences::Auto,
-        }),
+        })),
         ..ResolveOptions::default()
     });
 
@@ -82,10 +84,10 @@ fn test_extend_tsconfig_template_variables() {
     let f = super::fixture_root().join("tsconfig/cases/extends-template-vars");
 
     let resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("tsconfig.json"),
             references: TsconfigReferences::Auto,
-        }),
+        })),
         extensions: vec![".ts".into(), ".js".into()],
         ..ResolveOptions::default()
     });
@@ -102,10 +104,10 @@ fn test_extend_tsconfig_missing_file() {
     let f = super::fixture_root().join("tsconfig/cases");
 
     let resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("nonexistent-tsconfig.json"),
             references: TsconfigReferences::Auto,
-        }),
+        })),
         ..ResolveOptions::default()
     });
 
@@ -118,10 +120,10 @@ fn test_extend_tsconfig_multiple_inheritance() {
     let f = super::fixture_root().join("tsconfig/cases/extends-chain");
 
     let resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("tsconfig.json"),
             references: TsconfigReferences::Auto,
-        }),
+        })),
         ..ResolveOptions::default()
     });
 
@@ -139,10 +141,10 @@ fn test_extend_tsconfig_preserves_child_settings() {
     let f = super::fixture_root().join("tsconfig/cases/extends-preserve-child");
 
     let resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("tsconfig.json"),
             references: TsconfigReferences::Auto,
-        }),
+        })),
         ..ResolveOptions::default()
     });
 

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -1,6 +1,8 @@
 //! Tests for tsconfig project references
 
-use crate::{ResolveError, ResolveOptions, Resolver, TsconfigOptions, TsconfigReferences};
+use crate::{
+    ResolveError, ResolveOptions, Resolver, TsconfigDiscovery, TsconfigOptions, TsconfigReferences,
+};
 
 #[test]
 fn auto() {
@@ -9,19 +11,19 @@ fn auto() {
     // The following resolver's `config_file` has defined it's own paths alias which has higher priority
     // some cases will work without references
     let resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("app"),
             references: TsconfigReferences::Auto,
-        }),
+        })),
         ..ResolveOptions::default()
     });
 
     // The following resolver's `config_file` has no `paths` alias with `references` enabled
     let no_paths_resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("app/tsconfig.nopaths.json"),
             references: TsconfigReferences::Auto,
-        }),
+        })),
         ..ResolveOptions::default()
     });
 
@@ -79,19 +81,19 @@ fn disabled() {
     // The following resolver's `config_file` has defined it's own paths alias which has higher priority
     // some cases will work without references
     let resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("app"),
             references: TsconfigReferences::Disabled,
-        }),
+        })),
         ..ResolveOptions::default()
     });
 
     // The following resolver's `config_file` has no `paths` alias with `references` enabled
     let no_paths_resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("app/tsconfig.nopaths.json"),
             references: TsconfigReferences::Disabled,
-        }),
+        })),
         ..ResolveOptions::default()
     });
 
@@ -139,19 +141,19 @@ fn manual() {
     // The following resolver's `config_file` has defined it's own paths alias which has higher priority
     // some cases will work without references
     let resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("app"),
             references: TsconfigReferences::Paths(vec!["../project_a/conf.json".into()]),
-        }),
+        })),
         ..ResolveOptions::default()
     });
 
     // The following resolver's `config_file` has no `paths` alias with `references` enabled
     let no_paths_resolver = Resolver::new(ResolveOptions {
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.join("app/tsconfig.nopaths.json"),
             references: TsconfigReferences::Paths(vec!["../project_a/conf.json".into()]),
-        }),
+        })),
         ..ResolveOptions::default()
     });
 
@@ -207,10 +209,10 @@ fn self_reference() {
 
     for (config_file, reference_paths) in pass {
         let resolver = Resolver::new(ResolveOptions {
-            tsconfig: Some(TsconfigOptions {
+            tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
                 config_file: config_file.clone(),
                 references: TsconfigReferences::Paths(reference_paths.clone()),
-            }),
+            })),
             ..ResolveOptions::default()
         });
         let path = f.join("app");
@@ -229,10 +231,10 @@ fn references_with_extends() {
 
     let resolver = Resolver::new(ResolveOptions {
         extensions: vec![".ts".into(), ".tsx".into()],
-        tsconfig: Some(TsconfigOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
             config_file: f.clone(),
             references: TsconfigReferences::Auto,
-        }),
+        })),
         ..ResolveOptions::default()
     });
 


### PR DESCRIPTION
## Summary

Add automatic tsconfig.json discovery that traverses up parent directories, similar to how package.json is discovered.

closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

Rolldown PR: https://github.com/rolldown/rolldown/pull/6602
Oxlint PR: https://github.com/oxc-project/oxc/pull/14721