### PR TITLE
perf(specifier): replace O(N·K) escape lookup with lockstep iteration

### DIFF
--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -73,9 +73,14 @@ impl<'a> Specifier<'a> {
         };
 
         let path = escaped_indexes.map_or(Cow::Borrowed(path), |escaped_indexes| {
-            let mut s = String::with_capacity(path.len());
+            // `escaped_indexes` is populated in scan order, so it is already sorted ascending.
+            // Avoid `Vec::contains` (O(K) per byte) by walking both in lockstep.
+            let mut s = String::with_capacity(path.len() - escaped_indexes.len());
+            let mut idx_iter = escaped_indexes.iter().copied().peekable();
             for (i, &b) in path.as_bytes().iter().enumerate() {
-                if !escaped_indexes.contains(&i) {
+                if idx_iter.peek() == Some(&i) {
+                    idx_iter.next();
+                } else {
                     s.push(b as char);
                 }
             }


### PR DESCRIPTION
## Summary

`Specifier::parse_query_fragment` reconstructs the path from an `escaped_indexes` `Vec<usize>` with `escaped_indexes.contains(&i)` for every byte of the path — O(path_len · escape_count) in the worst case.

The indexes are populated in scan order so the vec is already sorted ascending. Walk it as a peekable iterator alongside the path bytes for a single O(path_len + escape_count) pass.

Triggered only when a specifier contains a `\0#` escape sequence, so the impact on the default resolver path is negligible — this is mostly correctness/clarity hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)