### PR TITLE
perf: make CachedPathImpl::meta eager

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -61,6 +61,7 @@ impl<Fs: FileSystem> Cache<Fs> {
             is_node_modules,
             inside_node_modules,
             parent_weak,
+            &self.fs,
         )));
         paths.insert(cached_path.clone());
         cached_path
@@ -78,8 +79,9 @@ impl<Fs: FileSystem> Cache<Fs> {
         }
     }
 
+    #[allow(clippy::unused_self)]
     pub(crate) fn is_file(&self, path: &CachedPath, ctx: &mut Ctx) -> bool {
-        if let Some(meta) = path.meta(&self.fs) {
+        if let Some(meta) = path.meta() {
             ctx.add_file_dependency(path.path());
             meta.is_file
         } else {
@@ -88,8 +90,9 @@ impl<Fs: FileSystem> Cache<Fs> {
         }
     }
 
+    #[allow(clippy::unused_self)]
     pub(crate) fn is_dir(&self, path: &CachedPath, ctx: &mut Ctx) -> bool {
-        path.meta(&self.fs).map_or_else(
+        path.meta().map_or_else(
             || {
                 ctx.add_missing_dependency(path.path());
                 false


### PR DESCRIPTION
## Summary

This PR changes the `meta` field in `CachedPathImpl` from lazy initialization to eager initialization, computing file metadata immediately when a `CachedPath` is created.

## Changes

- **`CachedPathImpl` struct**: Changed `meta: OnceLock<Option<FileMetadata>>` to `meta: Option<FileMetadata>`
- **`CachedPathImpl::new()` constructor**: Added `FileSystem` parameter and eagerly compute metadata during construction
- **`CachedPath::meta()` accessor**: Simplified to return the stored value directly without requiring a `FileSystem` parameter
- **Call sites**: Updated to pass `FileSystem` to constructor and removed it from `meta()` calls

## Benefits

- **Performance**: Eliminates lazy initialization overhead on every metadata access
- **Simpler API**: The `meta()` method no longer requires a `FileSystem` parameter
- **More predictable**: Metadata is computed once at construction time, making performance characteristics more consistent

## Testing

All existing tests pass:
- ✅ 151 unit tests
- ✅ 12 integration tests  
- ✅ 11 resolve tests
- ✅ Clippy with strict warnings
- ✅ Documentation builds without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)