### PR TITLE
refactor: do not store is_symlink in CachedPathImpl

### DIFF
--- a/examples/many.rs
+++ b/examples/many.rs
@@ -52,10 +52,7 @@ fn main() {
         }
     }
 
-    // Initialize resolver
     let options = ResolveOptions {
-        alias_fields: vec![vec!["browser".into()]],
-        // ESM
         condition_names: vec!["node".into(), "import".into()],
         ..ResolveOptions::default()
     };

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -79,9 +79,9 @@ impl<Fs: FileSystem> Cache<Fs> {
     }
 
     pub(crate) fn is_file(&self, path: &CachedPath, ctx: &mut Ctx) -> bool {
-        if let Some(meta) = path.meta(&self.fs) {
+        if path.is_file(&self.fs).is_some_and(|b| b) {
             ctx.add_file_dependency(path.path());
-            meta.is_file
+            true
         } else {
             ctx.add_missing_dependency(path.path());
             false
@@ -89,12 +89,12 @@ impl<Fs: FileSystem> Cache<Fs> {
     }
 
     pub(crate) fn is_dir(&self, path: &CachedPath, ctx: &mut Ctx) -> bool {
-        path.meta(&self.fs).map_or_else(
+        path.is_dir(&self.fs).map_or_else(
             || {
                 ctx.add_missing_dependency(path.path());
                 false
             },
-            |meta| meta.is_dir,
+            |b| b,
         )
     }
 


### PR DESCRIPTION
`std::fs::metadata` always return `is_symlink: false` so it's confusing
and pointless to store it in CachedPathImpl