### PR TITLE
chore(deps): update pnp to v0.12.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ simdutf8 = { version = "0.1" }
 thiserror = "2"
 tracing = "0.1"
 
-pnp = { version = "0.12.7", optional = true }
+pnp = { version = "0.12.8", optional = true }
 
 document-features = { version = "0.2.12", optional = true }
 


### PR DESCRIPTION
# Description

The lock file was updated by Renovate ([PR](https://github.com/oxc-project/oxc-resolver/pull/969)), but the `pnp` version in Cargo.toml still specifies `0.12.7`. This PR bumps the version so that downstream projects like rolldown can pick up the updated `pnp` crate.

refs: https://github.com/rolldown/rolldown/pull/8021#issuecomment-3788620359