### PR TITLE
perf: use IdentityHasher for visited set to avoid double hashing

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -230,7 +230,8 @@ impl<Fs: FileSystem> Cache<Fs> {
         // The Result is stored inside the OnceLock to cache both success and failure cases.
         let result = path.canonicalized.get_or_init(|| {
             // Each canonicalization chain gets its own visited set for circular symlink detection
-            let mut visited = StdHashSet::new();
+            let mut visited =
+                StdHashSet::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
             self.canonicalize_with_visited(path, &mut visited).map(|cp| Arc::downgrade(&cp.0))
         });
 
@@ -252,7 +253,7 @@ impl<Fs: FileSystem> Cache<Fs> {
     fn canonicalize_with_visited(
         &self,
         path: &CachedPath,
-        visited: &mut StdHashSet<u64>,
+        visited: &mut StdHashSet<u64, BuildHasherDefault<IdentityHasher>>,
     ) -> Result<CachedPath, ResolveError> {
         // Check for circular symlink by tracking visited paths in the current canonicalization chain
         if !visited.insert(path.hash) {


### PR DESCRIPTION
## Summary

- Replace `FxHashSet<u64>` with `HashSet<u64, BuildHasherDefault<IdentityHasher>>` for the visited set in canonicalization
- Avoids double hashing since the stored values are already hash values (`u64`)
- Consistent with the existing usage of `IdentityHasher` for `HashSet<CachedPath>` in the same file

## Test plan

- ✅ All existing tests pass (`cargo test --lib`)
- ✅ No clippy warnings (`cargo clippy --all-targets -- --deny warnings`)
- ✅ Code compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)