### PR TITLE
Add additional Node builtins from v24.12.0

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -38,6 +38,7 @@ pub const NODEJS_BUILTINS: &[&str] = &[
     "http2",
     "https",
     "inspector",
+    "inspector/promises",
     "module",
     "net",
     "os",
@@ -49,6 +50,7 @@ pub const NODEJS_BUILTINS: &[&str] = &[
     "punycode",
     "querystring",
     "readline",
+    "readline/promises",
     "repl",
     "stream",
     "stream/consumers",
@@ -66,8 +68,13 @@ pub const NODEJS_BUILTINS: &[&str] = &[
     "util/types",
     "v8",
     "vm",
+    "wasi",
     "worker_threads",
     "zlib",
+    "node:sea",
+    "node:sqlite",
+    "node:test",
+    "node:test/reporters",
 ];
 
 #[test]


### PR DESCRIPTION
I have locally implemented the `import/no-unresolved` rule, but found that it was failing with some common Node builtins because this list was out of date. So this is an update of it from Node v24.12.0 using the command in the comments.

Once this is merged, I'll put up a PR for the new rule over in the `oxc` repo.