### PR TITLE
feat: add `resolve_file` API for tsconfig auto discovery to work

### DIFF
--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -219,7 +219,7 @@ fn alias_is_full_path() {
     ];
 
     for specifier in specifiers {
-        let resolution = resolver.resolve_with_context(&f, &specifier, &mut ctx);
+        let resolution = resolver.resolve_with_context(&f, &specifier, None, &mut ctx);
         assert_eq!(resolution.map(|r| r.full_path()), Ok(dir.join("index.js")));
     }
 

--- a/src/tests/dependencies.rs
+++ b/src/tests/dependencies.rs
@@ -93,7 +93,7 @@ mod test {
             let mut ctx = ResolveContext::default();
             let path = PathBuf::from(context);
             let resolved_path =
-                resolver.resolve_with_context(path, request, &mut ctx).map(|r| r.full_path());
+                resolver.resolve_with_context(path, request, None, &mut ctx).map(|r| r.full_path());
             assert_eq!(resolved_path, Ok(PathBuf::from(result)));
             let file_dependencies = file_dependencies.iter().map(PathBuf::from).collect();
             let missing_dependencies = missing_dependencies.iter().map(PathBuf::from).collect();

--- a/src/tests/exports_field.rs
+++ b/src/tests/exports_field.rs
@@ -2554,6 +2554,7 @@ fn test_cases() {
                 &cached_path,
                 case.request,
                 &case.exports_field,
+                None,
                 &mut Ctx::default(),
             )
             .map(|p| p.map(|p| p.to_path_buf()));

--- a/src/tests/extensions.rs
+++ b/src/tests/extensions.rs
@@ -51,7 +51,7 @@ fn default_enforce_extension() {
         extensions: vec![".ts".into(), String::new(), ".js".into()],
         ..ResolveOptions::default()
     })
-    .resolve_with_context(&f, "./foo", &mut ctx);
+    .resolve_with_context(&f, "./foo", None, &mut ctx);
 
     assert_eq!(resolved.map(Resolution::into_path_buf), Ok(f.join("foo.ts")));
     assert_eq!(
@@ -72,7 +72,7 @@ fn respect_enforce_extension() {
         extensions: vec![".ts".into(), String::new(), ".js".into()],
         ..ResolveOptions::default()
     })
-    .resolve_with_context(&f, "./foo", &mut ctx);
+    .resolve_with_context(&f, "./foo", None, &mut ctx);
 
     assert_eq!(resolved.map(Resolution::into_path_buf), Ok(f.join("foo.ts")));
     assert_eq!(

--- a/src/tests/imports_field.rs
+++ b/src/tests/imports_field.rs
@@ -1325,6 +1325,7 @@ fn test_cases() {
                 &cached_path,
                 true,
                 &case.condition_names.iter().map(ToString::to_string).collect::<Vec<_>>(),
+                None,
                 &mut Ctx::default(),
             )
             .map(|p| p.map(|p| p.to_path_buf()));

--- a/src/tests/incorrect_description_file.rs
+++ b/src/tests/incorrect_description_file.rs
@@ -10,7 +10,7 @@ fn incorrect_description_file_1() {
     let f = super::fixture().join("incorrect-package");
     let mut ctx = ResolveContext::default();
     let error =
-        Resolver::default().resolve_with_context(f.join("pack1"), ".", &mut ctx).unwrap_err();
+        Resolver::default().resolve_with_context(f.join("pack1"), ".", None, &mut ctx).unwrap_err();
     match error {
         ResolveError::Json(e) => {
             assert_eq!(e.path, f.join("pack1/package.json"));

--- a/src/tests/missing.rs
+++ b/src/tests/missing.rs
@@ -49,7 +49,7 @@ fn test() {
 
     for (specifier, missing_dependencies) in data {
         let mut ctx = ResolveContext::default();
-        let _ = resolver.resolve_with_context(&f, specifier, &mut ctx);
+        let _ = resolver.resolve_with_context(&f, specifier, None, &mut ctx);
 
         for path in ctx.file_dependencies {
             assert_eq!(path, path.normalize(), "{path:?}");
@@ -87,8 +87,8 @@ fn alias_and_extensions() {
     });
 
     let mut ctx = ResolveContext::default();
-    let _ = resolver.resolve_with_context(&f, "@scope-js/package-name/dir/router", &mut ctx);
-    let _ = resolver.resolve_with_context(&f, "react-dom/client", &mut ctx);
+    let _ = resolver.resolve_with_context(&f, "@scope-js/package-name/dir/router", None, &mut ctx);
+    let _ = resolver.resolve_with_context(&f, "react-dom/client", None, &mut ctx);
 
     for path in ctx.file_dependencies {
         assert_eq!(path, path.normalize(), "{path:?}");

--- a/src/tests/tsconfck.rs
+++ b/src/tests/tsconfck.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use walkdir::WalkDir;
 
-use crate::Resolver;
+use crate::{ResolveOptions, Resolver, TsconfigDiscovery};
 
 fn walk(dir: &PathBuf) -> Vec<PathBuf> {
     WalkDir::new(dir)
@@ -84,7 +84,10 @@ fn part_of_solution() {
         ("referenced-exclude", "src/bar.ts", "tsconfig.bar.json"),
     ];
 
-    let resolver = Resolver::default();
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
     for (dir, specifier, expected) in pass {
         let dir = root.join(dir);
         let tsconfig = resolver.find_tsconfig(dir.join(specifier)).unwrap().unwrap();
@@ -96,7 +99,10 @@ fn part_of_solution() {
 #[test]
 fn find() {
     let dir = super::fixture_root().join("tsconfck").join("find").join("a");
-    let resolver = Resolver::default();
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
 
     let result = resolver.find_tsconfig(dir.join("foo.ts"));
     let path = result.map(|tsconfig| tsconfig.unwrap().path().to_path_buf());

--- a/src/tests/tsconfig_discovery.rs
+++ b/src/tests/tsconfig_discovery.rs
@@ -20,6 +20,6 @@ fn tsconfig_discovery_virtual_file_importer() {
     });
 
     let resolved_path =
-        resolver.resolve("\0virtual-module", "random-import").map(|f| f.full_path());
+        resolver.resolve_file("\0virtual-module/foo.js", "random-import").map(|f| f.full_path());
     assert_eq!(resolved_path, Err(ResolveError::NotFound("random-import".into())));
 }

--- a/src/tests/tsconfig_extends.rs
+++ b/src/tests/tsconfig_extends.rs
@@ -55,7 +55,8 @@ fn test_extend_tsconfig_paths() {
     });
 
     // Test that paths are resolved correctly after inheritance
-    let resolved_path = resolver.resolve(&f, "@/test").map(|f| f.full_path());
+    let resolved_path =
+        resolver.resolve_file(f.join("src").join("test.ts"), "@/test").map(|f| f.full_path());
     assert_eq!(resolved_path, Ok(f.join("src/test.ts")));
 }
 
@@ -93,7 +94,8 @@ fn test_extend_tsconfig_template_variables() {
     });
 
     // Test that template variables work correctly with extends
-    let resolved_path = resolver.resolve(&f, "@/utils").map(|f| f.full_path());
+    let resolved_path =
+        resolver.resolve_file(f.join("src/utils.ts"), "@/utils").map(|f| f.full_path());
     assert_eq!(resolved_path, Ok(f.join("src/utils.ts")));
 }
 

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -42,7 +42,7 @@ pub fn tsconfig_resolve_impl(tsconfig_discovery: bool) {
             ..ResolveOptions::default()
         });
         let path = subdir.map_or_else(|| dir.clone(), |subdir| dir.join(subdir));
-        let resolved_path = resolver.resolve(&path, request).map(|f| f.full_path());
+        let resolved_path = resolver.resolve_file(&path, request).map(|f| f.full_path());
         assert_eq!(resolved_path, Ok(expected), "{request} {path:?}");
     }
 
@@ -75,7 +75,7 @@ pub fn tsconfig_resolve_impl(tsconfig_discovery: bool) {
             }),
             ..ResolveOptions::default()
         });
-        let resolution = resolver.resolve(&path, request).map(|f| f.full_path());
+        let resolution = resolver.resolve_file(&path, request).map(|f| f.full_path());
         assert_eq!(resolution, expected, "{path:?} {request}");
     }
 }
@@ -97,7 +97,7 @@ fn tsconfig_fallthrough() {
         ..ResolveOptions::default()
     });
 
-    let resolved_path = resolver.resolve(&f, "/");
+    let resolved_path = resolver.resolve_file(&f, "/");
     assert_eq!(resolved_path, Err(ResolveError::NotFound("/".into())));
 }
 
@@ -113,7 +113,7 @@ fn json_with_comments() {
         ..ResolveOptions::default()
     });
 
-    let resolved_path = resolver.resolve(&f, "foo").map(|f| f.full_path());
+    let resolved_path = resolver.resolve_file(&f, "foo").map(|f| f.full_path());
     assert_eq!(resolved_path, Ok(f.join("bar.js")));
 }
 
@@ -129,7 +129,7 @@ fn with_bom() {
         ..ResolveOptions::default()
     });
 
-    let resolved_path = resolver.resolve(&f, "foo").map(|f| f.full_path());
+    let resolved_path = resolver.resolve_file(&f, "foo").map(|f| f.full_path());
     assert_eq!(resolved_path, Ok(f.join("bar.js")));
 }
 
@@ -145,7 +145,7 @@ fn broken() {
         ..ResolveOptions::default()
     });
 
-    let resolved_path = resolver.resolve(&f, "/");
+    let resolved_path = resolver.resolve_file(&f, "/");
     let error = ResolveError::Json(JSONError {
         path: f.join("tsconfig_broken.json"),
         message: String::from("EOF while parsing an object at line 2 column 0"),
@@ -167,7 +167,7 @@ fn empty() {
         ..ResolveOptions::default()
     });
 
-    let resolved_path = resolver.resolve(&f, "./index").map(|f| f.full_path());
+    let resolved_path = resolver.resolve_file(f.join("index.js"), "./index").map(|f| f.full_path());
     assert_eq!(resolved_path, Ok(f.join("index.js")));
 }
 
@@ -325,7 +325,8 @@ fn test_template_variable() {
             })),
             ..ResolveOptions::default()
         });
-        let resolved_path = resolver.resolve(&dir, request).map(|f| f.full_path());
+        let resolved_path =
+            resolver.resolve_file(dir.join("src").join("foo.js"), request).map(|f| f.full_path());
         assert_eq!(resolved_path, Ok(expected), "{request} {tsconfig} {dir:?}");
     }
 }
@@ -349,7 +350,7 @@ fn test_paths_nested_base() {
             })),
             ..ResolveOptions::default().with_extension(String::from(".ts"))
         });
-        let resolved_path = resolver.resolve(&dir, request).map(|f| f.full_path());
+        let resolved_path = resolver.resolve_file(&dir, request).map(|f| f.full_path());
         assert_eq!(resolved_path, Ok(expected), "{request} {tsconfig} {dir:?}");
     }
 }
@@ -373,7 +374,7 @@ fn test_parent_base_url() {
             })),
             ..ResolveOptions::default().with_extension(String::from(".ts"))
         });
-        let resolved_path = resolver.resolve(&dir, request).map(|f| f.full_path());
+        let resolved_path = resolver.resolve_file(&dir, request).map(|f| f.full_path());
         assert_eq!(resolved_path, expected, "{request} {tsconfig} {dir:?}");
     }
 }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -368,19 +368,21 @@ impl TsConfig {
         }
     }
 
-    /// Resolves the given `specifier` within the project configured by this
-    /// tsconfig, relative to the given `path`.
+    /// Resolves the given `specifier` within project references and then [CompilerOptions::paths].
     ///
     /// `specifier` can be either a real path or an alias.
     #[must_use]
-    pub(crate) fn resolve(&self, path: &Path, specifier: &str) -> Vec<PathBuf> {
-        let paths = self.resolve_path_alias(specifier);
+    pub(crate) fn resolve_references_then_self_paths(
+        &self,
+        path: &Path,
+        specifier: &str,
+    ) -> Vec<PathBuf> {
         for tsconfig in &self.references_resolved {
             if path.starts_with(tsconfig.base_path()) {
-                return [tsconfig.resolve_path_alias(specifier), paths].concat();
+                return tsconfig.resolve_path_alias(specifier);
             }
         }
-        paths
+        self.resolve_path_alias(specifier)
     }
 
     /// Resolves the given `specifier` within the project configured by this

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -110,6 +110,7 @@ fn dependencies() {
     let _ = Resolver::new(ResolveOptions::default()).resolve_with_context(
         path,
         "./tests/package.json",
+        None,
         &mut ctx,
     );
     assert!(!ctx.file_dependencies.is_empty());


### PR DESCRIPTION
Add a new API to make tsconfig paths work with the auto-discovered tsconfig.

```rust
    /// Resolve `specifier` for an absolute path to a file.
    ///
    /// NOTE: [TsconfigDiscovery::Auto] only work for this API, use `ResolverGeneric::resolve_file` instead.
    ///
    /// # Errors
    ///
    /// * See [ResolveError]
    ///
    /// # Panics
    ///
    /// * If the provided path is not a file.
    pub fn resolve_file<P: AsRef<Path>>(
        &self,
        file: P,
        specifier: &str,
    ) -> Result<Resolution, ResolveError> {
```

---

New concept:

Given an input file:

* There is always a tsconfig associated with this file, we call it the resolved tsconfig, or tsconfig solution (in tsconfck)
* When resolving path aliases, always use the resolved tsconfig.