### PR TITLE
feat: allow subpath imports that start with #/

### DIFF
--- a/fixtures/enhanced-resolve/test/fixtures/imports-exports-wildcard/node_modules/m/package.json
+++ b/fixtures/enhanced-resolve/test/fixtures/imports-exports-wildcard/node_modules/m/package.json
@@ -12,6 +12,8 @@
     "./middle-5/*/$": "./src/middle-5/*/$.js"
   },
   "imports": {
-    "#internal/*.js": "./src/internal/*.js"
+    "#internal/*.js": "./src/internal/*.js",
+    "#/internal/*.js": "./src/internal/*.js",
+    "#/*": "./src/*"
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1611,7 +1611,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         for imports in package_json.imports_fields(&self.options.imports_fields) {
             if !has_imports {
                 has_imports = true;
-                if specifier == "#" || specifier.starts_with("#/") {
+                if specifier == "#" {
                     return Err(ResolveError::InvalidModuleSpecifier(
                         specifier.to_string(),
                         package_json.path().to_path_buf(),

--- a/src/tests/imports_field.rs
+++ b/src/tests/imports_field.rs
@@ -30,6 +30,9 @@ fn test_simple() {
         ("should resolve package #3", f.clone(), "#ccc/index.js", f.join("node_modules/c/index.js")),
         ("should resolve package #4", f.clone(), "#c", f.join("node_modules/c/index.js")),
         ("should resolve with wildcard pattern", f2.clone(), "#internal/i.js", f2.join("src/internal/i.js")),
+        ("wildcard #/path", f2.clone(), "#/internal/i.js", f2.join("src/internal/i.js")),
+        ("wildcard #/* 1", f2.clone(), "#/features/f", f2.join("src/features/f.js")),
+        ("wildcard #/* 2", f2.clone(), "#/features/y/y.js", f2.join("src/features/y/y.js")),
     ];
 
     for (comment, path, request, expected) in pass {
@@ -46,8 +49,6 @@ fn test_simple() {
         ("should disallow resolve out of package scope", f.clone(), "#b", ResolveError::InvalidPackageTarget("../b.js".to_string(), "#b".to_string(), f.join("package.json"))),
         ("should resolve package #2", f.clone(), "#a", ResolveError::PackageImportNotDefined("#a".to_string(), f.join("package.json"))),
         ("# is not allowed", f.clone(), "#", ResolveError::InvalidModuleSpecifier("#".to_string(), f.join("package.json"))),
-        ("#/ is not allowed", f.clone(), "#/", ResolveError::InvalidModuleSpecifier("#/".to_string(), f.join("package.json"))),
-        ("#/foo is not allowed", f.clone(), "#/foo", ResolveError::InvalidModuleSpecifier("#/foo".to_string(), f.join("package.json")))
     ];
 
     for (comment, path, request, error) in fail {


### PR DESCRIPTION
closes #904

This opens up the door to symmetric `exports` and `imports`:

package.json:

```
{
  "exports": {
    "./*": "./src/*"
  },
  "imports": {
    "#/*": "./src/*"
  }
}
```