### PR TITLE
fix: skip loading tsconfig.json from virtual module paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1505,17 +1505,12 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         if cached_path.inside_node_modules() {
             return Ok(None);
         }
-
-        let mut cache_value = cached_path.clone();
-        // Go up directories when the querying path is not a directory
-        while !self.cache.is_dir(&cache_value, ctx) {
-            if let Some(cv) = cache_value.parent() {
-                cache_value = cv;
-            } else {
-                break;
-            }
+        // Skip non-absolute paths (e.g. virtual modules)
+        if !cached_path.path.is_absolute() {
+            return Ok(None);
         }
-        let mut cache_value = Some(cache_value);
+
+        let mut cache_value = Some(cached_path.clone());
         while let Some(cv) = cache_value {
             if let Some(tsconfig) = cv.tsconfig.get_or_try_init(|| {
                 let tsconfig_path = cv.path.join("tsconfig.json");

--- a/src/tests/tsconfig_discovery.rs
+++ b/src/tests/tsconfig_discovery.rs
@@ -2,7 +2,24 @@
 //!
 //! Tests that tsconfig.json can be auto-discovered when no explicit tsconfig option is provided.
 
+use crate::{ResolveError, ResolveOptions, Resolver, TsconfigDiscovery};
+
 #[test]
 fn tsconfig_discovery() {
     super::tsconfig_paths::tsconfig_resolve_impl(/* tsconfig_discovery */ true);
+}
+
+#[test]
+fn tsconfig_discovery_virtual_file_importer() {
+    let f = super::fixture_root().join("tsconfig");
+
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        cwd: Some(f.join("cases/index")),
+        ..ResolveOptions::default()
+    });
+
+    let resolved_path =
+        resolver.resolve("\0virtual-module", "random-import").map(|f| f.full_path());
+    assert_eq!(resolved_path, Err(ResolveError::NotFound("random-import".into())));
 }


### PR DESCRIPTION
refs #758
fixes, https://github.com/vitejs/rolldown-vite/issues/477

The tests passes without the change, but covers the new `if`. To make a test that fails, we need to configure the cwd to a different path, but that makes the test more complex, so I didn't do that.
