### PR TITLE
perf: skip caching canonicalized paths when unchanged

### DIFF
--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -25,7 +25,10 @@ pub struct CachedPathImpl {
     pub is_node_modules: bool,
     pub inside_node_modules: bool,
     pub meta: OnceLock<Option<(/* is_file */ bool, /* is_dir */ bool)>>, // None means not found.
-    pub canonicalized: OnceLock<(Weak<Self>, PathBuf)>,
+    /// Cached canonicalization result.
+    /// - `None` means canonical path == self (no symlink in path), avoids PathBuf allocation
+    /// - `Some((weak, path))` means canonical path differs (symlink was resolved)
+    pub canonicalized: OnceLock<Option<(Weak<Self>, PathBuf)>>,
     pub node_modules: OnceLock<Option<Weak<Self>>>,
     pub package_json: OnceLock<Option<PackageJsonIndex>>,
     /// `tsconfig.json` found at path.


### PR DESCRIPTION
## Summary

- Only cache canonicalization results when the canonical path differs from the original path
- For non-symlink paths, `canonical(path) == path`, so caching is unnecessary
- Uses fast `as_os_str()` byte comparison instead of slower `Path` equality

This reduces cache size by ~63% in typical monorepo setups where most intermediate path components (like `/Users`, `/Users/name`, etc.) are not symlinks.

Closes #852

🤖 Generated with [Claude Code](https://claude.ai/code)