### PR TITLE
refactor: prioritize project references and check file extension per referenced tsconfig

### DIFF
--- a/src/tests/tsconfck.rs
+++ b/src/tests/tsconfck.rs
@@ -65,8 +65,8 @@ fn part_of_solution() {
         ("mixed", "src/baz.cts", "tsconfig.src.json"),
         ("mixed", "src/foo.ts", "tsconfig.src.json"),
         ("mixed", "src/foo.spec.ts", "tsconfig.test.json"),
-        ("referenced-extends-original", "src/foo.ts", "tsconfig.json"),
-        ("referenced-extends-original", "tests/foo.test.ts", "tsconfig.json"),
+        ("referenced-extends-original", "src/foo.ts", "src/tsconfig.src.json"),
+        ("referenced-extends-original", "tests/foo.test.ts", "tests/tsconfig.test.json"),
         ("referenced-with-configDir", "src/foo.ts", "tsconfig.src.json"),
         (
             "referenced-with-configDir-and-extends",

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -524,8 +524,6 @@ enum GlobPattern<'a> {
 impl TsConfig {
     pub(crate) fn resolve_tsconfig_solution(tsconfig: Arc<Self>, path: &Path) -> Arc<Self> {
         if !tsconfig.references_resolved.is_empty()
-            && tsconfig.is_file_extension_allowed_in_tsconfig(path)
-            && !tsconfig.is_file_included_in_tsconfig(path)
             && let Some(solution_tsconfig) = tsconfig
                 .references_resolved
                 .iter()
@@ -538,6 +536,10 @@ impl TsConfig {
     }
 
     fn is_file_included_in_tsconfig(&self, path: &Path) -> bool {
+        // 0. Check extension first - each tsconfig uses its own allowJs setting
+        if !self.is_file_extension_allowed_in_tsconfig(path) {
+            return false;
+        }
         // 1. Check files array (highest priority - overrides exclude)
         if self.files.as_ref().is_some_and(|files| files.iter().any(|file| Path::new(file) == path))
         {
@@ -549,32 +551,32 @@ impl TsConfig {
                 if self.files.is_some() {
                     false
                 } else {
-                    self.is_glob_matches(path, GlobPattern::All)
+                    Self::is_glob_matches(path, GlobPattern::All)
                 }
             },
-            |include_patterns| self.is_glob_matches(path, GlobPattern::Pattern(include_patterns)),
+            |include_patterns| Self::is_glob_matches(path, GlobPattern::Pattern(include_patterns)),
         );
         // 3. Check exclude patterns
         if is_included {
             return self.exclude.as_ref().is_none_or(|exclude_patterns| {
-                !self.is_glob_matches(path, GlobPattern::Pattern(exclude_patterns))
+                !Self::is_glob_matches(path, GlobPattern::Pattern(exclude_patterns))
             });
         }
         false
     }
 
-    fn is_glob_matches(&self, path: &Path, pattern: GlobPattern) -> bool {
+    fn is_glob_matches(path: &Path, pattern: GlobPattern) -> bool {
         let path_str = path.to_string_lossy().replace('\\', "/");
         match pattern {
-            GlobPattern::All => self.is_glob_match(GLOB_ALL_PATTERN, path, &path_str),
+            GlobPattern::All => Self::is_glob_match(GLOB_ALL_PATTERN, &path_str),
             GlobPattern::Pattern(patterns) => patterns.iter().any(|pattern| {
                 let pattern = pattern.to_string_lossy().replace('\\', "/");
-                self.is_glob_match(pattern.as_ref(), path, &path_str)
+                Self::is_glob_match(pattern.as_ref(), &path_str)
             }),
         }
     }
 
-    fn is_glob_match(&self, pattern: &str, path: &Path, path_str: &str) -> bool {
+    fn is_glob_match(pattern: &str, path_str: &str) -> bool {
         if pattern == path_str {
             return true;
         }
@@ -594,10 +596,6 @@ impl TsConfig {
         } else {
             Cow::Borrowed(pattern)
         };
-        // Fast check: if pattern ends with *, filename must have valid extension
-        if pattern.ends_with('*') && !self.is_file_extension_allowed_in_tsconfig(path) {
-            return false;
-        }
         fast_glob::glob_match(pattern.as_ref(), path_str)
     }
 


### PR DESCRIPTION
closes #1086

1. **`resolve_tsconfig_solution`**: Removed the parent-level `is_file_extension_allowed_in_tsconfig` and `!is_file_included_in_tsconfig` guards, so project references are always prioritized.
2. **`is_file_included_in_tsconfig`**: Moved the extension check into the beginning of this method, so each referenced tsconfig uses its own `allowJs` setting.
3. **`is_glob_match`**: Removed the now-redundant extension fast check, and since the `path` parameter was no longer needed, converted `is_glob_match`/`is_glob_matches` to static methods.

---

I found that many behaviors in `tsconfck` are inconsistent with TypeScript and are therefore incorrect.