### PR TITLE
feat(tsconfig): implement solution-style tsconfig resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +391,15 @@ dependencies = [
  "bit-set",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "fast-glob"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d26eec0ae9682c457cb0f85de67ad417b716ae852736a5d94c2ad6e92a997c9"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -856,6 +871,7 @@ dependencies = [
  "dirs",
  "document-features",
  "fancy-regex",
+ "fast-glob",
  "indexmap",
  "json-strip-comments",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ name = "resolver"
 
 [dependencies]
 cfg-if = "1"
+fast-glob = "1.0.0"
 indexmap = { version = "2", features = ["serde"] }
 json-strip-comments = "3"
 once_cell = "1" # Use `std::sync::OnceLock::get_or_try_init` when it is stable.

--- a/fixtures/tsconfig/cases/solution_style/packages/pkg-a/src/index.ts
+++ b/fixtures/tsconfig/cases/solution_style/packages/pkg-a/src/index.ts
@@ -1,0 +1,1 @@
+export const pkgAIndex = 'pkg-a';

--- a/fixtures/tsconfig/cases/solution_style/packages/pkg-a/tsconfig.json
+++ b/fixtures/tsconfig/cases/solution_style/packages/pkg-a/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@pkg-a/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/fixtures/tsconfig/cases/solution_style/packages/pkg-b/src/index.js
+++ b/fixtures/tsconfig/cases/solution_style/packages/pkg-b/src/index.js
@@ -1,0 +1,1 @@
+export const pkgBIndexJS = 'pkg-b-js';

--- a/fixtures/tsconfig/cases/solution_style/packages/pkg-b/src/index.ts
+++ b/fixtures/tsconfig/cases/solution_style/packages/pkg-b/src/index.ts
@@ -1,0 +1,1 @@
+export const pkgBIndex = 'pkg-b';

--- a/fixtures/tsconfig/cases/solution_style/packages/pkg-b/tsconfig.json
+++ b/fixtures/tsconfig/cases/solution_style/packages/pkg-b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "allowJs": true,
+    "paths": {
+      "@pkg-b/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/fixtures/tsconfig/cases/solution_style/packages/pkg-c/lib/index.test.ts
+++ b/fixtures/tsconfig/cases/solution_style/packages/pkg-c/lib/index.test.ts
@@ -1,0 +1,1 @@
+// This file should be excluded by pkg-c's exclude pattern

--- a/fixtures/tsconfig/cases/solution_style/packages/pkg-c/lib/index.ts
+++ b/fixtures/tsconfig/cases/solution_style/packages/pkg-c/lib/index.ts
@@ -1,0 +1,1 @@
+export const pkgCIndex = 'pkg-c';

--- a/fixtures/tsconfig/cases/solution_style/packages/pkg-c/tsconfig.json
+++ b/fixtures/tsconfig/cases/solution_style/packages/pkg-c/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@pkg-c/*": ["./lib/*"]
+    }
+  },
+  "include": ["lib/**/*"],
+  "exclude": ["lib/**/*.test.ts"]
+}

--- a/fixtures/tsconfig/cases/solution_style/src/index.ts
+++ b/fixtures/tsconfig/cases/solution_style/src/index.ts
@@ -1,0 +1,1 @@
+export const rootIndex = 'root';

--- a/fixtures/tsconfig/cases/solution_style/tsconfig.json
+++ b/fixtures/tsconfig/cases/solution_style/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "allowJs": true,
+    "paths": {
+      "root/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "./packages/pkg-a" },
+    { "path": "./packages/pkg-b" },
+    { "path": "./packages/pkg-c" }
+  ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,13 +199,16 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     ///
     /// * See [ResolveError]
     pub fn resolve_tsconfig<P: AsRef<Path>>(&self, path: P) -> Result<Arc<TsConfig>, ResolveError> {
+        self.resolve_tsconfig_with_references(path, &TsconfigReferences::Auto)
+    }
+
+    pub fn resolve_tsconfig_with_references<P: AsRef<Path>>(
+        &self,
+        path: P,
+        references: &TsconfigReferences,
+    ) -> Result<Arc<TsConfig>, ResolveError> {
         let path = path.as_ref();
-        self.load_tsconfig(
-            true,
-            path,
-            &TsconfigReferences::Auto,
-            &mut TsconfigResolveContext::default(),
-        )
+        self.load_tsconfig(true, path, references, &mut TsconfigResolveContext::default())
     }
 
     /// Resolve `specifier` at absolute `path` with [ResolveContext]
@@ -1469,7 +1472,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 let Some(tsconfig) = self.find_tsconfig(cached_path, ctx)? else {
                     return Ok(None);
                 };
-                tsconfig
+                tsconfig.resolve_for_file(cached_path.path())
             }
         };
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod tsconfig_discovery;
 mod tsconfig_extends;
 mod tsconfig_paths;
 mod tsconfig_project_references;
+mod tsconfig_solution_style;
 #[cfg(target_os = "windows")]
 mod windows;
 

--- a/src/tests/tsconfig_solution_style.rs
+++ b/src/tests/tsconfig_solution_style.rs
@@ -1,0 +1,174 @@
+//! Tests for solution-style tsconfig resolution
+//!
+//! Tests the `TsConfig::resolve_for_file` method which implements solution-style
+//! tsconfig resolution similar to tsconfck's `resolveSolutionTSConfig`.
+
+use std::{path::Path, sync::Arc};
+
+use crate::{ResolveOptions, Resolver, TsConfig};
+
+/// Helper function to load a tsconfig with references
+fn load_tsconfig(path: &Path) -> Arc<TsConfig> {
+    let resolver = Resolver::new(ResolveOptions::default());
+    resolver.resolve_tsconfig(path).unwrap()
+}
+
+#[test]
+fn resolve_for_file_basic() {
+    let f = super::fixture_root().join("tsconfig/cases/solution_style");
+
+    // Load root tsconfig with references
+    let root_tsconfig = load_tsconfig(&f.join("tsconfig.json"));
+
+    // File in root src/ should use root tsconfig
+    let file_path = f.join("src/index.ts");
+    let resolved = root_tsconfig.resolve_for_file(&file_path);
+    assert_eq!(resolved.path(), root_tsconfig.path(), "File in src/ should use root tsconfig");
+
+    // File in pkg-a should use pkg-a's tsconfig
+    let file_path = f.join("packages/pkg-a/src/index.ts");
+    let resolved = root_tsconfig.resolve_for_file(&file_path);
+    assert_eq!(
+        resolved.path(),
+        f.join("packages/pkg-a/tsconfig.json"),
+        "File in pkg-a/src/ should use pkg-a's tsconfig"
+    );
+
+    // File in pkg-b should use pkg-b's tsconfig
+    let file_path = f.join("packages/pkg-b/src/index.ts");
+    let resolved = root_tsconfig.resolve_for_file(&file_path);
+    assert_eq!(
+        resolved.path(),
+        f.join("packages/pkg-b/tsconfig.json"),
+        "File in pkg-b/src/ should use pkg-b's tsconfig"
+    );
+
+    // File in pkg-c's lib/ should use pkg-c's tsconfig
+    let file_path = f.join("packages/pkg-c/lib/index.ts");
+    let resolved = root_tsconfig.resolve_for_file(&file_path);
+    assert_eq!(
+        resolved.path(),
+        f.join("packages/pkg-c/tsconfig.json"),
+        "File in pkg-c/lib/ should use pkg-c's tsconfig"
+    );
+}
+
+#[test]
+fn resolve_for_file_exclude_patterns() {
+    let f = super::fixture_root().join("tsconfig/cases/solution_style");
+    let root_tsconfig = load_tsconfig(&f.join("tsconfig.json"));
+
+    // pkg-c excludes *.test.ts files
+    let excluded_file = f.join("packages/pkg-c/lib/index.test.ts");
+    let resolved = root_tsconfig.resolve_for_file(&excluded_file);
+
+    // Should fall back to root tsconfig since file is excluded from pkg-c
+    assert_eq!(
+        resolved.path(),
+        root_tsconfig.path(),
+        "Excluded files should fall back to root tsconfig"
+    );
+
+    // Non-excluded file should still use pkg-c's tsconfig
+    let included_file = f.join("packages/pkg-c/lib/index.ts");
+    let resolved = root_tsconfig.resolve_for_file(&included_file);
+    assert_eq!(
+        resolved.path(),
+        f.join("packages/pkg-c/tsconfig.json"),
+        "Non-excluded files should use pkg-c's tsconfig"
+    );
+}
+
+#[test]
+fn resolve_for_file_allowjs() {
+    let f = super::fixture_root().join("tsconfig/cases/solution_style");
+    let root_tsconfig = load_tsconfig(&f.join("tsconfig.json"));
+
+    // pkg-b has allowJs: true, so .js files should use pkg-b's tsconfig
+    let js_file = f.join("packages/pkg-b/src/index.js");
+    let resolved = root_tsconfig.resolve_for_file(&js_file);
+    assert_eq!(
+        resolved.path(),
+        f.join("packages/pkg-b/tsconfig.json"),
+        "With allowJs, .js files should use pkg-b's tsconfig"
+    );
+
+    // pkg-a doesn't have allowJs, so .js files should fall back to root
+    let js_file = f.join("packages/pkg-a/src/script.js");
+    let resolved = root_tsconfig.resolve_for_file(&js_file);
+    assert_eq!(
+        resolved.path(),
+        root_tsconfig.path(),
+        "Without allowJs, .js files should fall back to root tsconfig"
+    );
+}
+
+#[test]
+fn resolve_for_file_non_ts_js_files() {
+    let f = super::fixture_root().join("tsconfig/cases/solution_style");
+    let root_tsconfig = load_tsconfig(&f.join("tsconfig.json"));
+
+    // Non-TS/JS files should not trigger solution-style resolution
+    let json_file = f.join("packages/pkg-a/src/data.json");
+    let resolved = root_tsconfig.resolve_for_file(&json_file);
+    assert_eq!(resolved.path(), root_tsconfig.path(), "Non-TS/JS files should use root tsconfig");
+
+    // .css, .html, etc. should also fall back to root
+    let css_file = f.join("packages/pkg-a/src/styles.css");
+    let resolved = root_tsconfig.resolve_for_file(&css_file);
+    assert_eq!(resolved.path(), root_tsconfig.path(), "CSS files should use root tsconfig");
+}
+
+#[test]
+fn resolve_for_file_no_references() {
+    let f = super::fixture_root().join("tsconfig/cases/solution_style");
+
+    // Load pkg-a's tsconfig which has no references
+    let pkg_a_tsconfig = load_tsconfig(&f.join("packages/pkg-a/tsconfig.json"));
+
+    // When a tsconfig has no references, it should always return itself
+    let file_in_pkg_a = f.join("packages/pkg-a/src/index.ts");
+    let resolved = pkg_a_tsconfig.resolve_for_file(&file_in_pkg_a);
+    assert_eq!(
+        resolved.path(),
+        pkg_a_tsconfig.path(),
+        "Tsconfig without references should always return itself"
+    );
+
+    // Even for files outside its directory
+    let file_in_pkg_b = f.join("packages/pkg-b/src/index.ts");
+    let resolved = pkg_a_tsconfig.resolve_for_file(&file_in_pkg_b);
+    assert_eq!(
+        resolved.path(),
+        pkg_a_tsconfig.path(),
+        "Tsconfig without references should return itself for any file"
+    );
+}
+
+#[test]
+fn resolve_for_file_extensions() {
+    let f = super::fixture_root().join("tsconfig/cases/solution_style");
+    let root_tsconfig = load_tsconfig(&f.join("tsconfig.json"));
+
+    // Test all TS extensions
+    for ext in ["ts", "tsx", "mts", "cts"] {
+        let file = f.join(format!("packages/pkg-a/src/index.{ext}"));
+        let resolved = root_tsconfig.resolve_for_file(&file);
+        assert_eq!(
+            resolved.path(),
+            f.join("packages/pkg-a/tsconfig.json"),
+            ".{ext} files should trigger solution-style resolution"
+        );
+    }
+
+    // Test JS extensions with allowJs
+    for ext in ["js", "jsx", "mjs", "cjs"] {
+        let file = f.join(format!("packages/pkg-b/src/index.{ext}"));
+        let resolved = root_tsconfig.resolve_for_file(&file);
+        assert_eq!(
+            resolved.path(),
+            f.join("packages/pkg-b/tsconfig.json"),
+            ".{ext} files should trigger solution-style resolution with allowJs"
+        );
+    }
+}


### PR DESCRIPTION
closes #790

Implement solution-style tsconfig resolution similar to tsconfck' [`resolveSolutionTSConfig`](https://github.com/dominikg/tsconfck/blob/68554fa8b99cd02dc6ca96bcdbcd4e04123986ef/packages/tsconfck/src/util.js#L137-L158). This automatically selects the correct tsconfig for a file in monorepo/solution-style projects with project references.

  Changes:
  - Add `TsConfig::resolve_for_file` method to resolve the appropriate  tsconfig based on file inclusion patterns
  - Add `TsConfig::is_file_included` to check if files match tsconfig's include/exclude/files patterns
  - Add `TsConfig::is_glob_match` for glob pattern matching with support for TypeScript's pattern normalization
  - Integrate solution-style resolution in `TsconfigDiscovery::Auto` mode
  - Add `fast-glob` dependency for efficient pattern matching
  - Add comprehensive test suite with 6 tests covering basic resolution,
    exclude patterns, allowJs, extensions, and edge cases
  - Add test fixtures for monorepo scenarios with multiple packages

  The implementation respects TypeScript's file inclusion rules including:
  - `files` array (highest priority)
  - `include` patterns with implicit `**/*` globstar
  - `exclude` patterns
  - `allowJs` configuration for JavaScript files
  - All TypeScript extensions (`ts`, `tsx`, `mts`, `cts`, `js`, `jsx`, `mjs`, `cjs`)

I’ll add more tests for the `is_file_included` and `is_glob_match` methods in the next PRs.