### PR TITLE
fix: show yarn pnp errors as-is instead of NotFound error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1058,7 +1058,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             }
 
             Ok(pnp::Resolution::Skipped) => Ok(None),
-            Err(_) => Err(ResolveError::NotFound(specifier.to_string())),
+            Err(err) => Err(ResolveError::YarnPnpError(err)),
         }
     }
 


### PR DESCRIPTION
Yarn pnp errors were output as NotFound and was a bit confusing.

Before:
```
{
  error: "Cannot find module 'use-sync-external-store/shim/with-selector.js'"
}
```

After:
```
{
  error: "zustand tried to access use-sync-external-store, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.\n" +
    '\n' +
    'Required package: use-sync-external-store (via "use-sync-external-store/shim/with-selector.js")\n' +
    'Required by: zustand@virtual:1c9ffcdd3c294d9f00a4700610b6eee225ba7496e9cf71f4e2c84e6a78adfb6d89ded76acac79698b89ce4168fbd26a40683c1459c3d813f8bbe6a6de1deb690#npm:5.0.9 (via /home/green/workspace/temp/oxc-resolver-yarn-pnp-bug/.yarn/__virtual__/zustand-virtual-88b9bb390c/4/.yarn/berry/cache/zustand-npm-5.0.9-1d6cab4a48-10c0.zip/node_modules/zustand/esm/)'
}
```

I got the message above by https://github.com/sapphi-red-repros/yarn-pnp-rust-error-message. It seems the error message is wrong as `require.resolve` shows
```
Error: zustand tried to access use-sync-external-store (a peer dependency) but it isn't provided by your application; this makes the require call ambiguous and unsound.

Required package: use-sync-external-store (via "use-sync-external-store/shim/with-selector.js")
Required by: zustand@virtual:1c9ffcdd3c294d9f00a4700610b6eee225ba7496e9cf71f4e2c84e6a78adfb6d89ded76acac79698b89ce4168fbd26a40683c1459c3d813f8bbe6a6de1deb690#npm:5.0.9 (via /home/green/workspace/temp/oxc-resolver-yarn-pnp-bug/.yarn/__virtual__/zustand-virtual-88b9bb390c/4/.yarn/berry/cache/zustand-npm-5.0.9-1d6cab4a48-10c0.zip/node_modules/zustand/esm/)
Ancestor breaking the chain: oxc-resolver-yarn-pnp-bug@workspace:.
```
But I think that's a separate problem.
