### PR TITLE
fix: restore webcontainer-fallback.js for Stackblitz support

### DIFF
--- a/napi/webcontainer-fallback.js
+++ b/napi/webcontainer-fallback.js
@@ -1,0 +1,23 @@
+const fs = require('node:fs');
+const childProcess = require('node:child_process');
+
+const pkg = JSON.parse(
+  fs.readFileSync(require.resolve('oxc-resolver/package.json'), 'utf-8'),
+);
+const version = pkg.version;
+const baseDir = `/tmp/oxc-resolver-${version}`;
+const bindingEntry = `${baseDir}/node_modules/@oxc-resolver/binding-wasm32-wasi/resolver.wasi.cjs`;
+
+if (!fs.existsSync(bindingEntry)) {
+  fs.rmSync(baseDir, { recursive: true, force: true });
+  fs.mkdirSync(baseDir, { recursive: true });
+  const bindingPkg = `@oxc-resolver/binding-wasm32-wasi@${version}`;
+  // eslint-disable-next-line: no-console
+  console.log(`[oxc-resolver] Downloading ${bindingPkg} on WebContainer...`);
+  childProcess.execFileSync('pnpm', ['i', bindingPkg], {
+    cwd: baseDir,
+    stdio: 'inherit',
+  });
+}
+
+module.exports = require(bindingEntry);


### PR DESCRIPTION
## Summary

Restores the `webcontainer-fallback.js` file that was accidentally deleted in #592, fixing Stackblitz/WebContainer support.

## Problem

The `napi/webcontainer-fallback.js` file was accidentally deleted in commit 195e2f9 during a backport from `unrs/unrs-resolver`, but:
- The code that requires it was still present in `napi/index.js` (lines 560-566)
- The file was still listed in `package.json` under the `files` array
- This caused the package to fail on Stackblitz and other WebContainer environments

## Solution

Restored the file with the original implementation from commit 0180b05 that:
- Detects when running in a WebContainer environment via `globalThis.process?.versions?.["webcontainer"]`
- Automatically downloads `@oxc-resolver/binding-wasm32-wasi` when needed
- Caches the download in `/tmp/oxc-resolver-{version}`

## Test Plan

- [x] All existing tests pass
- [x] File is properly staged and committed

Fixes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)