### PR TITLE
perf: Remove double allocation in Cache::value

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -61,7 +61,7 @@ impl<Fs: FileSystem> Cache<Fs> {
         let parent_weak = parent.as_ref().map(|p| Arc::downgrade(&p.0));
         let cached_path = CachedPath(Arc::new(CachedPathImpl::new(
             hash,
-            path.to_path_buf().into_boxed_path(),
+            Box::from(path),
             is_node_modules,
             inside_node_modules,
             parent_weak,


### PR DESCRIPTION
path.to_path_buf() allocates a PathBuf, then into_boxed_path() calls shrink_to_fit() internally which can trigger a second reallocation to remove excess capacity before producing the Box<Path>.

Box::from(path) goes directly from &Path to Box<Path> in a single allocation of exactly the right size, with no intermediate PathBuf.

Single thread & symlink resolution perf using the in-memory fs:
``` 
resolver_memory/single-thread
                        time:   [68.337 µs 68.501 µs 68.662 µs]
                        change: [−4.9898% −3.1406% −1.2776%] (p = 0.00 < 0.05)
                        Performance has improved.

resolver_memory/resolve from symlinks
                        time:   [12.789 ms 12.813 ms 12.838 ms]
                        change: [−4.6672% −4.4035% −4.1182%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Then with the real filesystem:
```
resolver_real/single-thread
                        time:   [71.252 µs 71.332 µs 71.419 µs]
                        change: [−4.1741% −2.7475% −1.3819%] (p = 0.00 < 0.05)
                        Performance has improved.

resolver_real/resolve from symlinks
                        time:   [16.542 ms 16.557 ms 16.574 ms]
                        change: [−3.3940% −3.2391% −3.0938%] (p = 0.00 < 0.05)
                        Performance has improved.

package_json_deserialization/small
                        time:   [297.20 ns 297.26 ns 297.32 ns]
                        change: [−3.0348% −2.9934% −2.9452%] (p = 0.00 < 0.05)
                        Performance has improved.

package_json_deserialization/medium
                        time:   [843.59 ns 843.79 ns 844.04 ns]
                        change: [−1.1460% −1.1082% −1.0714%] (p = 0.00 < 0.05)
                        Performance has improved.

package_json_deserialization/large
                        time:   [1.8907 µs 1.8910 µs 1.8914 µs]
                        change: [−2.5854% −2.5484% −2.5135%] (p = 0.00 < 0.05)
                        Performance has improved.
```