### PR TITLE
chore: release v11.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.14.0](https://github.com/oxc-project/oxc-resolver/compare/v11.13.2...v11.14.0) - 2025-11-24
+
+### <!-- 0 -->🚀 Features
+
+- add `resolve_file` API for tsconfig auto discovery to work ([#860](https://github.com/oxc-project/oxc-resolver/pull/860)) (by @Boshen) - #860
+- port tsconfck (find tsconfig files) ([#854](https://github.com/oxc-project/oxc-resolver/pull/854)) (by @Boshen) - #854
+- add many.rs example for profiling resolver with many packages ([#836](https://github.com/oxc-project/oxc-resolver/pull/836)) (by @Boshen) - #836
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- apply `conditionNames: ['node', 'import']` when resolving tsconfig extends ([#869](https://github.com/oxc-project/oxc-resolver/pull/869)) (by @Boshen) - #869
+- do not resolve to `node_modules/pacakge/index` ([#849](https://github.com/oxc-project/oxc-resolver/pull/849)) (by @Boshen) - #849
+- use std::fs::canonicalize as a fallback when canonicalize fails ([#835](https://github.com/oxc-project/oxc-resolver/pull/835)) (by @Boshen) - #835
+
+### <!-- 2 -->🚜 Refactor
+
+- remove the redundant `inner_resolver` from `load_pnp` ([#862](https://github.com/oxc-project/oxc-resolver/pull/862)) (by @Boshen) - #862
+- improve `Debug` and `Display` for `CachedPath` ([#861](https://github.com/oxc-project/oxc-resolver/pull/861)) (by @Boshen) - #861
+- too_many_arguments = "allow" ([#863](https://github.com/oxc-project/oxc-resolver/pull/863)) (by @Boshen) - #863
+- change Tsconfig::parse to accept owned string; add replace_bom_with_whitespace ([#859](https://github.com/oxc-project/oxc-resolver/pull/859)) (by @Boshen) - #859
+- remove the useless getters and setters from `CompilerOptions` ([#858](https://github.com/oxc-project/oxc-resolver/pull/858)) (by @Boshen) - #858
+- add `Tsconfig:references_resolved` ([#856](https://github.com/oxc-project/oxc-resolver/pull/856)) (by @Boshen) - #856
+- move tsconfig resolution related code to its own file ([#855](https://github.com/oxc-project/oxc-resolver/pull/855)) (by @Boshen) - #855
+- use RwLock<Vec<Arc<PackageJson>> for package.json storage ([#838](https://github.com/oxc-project/oxc-resolver/pull/838)) (by @Boshen) - #838
+- do not store is_symlink in CachedPathImpl ([#850](https://github.com/oxc-project/oxc-resolver/pull/850)) (by @Boshen) - #850
+- remove CachedPathImpl::canonicaling ([#834](https://github.com/oxc-project/oxc-resolver/pull/834)) (by @Boshen) - #834
+
+### <!-- 4 -->⚡ Performance
+
+- cache all package.json resolutions for faster package.json lookup ([#853](https://github.com/oxc-project/oxc-resolver/pull/853)) (by @Boshen) - #853
+- do not canonicalize the entry path ([#848](https://github.com/oxc-project/oxc-resolver/pull/848)) (by @Boshen) - #848
+- remove Result from `CachedPathImpl::canonicalized` ([#847](https://github.com/oxc-project/oxc-resolver/pull/847)) (by @Boshen) - #847
+- fast path for node_modules/package ([#839](https://github.com/oxc-project/oxc-resolver/pull/839)) (by @Boshen) - #839
+- cache canonicalization results at every recursion level ([#843](https://github.com/oxc-project/oxc-resolver/pull/843)) (by @Boshen) - #843
+- use IdentityHasher for visited set to avoid double hashing ([#837](https://github.com/oxc-project/oxc-resolver/pull/837)) (by @Boshen) - #837
+
+### Contributors
+
+* @Boshen
+* @renovate[bot]
+
 ## [11.13.2](https://github.com/oxc-project/oxc-resolver/compare/v11.13.1...v11.13.2) - 2025-11-12
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "oxc_resolver"
-version = "11.13.2"
+version = "11.14.0"
 dependencies = [
  "cfg-if",
  "criterion2",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver_napi"
-version = "11.13.2"
+version = "11.14.0"
 dependencies = [
  "fancy-regex",
  "mimalloc-safe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rust-version = "1.88.0"
 description = "ESM / CJS module resolution"
 
 [workspace.dependencies]
-oxc_resolver = { version = "11.13.2", path = "." }
+oxc_resolver = { version = "11.14.0", path = "." }
 
 [package]
 name = "oxc_resolver"
-version = "11.13.2"
+version = "11.14.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/fixtures/tsconfck/node_modules/@tsconfig/node18
+++ b/fixtures/tsconfck/node_modules/@tsconfig/node18
@@ -1,1 +1,0 @@
-../../../../node_modules/.pnpm/@tsconfig+node18@18.2.6/node_modules/@tsconfig/node18

--- a/fixtures/tsconfck/node_modules/isaacscript-tsconfig
+++ b/fixtures/tsconfck/node_modules/isaacscript-tsconfig
@@ -1,1 +1,0 @@
-../../../node_modules/.pnpm/isaacscript-tsconfig@7.0.1/node_modules/isaacscript-tsconfig

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_resolver_napi"
-version = "11.13.2"
+version = "11.14.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/napi/index.js
+++ b/napi/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-android-arm64')
         const bindingPackageVersion = require('@oxc-resolver/binding-android-arm64/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-android-arm-eabi')
         const bindingPackageVersion = require('@oxc-resolver/binding-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-win32-x64-gnu')
         const bindingPackageVersion = require('@oxc-resolver/binding-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-win32-x64-msvc')
         const bindingPackageVersion = require('@oxc-resolver/binding-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-win32-ia32-msvc')
         const bindingPackageVersion = require('@oxc-resolver/binding-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-win32-arm64-msvc')
         const bindingPackageVersion = require('@oxc-resolver/binding-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@oxc-resolver/binding-darwin-universal')
       const bindingPackageVersion = require('@oxc-resolver/binding-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-darwin-x64')
         const bindingPackageVersion = require('@oxc-resolver/binding-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-darwin-arm64')
         const bindingPackageVersion = require('@oxc-resolver/binding-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-freebsd-x64')
         const bindingPackageVersion = require('@oxc-resolver/binding-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-freebsd-arm64')
         const bindingPackageVersion = require('@oxc-resolver/binding-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-x64-musl')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-x64-gnu')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-arm64-musl')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-arm64-gnu')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-arm-musleabihf')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-loong64-musl')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-loong64-gnu')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-riscv64-musl')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@oxc-resolver/binding-linux-riscv64-gnu')
           const bindingPackageVersion = require('@oxc-resolver/binding-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-linux-ppc64-gnu')
         const bindingPackageVersion = require('@oxc-resolver/binding-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-linux-s390x-gnu')
         const bindingPackageVersion = require('@oxc-resolver/binding-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-openharmony-arm64')
         const bindingPackageVersion = require('@oxc-resolver/binding-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-openharmony-x64')
         const bindingPackageVersion = require('@oxc-resolver/binding-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@oxc-resolver/binding-openharmony-arm')
         const bindingPackageVersion = require('@oxc-resolver/binding-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '11.13.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.13.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxc-resolver",
-  "version": "11.13.2",
+  "version": "11.14.0",
   "license": "MIT",
   "description": "Oxc Resolver Node API",
   "packageManager": "pnpm@10.23.0",


### PR DESCRIPTION



## 🤖 New release

* `oxc_resolver`: 11.13.2 -> 11.14.0
* `oxc_resolver_napi`: 11.13.2 -> 11.14.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `oxc_resolver`

<blockquote>

## [11.14.0](https://github.com/oxc-project/oxc-resolver/compare/v11.13.2...v11.14.0) - 2025-11-24

### <!-- 0 -->🚀 Features

- add `resolve_file` API for tsconfig auto discovery to work ([#860](https://github.com/oxc-project/oxc-resolver/pull/860)) (by @Boshen) - #860
- port tsconfck (find tsconfig files) ([#854](https://github.com/oxc-project/oxc-resolver/pull/854)) (by @Boshen) - #854
- add many.rs example for profiling resolver with many packages ([#836](https://github.com/oxc-project/oxc-resolver/pull/836)) (by @Boshen) - #836

### <!-- 1 -->🐛 Bug Fixes

- apply `conditionNames: ['node', 'import']` when resolving tsconfig extends ([#869](https://github.com/oxc-project/oxc-resolver/pull/869)) (by @Boshen) - #869
- do not resolve to `node_modules/pacakge/index` ([#849](https://github.com/oxc-project/oxc-resolver/pull/849)) (by @Boshen) - #849
- use std::fs::canonicalize as a fallback when canonicalize fails ([#835](https://github.com/oxc-project/oxc-resolver/pull/835)) (by @Boshen) - #835

### <!-- 2 -->🚜 Refactor

- remove the redundant `inner_resolver` from `load_pnp` ([#862](https://github.com/oxc-project/oxc-resolver/pull/862)) (by @Boshen) - #862
- improve `Debug` and `Display` for `CachedPath` ([#861](https://github.com/oxc-project/oxc-resolver/pull/861)) (by @Boshen) - #861
- too_many_arguments = "allow" ([#863](https://github.com/oxc-project/oxc-resolver/pull/863)) (by @Boshen) - #863
- change Tsconfig::parse to accept owned string; add replace_bom_with_whitespace ([#859](https://github.com/oxc-project/oxc-resolver/pull/859)) (by @Boshen) - #859
- remove the useless getters and setters from `CompilerOptions` ([#858](https://github.com/oxc-project/oxc-resolver/pull/858)) (by @Boshen) - #858
- add `Tsconfig:references_resolved` ([#856](https://github.com/oxc-project/oxc-resolver/pull/856)) (by @Boshen) - #856
- move tsconfig resolution related code to its own file ([#855](https://github.com/oxc-project/oxc-resolver/pull/855)) (by @Boshen) - #855
- use RwLock<Vec<Arc<PackageJson>> for package.json storage ([#838](https://github.com/oxc-project/oxc-resolver/pull/838)) (by @Boshen) - #838
- do not store is_symlink in CachedPathImpl ([#850](https://github.com/oxc-project/oxc-resolver/pull/850)) (by @Boshen) - #850
- remove CachedPathImpl::canonicaling ([#834](https://github.com/oxc-project/oxc-resolver/pull/834)) (by @Boshen) - #834

### <!-- 4 -->⚡ Performance

- cache all package.json resolutions for faster package.json lookup ([#853](https://github.com/oxc-project/oxc-resolver/pull/853)) (by @Boshen) - #853
- do not canonicalize the entry path ([#848](https://github.com/oxc-project/oxc-resolver/pull/848)) (by @Boshen) - #848
- remove Result from `CachedPathImpl::canonicalized` ([#847](https://github.com/oxc-project/oxc-resolver/pull/847)) (by @Boshen) - #847
- fast path for node_modules/package ([#839](https://github.com/oxc-project/oxc-resolver/pull/839)) (by @Boshen) - #839
- cache canonicalization results at every recursion level ([#843](https://github.com/oxc-project/oxc-resolver/pull/843)) (by @Boshen) - #843
- use IdentityHasher for visited set to avoid double hashing ([#837](https://github.com/oxc-project/oxc-resolver/pull/837)) (by @Boshen) - #837

### Contributors

* @Boshen
* @renovate[bot]
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).