### PR TITLE
test: Add a test to ensure NODEJS_BUILTINS is alphabetized.

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -69,3 +69,11 @@ pub const NODEJS_BUILTINS: &[&str] = &[
     "worker_threads",
     "zlib",
 ];
+
+#[test]
+fn test_alphabetization() {
+    let mut sorted_builtins = NODEJS_BUILTINS.to_vec();
+    sorted_builtins.sort_unstable();
+
+    assert_eq!(sorted_builtins, NODEJS_BUILTINS);
+}


### PR DESCRIPTION
Just in case anyone adds a new one and makes a mistake...

This is used with binary_search in oxlint and the oxc-resolver crate itself, and so we need to make sure we have always sorted this static array, otherwise the binary_search can fail to find things.