### PR TITLE
perf: fast path for node_modules/package

### DIFF
--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -125,20 +125,6 @@ fn resolve_hash_as_module() {
 }
 
 #[test]
-fn prefer_file_over_dir() {
-    let f = super::fixture_root().join("prefer-file-over-dir");
-    let resolver = Resolver::default();
-    let data = [
-        ("one level package name", f.clone(), "bar", f.join("node_modules/bar.js")),
-        ("scoped level package name", f.clone(), "@foo/bar", f.join("node_modules/@foo/bar.js")),
-    ];
-    for (comment, path, request, expected) in data {
-        let resolved_path = resolver.resolve(&path, request).map(|r| r.full_path());
-        assert_eq!(resolved_path, Ok(expected), "{comment} {path:?} {request}");
-    }
-}
-
-#[test]
 fn resolve_edge_cases() {
     let f = super::fixture();
     let resolver = Resolver::default();


### PR DESCRIPTION
In cjs, the spec states

```
LOAD_NODE_MODULES(X, START)
1. let DIRS = NODE_MODULES_PATHS(START)
2. for each DIR in DIRS:
   a. LOAD_PACKAGE_EXPORTS(X, DIR)
   b. LOAD_AS_FILE(DIR/X)
   c. LOAD_AS_DIRECTORY(DIR/X)
```

`2.b. LOAD_AS_FILE(DIR/X)` never occurs in modern package managers, and I do not recall any circumstance that creates a lone `node_modules/X.js` file.

This reduces a package lookup from

```
node_modules/X.js
node_modules/X.json
node_modules/X.node
node_modules/X/index.js
```

to

```
node_modules/X/
(if X failed)
node_modules/X.js
node_modules/X.json
node_modules/X.node
```

NOTE: ESM does not have `LOAD_AS_FILE(DIR/X)` logic.

---

This change was introduced from

- `https://github.com/oxc-project/oxc-resolver/pull/592`
- `https://github.com/unrs/unrs-resolver/pull/116`

These PRs do not explain a real case for `node_modules/X.js` to accept such performance regression. 