### PR TITLE
feat(napi): drop `armv7-unknown-linux-musleabihf` support

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -109,6 +109,9 @@ jobs:
           - os: ubuntu-latest
             target: wasm32-wasip1-threads
             build: pnpm run build:debug --release # omit --features allocator
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-ohos
+            build: pnpm build --target aarch64-unknown-linux-ohos
 
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -121,6 +124,10 @@ jobs:
           cpu: ${{ matrix.cpu }}
 
       - run: rustup target add ${{ matrix.target }}
+
+      - name: Setup OpenHarmony SDK
+        if: ${{ contains(matrix.target, 'ohos') }}
+        uses: Boshen/setup-ohos-sdk@edb865a89a712f1f15dbad932dfa9cfce849d95c # v1.0.0
 
       - uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
         if: ${{ contains(matrix.target, 'musl') }}

--- a/package.json
+++ b/package.json
@@ -47,25 +47,25 @@
       }
     },
     "targets": [
-      "x86_64-pc-windows-msvc",
-      "aarch64-pc-windows-msvc",
-      "i686-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-linux-musl",
-      "x86_64-unknown-freebsd",
+      "aarch64-apple-darwin",
       "aarch64-linux-android",
+      "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
       "aarch64-unknown-linux-musl",
+      "aarch64-unknown-linux-ohos",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabihf",
-      "armv7-unknown-linux-musleabihf",
+      "i686-pc-windows-msvc",
       "powerpc64le-unknown-linux-gnu",
       "riscv64gc-unknown-linux-gnu",
       "riscv64gc-unknown-linux-musl",
       "s390x-unknown-linux-gnu",
+      "wasm32-wasip1-threads",
       "x86_64-apple-darwin",
-      "aarch64-apple-darwin",
-      "wasm32-wasip1-threads"
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl"
     ]
   }
 }


### PR DESCRIPTION
Also add aarch64-unknown-linux-ohos support.

armv7-unknown-linux-musleabihf target is broken for a while (nodejs/node#53489) and is a legacy target.

closes #870