### PR TITLE
fix: re-calculate `CachedPathImpl::parent` and `CachedPathImpl::node_modules` if the cache is dropped

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -240,7 +240,7 @@ impl<Fs: FileSystem> Cache<Fs> {
 
         path.canonicalizing.store(tid, Ordering::Release);
 
-        let res = path.parent().map_or_else(
+        let res = path.parent(self).map_or_else(
             || Ok(path.normalize_root(self)),
             |parent| {
                 self.canonicalize_impl(&parent).and_then(|parent_canonical| {
@@ -251,7 +251,7 @@ impl<Fs: FileSystem> Cache<Fs> {
                         let link = self.fs.read_link(normalized.path())?;
                         if link.is_absolute() {
                             return self.canonicalize_impl(&self.value(&link.normalize()));
-                        } else if let Some(dir) = normalized.parent() {
+                        } else if let Some(dir) = normalized.parent(self) {
                             // Symlink is relative `../../foo.js`, use the path directory
                             // to resolve this symlink.
                             return self.canonicalize_impl(&dir.normalize_with(&link, self));

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -5,7 +5,7 @@ mod hasher;
 mod thread_local;
 
 pub use cache_impl::Cache;
-pub use cached_path::CachedPath;
+pub use cached_path::{CachedPath, OptionalWeak};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR is similar to #791 but for `CachedPathImpl::parent` and `CachedPathImpl::node_modules`.

This PR aims to fix the flaky failure like https://github.com/vitejs/rolldown-vite/actions/runs/19126439595/job/54657469579#step:11:216
