### PR TITLE
chore: remove oxfmt dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ just ready     # Run all checks (format, lint, test, build)
 just test      # Run all tests (Rust + Node.js)
 just check     # Cargo check with all features
 just lint      # Run clippy with strict settings
-just fmt       # Format code (cargo fmt + oxfmt)
+just fmt       # Format code (cargo fmt + vp fmt)
 ```
 
 ## Code Conventions

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@napi-rs/wasm-runtime": "^1.1.0",
     "@types/node": "^25.0.8",
     "emnapi": "^1.7.1",
-    "oxfmt": "^0.43.0",
     "typescript": "^6.0.0",
     "vite-plus": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,6 @@ importers:
       emnapi:
         specifier: ^1.7.1
         version: 1.8.1
-      oxfmt:
-        specifier: ^0.43.0
-        version: 0.43.0
       typescript:
         specifier: ^6.0.0
         version: 6.0.2


### PR DESCRIPTION
## Summary
- Remove standalone `oxfmt` devDependency since it is already bundled inside `vp fmt`
- Update `AGENTS.md` to reference `vp fmt` instead of `oxfmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)