### PR TITLE
fix: strip query and fragment before finding matched tsconfig file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,7 @@ dependencies = [
  "fast-glob",
  "indexmap",
  "json-strip-comments",
+ "memchr",
  "nodejs-built-in-modules",
  "once_cell",
  "papaya",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ cfg-if = "1"
 compact_str = "0.9"
 fast-glob = "1"
 indexmap = { version = "2", features = ["serde"] }
+memchr = "2"
 json-strip-comments = "3.1"
 nodejs-built-in-modules = "1.0.0"
 once_cell = "1" # Use `std::sync::OnceLock::get_or_try_init` when it is stable.

--- a/fixtures/tsconfig/cases/query-params/src/foo.js
+++ b/fixtures/tsconfig/cases/query-params/src/foo.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/fixtures/tsconfig/cases/query-params/src/index.ts
+++ b/fixtures/tsconfig/cases/query-params/src/index.ts
@@ -1,0 +1,2 @@
+import foo from "@alias/foo.js";
+export default foo;

--- a/fixtures/tsconfig/cases/query-params/tsconfig.app.json
+++ b/fixtures/tsconfig/cases/query-params/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "paths": {
+      "@alias/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/fixtures/tsconfig/cases/query-params/tsconfig.json
+++ b/fixtures/tsconfig/cases/query-params/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.app.json" }
+  ]
+}

--- a/src/path.rs
+++ b/src/path.rs
@@ -3,9 +3,22 @@
 //! Code adapted from the following libraries
 //! * [path-absolutize](https://docs.rs/path-absolutize)
 //! * [normalize_path](https://docs.rs/normalize-path)
-use std::path::{Component, Path, PathBuf};
+use std::{
+    ffi::OsStr,
+    path::{Component, Path, PathBuf},
+};
 
 pub const SLASH_START: &[char; 2] = &['/', '\\'];
+
+/// Strip query parameters (`?...`) and hash fragments (`#...`) from a file path.
+pub fn strip_query_and_fragment(path: &Path) -> &Path {
+    let bytes = path.as_os_str().as_encoded_bytes();
+    let Some(end) = memchr::memchr2(b'?', b'#', bytes) else {
+        return path;
+    };
+    // SAFETY: Splitting at ASCII `?` or `#` preserves valid OsStr encoding.
+    Path::new(unsafe { OsStr::from_encoded_bytes_unchecked(&bytes[..end]) })
+}
 
 /// Extension trait to add path normalization to std's [`Path`].
 pub trait PathUtil {
@@ -156,4 +169,27 @@ fn normalize_relative() {
     assert_eq!(Path::new("foo/.././foo/").normalize_relative(), Path::new("foo"));
     assert_eq!(Path::new("foo../../..").normalize_relative(), Path::new(".."));
     assert_eq!(Path::new("jest-runner-../../").normalize_relative(), Path::new(""));
+}
+
+#[test]
+fn test_strip_query_and_fragment() {
+    assert_eq!(strip_query_and_fragment(Path::new("/src/foo.ts")), Path::new("/src/foo.ts"));
+    assert_eq!(
+        strip_query_and_fragment(Path::new("/src/foo.ts?custom=foo")),
+        Path::new("/src/foo.ts")
+    );
+    assert_eq!(
+        strip_query_and_fragment(Path::new("/src/foo.ts#fragment")),
+        Path::new("/src/foo.ts")
+    );
+    assert_eq!(
+        strip_query_and_fragment(Path::new("/src/foo.ts?key=val#frag")),
+        Path::new("/src/foo.ts")
+    );
+    assert_eq!(
+        strip_query_and_fragment(Path::new("/src/foo.ts#frag?key=val")),
+        Path::new("/src/foo.ts")
+    );
+    assert_eq!(strip_query_and_fragment(Path::new("")), Path::new(""));
+    assert_eq!(strip_query_and_fragment(Path::new("?query")), Path::new(""));
 }

--- a/src/tests/tsconfig_discovery.rs
+++ b/src/tests/tsconfig_discovery.rs
@@ -26,6 +26,49 @@ fn tsconfig_discovery_virtual_file_importer() {
     assert_eq!(resolved_path, Err(ResolveError::NotFound("random-import".into())));
 }
 
+/// When the importer path has query parameters (e.g. `file.tsx?custom=foo`),
+/// auto-discovery should strip them before walking parent directories
+/// and discover the correct tsconfig.json.
+///
+/// Uses a fixture with project references where the root tsconfig has `include: []`
+/// and a referenced tsconfig.app.json has `include: ["src/**/*"]` with path aliases.
+/// Without stripping query params, `resolve_tsconfig_solution` fails to match the
+/// file against the reference's include pattern, returning the wrong tsconfig.
+#[test]
+fn tsconfig_discovery_query_params() {
+    let f = super::fixture_root().join("tsconfig/cases/query-params");
+    let expected_tsconfig = f.join("tsconfig.app.json");
+
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
+
+    let clean_path = f.join("src/index.ts");
+
+    // Baseline — clean path discovers tsconfig.app.json (via project references)
+    let tsconfig = resolver.find_tsconfig(&clean_path).unwrap().unwrap();
+    assert_eq!(tsconfig.path, expected_tsconfig, "baseline: should select referenced tsconfig");
+
+    // With query parameter — should discover the same referenced tsconfig
+    let path_with_query = format!("{}?custom=foo", clean_path.display());
+    let tsconfig = resolver.find_tsconfig(&path_with_query).unwrap().unwrap();
+    assert_eq!(tsconfig.path, expected_tsconfig, "query param: should select referenced tsconfig");
+
+    // With fragment — should discover the same referenced tsconfig
+    let path_with_fragment = format!("{}#fragment", clean_path.display());
+    let tsconfig = resolver.find_tsconfig(&path_with_fragment).unwrap().unwrap();
+    assert_eq!(tsconfig.path, expected_tsconfig, "fragment: should select referenced tsconfig");
+
+    // With both query and fragment — should discover the same referenced tsconfig
+    let path_with_both = format!("{}?custom=foo#fragment", clean_path.display());
+    let tsconfig = resolver.find_tsconfig(&path_with_both).unwrap().unwrap();
+    assert_eq!(
+        tsconfig.path, expected_tsconfig,
+        "query+fragment: should select referenced tsconfig"
+    );
+}
+
 /// When a tsconfig.json exists but is not readable (e.g. permission denied),
 /// auto-discovery should skip it and return `Ok(None)` instead of erroring.
 #[test]

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -53,7 +53,8 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         &self,
         path: P,
     ) -> Result<Option<Arc<TsConfig>>, ResolveError> {
-        let path = path.as_ref();
+        // Vite plugins may append query params to real file paths (e.g. `file.tsx?custom=foo`), which are not valid filesystem path components.
+        let path = crate::path::strip_query_and_fragment(path.as_ref());
         let cached_path = self.cache.value(path);
         self.find_tsconfig_tracing(&cached_path)
     }


### PR DESCRIPTION
When `tsconfig: 'auto'` is configured, `find_tsconfig()` receives the raw importer path from the caller. Vite plugins commonly append query parameters to real file paths (e.g. `src/routes/index.tsx?custom=foo`). This caused the path to not match the expected tsconfig files (https://github.com/vitejs/vite/issues/21889).

This PR fixes that by stripping query params and hash fragments from the importer path before finding the tsconfig.json that matches.