### PR TITLE
perf: add `nearest_tsconfig` cache to avoid redundant directory walks

### DIFF
--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -31,6 +31,9 @@ pub struct CachedPathImpl {
     pub tsconfig: OnceLock<Option<Arc<TsConfig>>>,
     /// `tsconfig.json` after resolving `references`, `files`, `include` and `extend`.
     pub resolved_tsconfig: OnceLock<Option<Arc<TsConfig>>>,
+    /// Cached result of `find_tsconfig_auto` walk from this directory upward.
+    /// Only accessed via `get()`/`set()` to avoid deadlocks.
+    pub nearest_tsconfig: OnceLock<Option<Arc<TsConfig>>>,
 }
 
 impl CachedPathImpl {
@@ -53,6 +56,7 @@ impl CachedPathImpl {
             package_json: OnceLock::new(),
             tsconfig: OnceLock::new(),
             resolved_tsconfig: OnceLock::new(),
+            nearest_tsconfig: OnceLock::new(),
         }
     }
 }

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -70,11 +70,11 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         if !cached_path.path.is_absolute() {
             return Ok(None);
         }
-        let span = tracing::debug_span!("find_tsconfig", path = %cached_path);
-        let _enter = span.enter();
         cached_path
             .resolved_tsconfig
             .get_or_try_init(|| {
+                let span = tracing::debug_span!("find_tsconfig", path = %cached_path);
+                let _enter = span.enter();
                 self.find_tsconfig_impl(cached_path).map(|option_tsconfig| {
                     option_tsconfig.map(|tsconfig| {
                         let r = TsConfig::resolve_tsconfig_solution(tsconfig, cached_path.path());
@@ -108,7 +108,21 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     ) -> Result<Option<Arc<TsConfig>>, ResolveError> {
         let mut ctx = Ctx::default();
         let mut cache_value = Some(cached_path.clone());
+        // Track visited paths to propagate the walk result back.
+        // After a walk completes, all visited paths get the result cached in `nearest_tsconfig`.
+        // Future walks that reach any of these paths short-circuit in O(1).
+        // Pre allocate 8 slots for the most common cases.
+        let mut visited: Vec<CachedPath> = Vec::with_capacity(8);
         while let Some(cv) = cache_value {
+            // if a previous walk already resolved this path,
+            // reuse that result and propagate to everything we visited on the way here.
+            if let Some(result) = cv.nearest_tsconfig.get() {
+                for v in &visited {
+                    v.nearest_tsconfig.get_or_init(|| result.clone());
+                }
+                return Ok(result.clone());
+            }
+            visited.push(cv.clone());
             if let Some(tsconfig) = cv.tsconfig.get_or_try_init(|| {
                 let tsconfig_path = cv.path.join("tsconfig.json");
                 let tsconfig_path = self.cache.value(&tsconfig_path);
@@ -124,9 +138,17 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                     Ok(None)
                 }
             })? {
-                return Ok(Some(Arc::clone(tsconfig)));
+                let result = Some(Arc::clone(tsconfig));
+                for v in &visited {
+                    v.nearest_tsconfig.get_or_init(|| result.clone());
+                }
+                return Ok(result);
             }
             cache_value = cv.parent(&self.cache);
+        }
+        // No tsconfig found — propagate None to all visited paths.
+        for v in &visited {
+            v.nearest_tsconfig.get_or_init(|| None);
         }
         Ok(None)
     }


### PR DESCRIPTION
## Problem

`find_tsconfig_auto` walks from a file up to `/` checking each directory. Without `nearest_tsconfig`, sibling files repeat the same walk:

```
src/d0/f0.jsx  →  walk d0/ → src/ → project/ → /  →  None   (12 hops)
src/d0/f1.jsx  →  walk d0/ → src/ → project/ → /  →  None   (12 hops, identical)
src/d0/f2.jsx  →  walk d0/ → src/ → project/ → /  →  None   (12 hops, identical)
```

## Solution

After a walk completes, propagate the result to every path visited. Future walks short-circuit when they hit a cached path.

```
Call 1: find_tsconfig("src/d0/f0.jsx")

  Visit f0.jsx → d0/ → src/ → project/ → ... → /   (full walk, 12 hops)
  Result: None
  Propagate: set nearest_tsconfig = None on f0.jsx, d0/, src/, project/, ...

Call 2: find_tsconfig("src/d0/f1.jsx")

  Visit f1.jsx → d0/ has nearest_tsconfig = None → STOP   (2 hops)

Call 3: find_tsconfig("src/d1/f0.jsx")

  Visit f0.jsx → d1/ → src/ has nearest_tsconfig = None → STOP   (3 hops)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a localized performance optimization to tsconfig discovery, with the main risk being incorrect cache propagation causing a path to reuse the wrong (or missing) `tsconfig` result.
> 
> **Overview**
> **Speeds up automatic `tsconfig.json` discovery** by caching the nearest walk result per `CachedPath`.
> 
> Adds a new `CachedPath.nearest_tsconfig` `OnceLock` and updates `find_tsconfig_auto` to record visited ancestors, short-circuit when any ancestor already has `nearest_tsconfig`, and propagate the final `Some(tsconfig)`/`None` result back to all visited paths to avoid redundant directory traversals for sibling files.
> 
> Moves creation of the `find_tsconfig` tracing span inside the `resolved_tsconfig.get_or_try_init` closure so span setup only happens on the cache-miss path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b77738b264b92d8813a529c26ef229d39fe4680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->