### PR TITLE
fix: tsconfig paths should not be applied to paths inside node_modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1453,6 +1453,9 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         specifier: &str,
         ctx: &mut Ctx,
     ) -> ResolveResult {
+        if cached_path.inside_node_modules() {
+            return Ok(None);
+        }
         let Some(tsconfig_options) = &self.options.tsconfig else {
             return Ok(None);
         };

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -45,7 +45,7 @@ fn tsconfig_resolve() {
 
     #[rustfmt::skip]
     let data = [
-        (f.join("node_modules/tsconfig-not-used"), "ts-path", Ok(f.join("src/foo.js"))),
+        (f.join("node_modules/tsconfig-not-used"), "ts-path", Err(ResolveError::NotFound("ts-path".to_string()))),
     ];
 
     let resolver = Resolver::new(ResolveOptions {


### PR DESCRIPTION
Found this case while working on tsconfig discovered.

Still uncertain about this change but the original test returns not found.

https://github.com/parcel-bundler/parcel/blob/b6224fd519f95e68d8b93ba90376fd94c8b76e69/packages/utils/node-resolver-rs/src/lib.rs#L2372-L2384

It should not pick up any tsconfig while resolving specifier inside `node_modules`.

https://github.com/oxc-project/oxc-resolver/blob/19902fbd7a8f926c4a99b59552f5e7dffbafb230/fixtures/tsconfig/node_modules/tsconfig-not-used/tsconfig.json#L4

Reference:

* https://github.com/aleclarson/vite-tsconfig-paths/blob/master/src/index.ts
* https://github.com/jonaskello/tsconfig-paths-webpack-plugin/blob/master/src/plugin.ts

The webpack plugin has no mention of `node_modules` but the vite plugin does.

@sapphi-red I'm not confident with this logic overall so assigning you to review.