### PR TITLE
fix: resolve clippy unnecessary_unwrap warning

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.0"
 profile = "default"

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -350,9 +350,9 @@ impl TsConfig {
             }
         }
 
-        if self.compiler_options.paths.is_some() {
+        if let Some(paths_map) = &mut self.compiler_options.paths {
             // Substitute template variable in `tsconfig.compilerOptions.paths`.
-            for paths in self.compiler_options.paths.as_mut().unwrap().values_mut() {
+            for paths in paths_map.values_mut() {
                 for path in paths {
                     *path = if let Some(stripped_path) =
                         path.to_string_lossy().strip_prefix(TEMPLATE_VARIABLE)


### PR DESCRIPTION
## Summary
- Fix clippy `unnecessary_unwrap` warning in `src/tsconfig.rs`
- Use `if let Some(...)` pattern instead of `is_some()` followed by `unwrap()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)