### PR TITLE
chore: release v11.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.11.1](https://github.com/oxc-project/oxc-resolver/compare/v11.11.0...v11.11.1) - 2025-10-21
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- derive Error for JSONError ([#779](https://github.com/oxc-project/oxc-resolver/pull/779)) (by @Boshen) - #779
+
+### Contributors
+
+* @Boshen
+
 ## [11.11.0](https://github.com/oxc-project/oxc-resolver/compare/v11.10.0...v11.11.0) - 2025-10-20
 
 ### <!-- 0 -->🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "oxc_resolver"
-version = "11.11.0"
+version = "11.11.1"
 dependencies = [
  "cfg-if",
  "criterion2",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver_napi"
-version = "11.11.0"
+version = "11.11.1"
 dependencies = [
  "fancy-regex",
  "mimalloc-safe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rust-version = "1.85.0"
 description = "ESM / CJS module resolution"
 
 [workspace.dependencies]
-oxc_resolver = { version = "11.11.0", path = "." }
+oxc_resolver = { version = "11.11.1", path = "." }
 
 [package]
 name = "oxc_resolver"
-version = "11.11.0"
+version = "11.11.1"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_resolver_napi"
-version = "11.11.0"
+version = "11.11.1"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/index.js
+++ b/napi/index.js
@@ -80,8 +80,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-resolver/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -96,8 +96,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-resolver/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@oxc-resolver/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-resolver/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -150,8 +150,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-resolver/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -166,8 +166,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-resolver/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -185,8 +185,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-resolver/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-resolver/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -201,8 +201,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-resolver/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -217,8 +217,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-resolver/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -237,8 +237,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-resolver/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -253,8 +253,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-resolver/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -274,8 +274,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -290,8 +290,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -308,8 +308,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -324,8 +324,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -342,8 +342,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -358,8 +358,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -376,8 +376,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -392,8 +392,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -410,8 +410,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -443,8 +443,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-resolver/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -459,8 +459,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-resolver/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -479,8 +479,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-resolver/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -495,8 +495,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-resolver/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -511,8 +511,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-resolver/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '11.11.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.11.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.11.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.11.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-resolver",
-  "version": "11.11.0",
+  "version": "11.11.1",
   "license": "MIT",
   "description": "Oxc Resolver Node API",
   "packageManager": "pnpm@10.18.3",


### PR DESCRIPTION



## 🤖 New release

* `oxc_resolver`: 11.11.0 -> 11.11.1
* `oxc_resolver_napi`: 11.11.0 -> 11.11.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `oxc_resolver`

<blockquote>

## [11.11.1](https://github.com/oxc-project/oxc-resolver/compare/v11.11.0...v11.11.1) - 2025-10-21

### <!-- 1 -->🐛 Bug Fixes

- derive Error for JSONError ([#779](https://github.com/oxc-project/oxc-resolver/pull/779)) (by @Boshen) - #779

### Contributors

* @Boshen
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).