### PR TITLE
fix: apply `conditionNames: ['node', 'import']` when resolving tsconfig extends

### DIFF
--- a/fixtures/tsconfig/cases/extends-esm/node_modules/@org/package/package.json
+++ b/fixtures/tsconfig/cases/extends-esm/node_modules/@org/package/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "@org/package",
+	"exports": {
+		".": {
+			"types": "./src/tsconfig.json",
+			"import": "./src/tsconfig.json",
+			"require": "./src/tsconfig.json"
+		}
+	}
+}

--- a/fixtures/tsconfig/cases/extends-esm/node_modules/@org/package/src/tsconfig.json
+++ b/fixtures/tsconfig/cases/extends-esm/node_modules/@org/package/src/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+  }
+}

--- a/fixtures/tsconfig/cases/extends-esm/tsconfig.json
+++ b/fixtures/tsconfig/cases/extends-esm/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"extends": ["@org/package"],
+	"compilerOptions": {
+	}
+}

--- a/fixtures/tsconfig/cases/extends-main/node_modules/@org/package/package.json
+++ b/fixtures/tsconfig/cases/extends-main/node_modules/@org/package/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "@org/package",
+	"main": "src/tsconfig.json"
+}

--- a/fixtures/tsconfig/cases/extends-main/node_modules/@org/package/src/tsconfig.json
+++ b/fixtures/tsconfig/cases/extends-main/node_modules/@org/package/src/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+  }
+}

--- a/fixtures/tsconfig/cases/extends-main/tsconfig.json
+++ b/fixtures/tsconfig/cases/extends-main/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"extends": ["@org/package"],
+	"compilerOptions": {
+	}
+}

--- a/src/tests/tsconfig_extends.rs
+++ b/src/tests/tsconfig_extends.rs
@@ -196,3 +196,24 @@ fn test_extend_tsconfig_no_override_existing() {
     // Parent's baseUrl should be inherited (with proper path resolution)
     assert!(compiler_options.base_url.is_some());
 }
+
+#[test]
+fn test_extend_package() {
+    let f = super::fixture_root().join("tsconfig/cases");
+
+    let data = ["extends-esm", "extends-main"];
+
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: f.join("tsconfig.json"),
+            references: TsconfigReferences::Auto,
+        })),
+        ..ResolveOptions::default()
+    });
+
+    for dir in data {
+        let resolution = resolver.resolve_tsconfig(f.join(dir)).expect("resolved");
+        let compiler_options = &resolution.compiler_options;
+        assert_eq!(compiler_options.target, Some("ES2020".to_string()));
+    }
+}

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -309,6 +309,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             _ => self
                 .clone_with_options(ResolveOptions {
                     tsconfig: None,
+                    condition_names: vec!["node".into(), "import".into()],
                     extensions: vec![".json".into()],
                     main_files: vec!["tsconfig".into()],
                     #[cfg(feature = "yarn_pnp")]


### PR DESCRIPTION
fixes #857