### PR TITLE
refactor(file_system): deduplicate read methods and use Vec<u8>

### DIFF
--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -371,7 +371,7 @@ fn bench_package_json_deserialization(c: &mut Criterion) {
     for (name, json) in data {
         group.bench_function(name, |b| {
             b.iter_with_setup_wrapper(|runner| {
-                let json = json.clone();
+                let json = json.clone().into_bytes();
                 runner.run(|| {
                     PackageJson::parse(&fs, test_path.clone(), test_realpath.clone(), json)
                         .expect("Failed to parse JSON");

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -109,9 +109,7 @@ impl<Fs: FileSystem> Cache<Fs> {
             .package_json
             .get_or_try_init(|| {
                 let package_json_path = path.path.join("package.json");
-                let Ok(package_json_string) =
-                    self.fs.read_to_string_bypass_system_cache(&package_json_path)
-                else {
+                let Ok(package_json_bytes) = self.fs.read(&package_json_path) else {
                     return Ok(None);
                 };
 
@@ -120,7 +118,7 @@ impl<Fs: FileSystem> Cache<Fs> {
                 } else {
                     package_json_path.clone()
                 };
-                PackageJson::parse(&self.fs, package_json_path, real_path, package_json_string)
+                PackageJson::parse(&self.fs, package_json_path, real_path, package_json_bytes)
                     .map(|package_json| Some(Arc::new(package_json)))
                     .map_err(ResolveError::Json)
             })
@@ -167,7 +165,7 @@ impl<Fs: FileSystem> Cache<Fs> {
         };
         let mut tsconfig_string = self
             .fs
-            .read_to_string_bypass_system_cache(&tsconfig_path)
+            .read_to_string(&tsconfig_path)
             .map_err(|_| ResolveError::TsconfigNotFound(path.to_path_buf()))?;
         let mut tsconfig =
             TsConfig::parse(root, &tsconfig_path, &mut tsconfig_string).map_err(|error| {

--- a/src/tests/memory_fs.rs
+++ b/src/tests/memory_fs.rs
@@ -52,15 +52,20 @@ impl FileSystem for MemoryFS {
         Self::default()
     }
 
-    fn read_to_string(&self, path: &Path) -> io::Result<String> {
+    fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
         use vfs::FileSystem;
         let mut file = self
             .fs
             .open_file(path.to_string_lossy().as_ref())
             .map_err(|err| io::Error::new(io::ErrorKind::NotFound, err))?;
-        let mut buffer = String::new();
-        file.read_to_string(&mut buffer).unwrap();
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer).unwrap();
         Ok(buffer)
+    }
+
+    fn read_to_string(&self, path: &Path) -> io::Result<String> {
+        let bytes = self.read(path)?;
+        crate::FileSystemOs::validate_string(bytes)
     }
 
     fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {


### PR DESCRIPTION
## Summary

Refactors the FileSystem trait to eliminate code duplication and improve maintainability:

- Added `read()` method returning `Vec<u8>` as the primary file reading method
- Deduplicated `read_to_string()` to call `read()` + UTF-8 validation
- Removed `read_to_string_bypass_system_cache()` method (simplified API)
- Updated `PackageJson::parse()` to work with `Vec<u8>` instead of `String`

🤖 Generated with [Claude Code](https://claude.com/claude-code)