### PR TITLE
chore: update packageManager to pnpm 11.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,5 +72,5 @@
       }
     }
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@11.0.4"
 }


### PR DESCRIPTION
## Summary
- update the pnpm package manager pin to `pnpm@11.0.4`
- add missing pnpm package manager metadata where needed
- keep lockfiles unchanged to avoid unrelated dependency updates