### PR TITLE
Setup OIDC for CodSpeed authentication

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,6 +20,8 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for OIDC authentication with CodSpeed
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
 
@@ -40,4 +42,3 @@ jobs:
         with:
           run: cargo codspeed run
           mode: instrumentation
-          token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission at job level for OIDC authentication with CodSpeed
- Remove `token` parameter from CodSpeedHQ action (OIDC auth is now automatic)

This configures the workflow to use OpenID Connect (OIDC) for authentication with CodSpeed instead of using repository secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)