### PR TITLE
feat(resolver): support NODE_PATH environment variable

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -503,6 +503,9 @@ pub enum TsconfigReferences {
 
 impl Default for ResolveOptions {
     fn default() -> Self {
+        let mut modules = get_node_path_directories();
+        modules.push("node_modules".into());
+
         Self {
             cwd: None,
             tsconfig: None,
@@ -518,7 +521,7 @@ impl Default for ResolveOptions {
             fully_specified: false,
             main_fields: vec!["main".into()],
             main_files: vec!["index".into()],
-            modules: vec!["node_modules".into()],
+            modules,
             resolve_to_context: false,
             prefer_relative: false,
             prefer_absolute: false,
@@ -532,6 +535,42 @@ impl Default for ResolveOptions {
             yarn_pnp: std::env::var("OXC_RESOLVER_YARN_PNP").is_ok(),
         }
     }
+}
+
+/// Get directories from NODE_PATH environment variable for module resolution.
+///
+/// NODE_PATH is a colon-separated (Unix) or semicolon-separated (Windows) list of directories
+/// that Node.js and other Node tooling use as additional paths for module resolution.
+///
+/// This function parses NODE_PATH and returns a Vec of directory paths that can be used
+/// by the resolver to locate external plugins.
+///
+/// # Returns
+/// A vector of directory paths from NODE_PATH, or an empty vector if NODE_PATH is not set.
+fn get_node_path_directories() -> Vec<String> {
+    std::env::var("NODE_PATH").ok().map_or_else(Vec::new, |node_path| parse_node_path(&node_path))
+}
+
+/// Parse NODE_PATH string into a vector of directory paths.
+///
+/// # Arguments
+/// * `node_path` - The NODE_PATH environment variable value
+///
+/// # Returns
+/// A vector of directory paths, or an empty vector if node_path is empty.
+fn parse_node_path(node_path: &str) -> Vec<String> {
+    if node_path.is_empty() {
+        return Vec::new();
+    }
+
+    // On Unix/Mac, NODE_PATH uses colon as separator
+    // On Windows, NODE_PATH uses semicolon as separator
+    #[cfg(target_family = "unix")]
+    let separator = ':';
+    #[cfg(target_family = "windows")]
+    let separator = ';';
+
+    node_path.split(separator).filter(|path| !path.is_empty()).map(String::from).collect()
 }
 
 // For tracing
@@ -694,5 +733,107 @@ mod test {
         };
 
         assert_eq!(format!("{options}"), "");
+    }
+
+    #[test]
+    fn test_parse_node_path_empty() {
+        // Test with empty string
+        let dirs = super::parse_node_path("");
+        assert!(dirs.is_empty());
+    }
+
+    #[test]
+    fn test_parse_node_path_single_path() {
+        // Test with a single path
+        #[cfg(target_family = "unix")]
+        let test_path = "/usr/local/lib/node_modules";
+        #[cfg(target_family = "windows")]
+        let test_path = "C:\\nodejs\\node_modules";
+
+        let dirs = super::parse_node_path(test_path);
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0], test_path);
+    }
+
+    #[test]
+    fn test_parse_node_path_multiple_paths() {
+        // Test with multiple paths using platform-specific separator
+        #[cfg(target_family = "unix")]
+        {
+            let test_paths =
+                "/usr/local/lib/node_modules:/home/user/.node_modules:/opt/node_modules";
+            let dirs = super::parse_node_path(test_paths);
+            assert_eq!(dirs.len(), 3);
+            assert_eq!(dirs[0], "/usr/local/lib/node_modules");
+            assert_eq!(dirs[1], "/home/user/.node_modules");
+            assert_eq!(dirs[2], "/opt/node_modules");
+        }
+        #[cfg(target_family = "windows")]
+        {
+            let test_paths =
+                "C:\\nodejs\\node_modules;D:\\project\\node_modules;E:\\global\\node_modules";
+            let dirs = super::parse_node_path(test_paths);
+            assert_eq!(dirs.len(), 3);
+            assert_eq!(dirs[0], "C:\\nodejs\\node_modules");
+            assert_eq!(dirs[1], "D:\\project\\node_modules");
+            assert_eq!(dirs[2], "E:\\global\\node_modules");
+        }
+    }
+
+    #[test]
+    fn test_parse_node_path_with_empty_entries() {
+        // Test with empty entries (consecutive separators)
+        #[cfg(target_family = "unix")]
+        {
+            let test_paths = "/usr/local/lib/node_modules::/home/user/.node_modules";
+            let dirs = super::parse_node_path(test_paths);
+            assert_eq!(dirs.len(), 2); // Empty entries should be filtered out
+            assert_eq!(dirs[0], "/usr/local/lib/node_modules");
+            assert_eq!(dirs[1], "/home/user/.node_modules");
+        }
+        #[cfg(target_family = "windows")]
+        {
+            let test_paths = "C:\\nodejs\\node_modules;;D:\\project\\node_modules";
+            let dirs = super::parse_node_path(test_paths);
+            assert_eq!(dirs.len(), 2); // Empty entries should be filtered out
+            assert_eq!(dirs[0], "C:\\nodejs\\node_modules");
+            assert_eq!(dirs[1], "D:\\project\\node_modules");
+        }
+    }
+
+    #[test]
+    fn test_parse_node_path_trailing_separator() {
+        // Test with trailing separator
+        #[cfg(target_family = "unix")]
+        {
+            let test_paths = "/usr/local/lib/node_modules:/home/user/.node_modules:";
+            let dirs = super::parse_node_path(test_paths);
+            assert_eq!(dirs.len(), 2);
+            assert_eq!(dirs[0], "/usr/local/lib/node_modules");
+            assert_eq!(dirs[1], "/home/user/.node_modules");
+        }
+        #[cfg(target_family = "windows")]
+        {
+            let test_paths = "C:\\nodejs\\node_modules;D:\\project\\node_modules;";
+            let dirs = super::parse_node_path(test_paths);
+            assert_eq!(dirs.len(), 2);
+            assert_eq!(dirs[0], "C:\\nodejs\\node_modules");
+            assert_eq!(dirs[1], "D:\\project\\node_modules");
+        }
+    }
+
+    #[test]
+    fn test_node_path_in_default_options() {
+        // Test that NODE_PATH directories are included in default options
+        // When NODE_PATH is not set, modules should just contain "node_modules"
+        let options = ResolveOptions::default();
+
+        // The last module should always be "node_modules"
+        assert_eq!(options.modules.last(), Some(&"node_modules".to_string()));
+
+        // If NODE_PATH was set, there would be additional entries before "node_modules"
+        // Since we can't control NODE_PATH in tests reliably, we just verify
+        // that node_modules is present
+        assert!(options.modules.contains(&"node_modules".to_string()));
     }
 }


### PR DESCRIPTION
Fix https://github.com/oxc-project/oxc/issues/18004
This change adds support for the NODE_PATH environment variable for module resolution. NODE_PATH is a colon-separated (Unix) or semicolon-separated (Windows) list of directories that Node.js and other Node tooling use as additional paths for module resolution.

Changes:
- Added `get_node_path_directories()` helper function to read NODE_PATH env var
- Added `parse_node_path()` helper function to parse the NODE_PATH string with platform-specific separators (colon for Unix/Mac, semicolon for Windows)
- Updated `ResolveOptions::default()` to include NODE_PATH directories in the `modules` field before "node_modules"
- Added comprehensive tests for NODE_PATH parsing including:
  - Empty paths
  - Single and multiple paths
  - Empty entries (consecutive separators)
  - Trailing separators

Ported from: https://github.com/oxc-project/oxc/pull/19385