### PR TITLE
perf: reduce PathBuf allocations in resolution pipeline

### DIFF
--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -24,7 +24,7 @@ pub struct CachedPathImpl {
     pub is_node_modules: bool,
     pub inside_node_modules: bool,
     pub meta: OnceLock<Option<(/* is_file */ bool, /* is_dir */ bool)>>, // None means not found.
-    pub canonicalized: OnceLock<(Weak<Self>, PathBuf)>,
+    pub canonicalized: OnceLock<(Weak<Self>, Box<Path>)>,
     pub node_modules: OnceLock<Option<Weak<Self>>>,
     pub package_json: OnceLock<Option<Arc<PackageJson>>>,
     /// `tsconfig.json` found at path.

--- a/src/tests/resolution.rs
+++ b/src/tests/resolution.rs
@@ -1,11 +1,16 @@
 use std::path::{Path, PathBuf};
 
-use crate::Resolution;
+use crate::{Cache, FileSystem as _, FileSystemOs, Resolution};
 
 #[test]
 fn test() {
+    #[cfg(feature = "yarn_pnp")]
+    let cache = Cache::new(FileSystemOs::new(false));
+    #[cfg(not(feature = "yarn_pnp"))]
+    let cache = Cache::new(FileSystemOs::new());
+    let cached_path = cache.value(Path::new("foo"));
     let resolution = Resolution {
-        path: PathBuf::from("foo"),
+        cached_path,
         query: Some("?query".to_string()),
         fragment: Some("#fragment".to_string()),
         package_json: None,


### PR DESCRIPTION
- Use `Box::from(path)` instead of `path.to_path_buf().into_boxed_path()`
  in `Cache::value()` to avoid intermediate PathBuf allocation
- Change `Resolution` to store `CachedPath` instead of `PathBuf`, deferring
  the PathBuf allocation to callers who actually need owned paths
- Change `canonicalize()` and `load_realpath()` to return `CachedPath`
  instead of `PathBuf`, avoiding unnecessary cloning
- Store `Box<Path>` instead of `PathBuf` in canonicalized cache fallback

In a 10K module rolldown benchmark, this eliminates ~87K `to_path_buf`
allocations (10.7 MB) from the resolution pipeline, reducing them to
effectively zero.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a perf-driven type/ownership refactor across the resolver’s core path plumbing; low behavioral intent but subtle changes around canonicalization and path equality/formatting could surface platform-specific regressions (notably Windows/symlinks).
> 
> **Overview**
> Reduces allocation churn in the resolution pipeline by switching from owned `PathBuf` returns to cached `CachedPath` values, including updating `Resolution` to store a `CachedPath` and only materializing a `PathBuf` on demand.
> 
> Updates cache internals to avoid intermediate `PathBuf` creation (`Box::from(path)` in `Cache::value`) and to store canonicalization fallbacks as `Box<Path>`; adjusts Windows canonicalization prefix-stripping to re-enter the cache. Tests and tracing were updated to use the new `Resolution`/realpath APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 924d4d74dadd948322f318bcf6f9d21225deaaa8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->