### PR TITLE
ci: replace OXC_BOT_PAT with GitHub App tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,16 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: oxc-project/release-plz@e2b12f55ad64a22af8e93634b94439c42913afca # v1.0.6
         id: release-plz
         with:
-          PAT: ${{ secrets.OXC_BOT_PAT }}
+          PAT: ${{ steps.app-token.outputs.token }}
 
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         with:
@@ -35,7 +41,7 @@ jobs:
       - name: Bump package.json
         if: ${{ steps.release-plz.outputs.prs_created }}
         env:
-          GH_TOKEN: ${{ secrets.OXC_BOT_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ fromJSON(steps.release-plz.outputs.pr).number }}
           VERSION: ${{ fromJSON(steps.release-plz.outputs.pr).releases[0].version }}
         run: |


### PR DESCRIPTION
## Summary
- replace `OXC_BOT_PAT` workflow usage with `actions/create-github-app-token`
- use `APP_ID` and `APP_PRIVATE_KEY` to mint per-job GitHub App installation tokens
- keep existing workflow behavior for PR creation, release flows, comments, dispatches, and checkout-backed pushes
