### PR TITLE
fix: only recreate the cache when `yarn_pnp` is toggled

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -4,3 +4,6 @@
 
 [files]
 extend-exclude = ["CHANGELOG.md"]
+
+[default.extend-identifiers]
+PnP = "PnP"


### PR DESCRIPTION
fixes #930