### PR TITLE
perf(alias): pre-compile fallback alias on resolver construction

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -50,18 +50,6 @@ pub fn compile_alias(aliases: &Alias) -> CompiledAlias {
 }
 
 impl<Fs: FileSystem> ResolverGeneric<Fs> {
-    pub(super) fn load_alias_by_options(
-        &self,
-        cached_path: &CachedPath,
-        specifier: &str,
-        aliases: &Alias,
-        tsconfig: Option<&TsConfig>,
-        ctx: &mut Ctx,
-    ) -> Result<Option<CachedPath>, ResolveError> {
-        let compiled_aliases = compile_alias(aliases);
-        self.load_alias(cached_path, specifier, &compiled_aliases, tsconfig, ctx)
-    }
-
     /// enhanced-resolve: AliasPlugin for [crate::ResolveOptions::alias] and [crate::ResolveOptions::fallback].
     pub(super) fn load_alias(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ pub struct ResolverGeneric<Fs> {
     options: ResolveOptions,
     cache: Arc<Cache<Fs>>,
     alias: CompiledAlias,
+    fallback: CompiledAlias,
 }
 
 impl<Fs> fmt::Debug for ResolverGeneric<Fs> {
@@ -142,6 +143,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     pub fn new(options: ResolveOptions) -> Self {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
+        let fallback = compile_alias(&options.fallback);
         cfg_if::cfg_if! {
             if #[cfg(feature = "yarn_pnp")] {
                 let fs = Fs::new(options.yarn_pnp);
@@ -150,13 +152,14 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             }
         }
         let cache = Arc::new(Cache::new(fs));
-        Self { options, cache, alias }
+        Self { options, cache, alias, fallback }
     }
 
     pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
-        Self { cache: Arc::new(Cache::new(file_system)), options, alias }
+        let fallback = compile_alias(&options.fallback);
+        Self { cache: Arc::new(Cache::new(file_system)), options, alias, fallback }
     }
 
     /// Clone the resolver using the same underlying cache.
@@ -165,6 +168,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     pub fn clone_with_options(&self, options: ResolveOptions) -> Self {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
+        let fallback = compile_alias(&options.fallback);
         cfg_if::cfg_if! {
             if #[cfg(feature = "yarn_pnp")] {
                 let cache = if (options.yarn_pnp && !self.options.yarn_pnp)
@@ -178,7 +182,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 let cache = Arc::clone(&self.cache);
             }
         }
-        Self { options, cache, alias }
+        Self { options, cache, alias, fallback }
     }
 
     /// Returns the options.
@@ -460,14 +464,11 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 return Err(err);
             }
             // enhanced-resolve: try fallback
-            self.load_alias_by_options(
-                cached_path,
-                specifier,
-                &self.options.fallback,
-                tsconfig,
-                ctx,
-            )
-            .and_then(|value| value.ok_or(err))
+            if self.fallback.is_empty() {
+                return Err(err);
+            }
+            self.load_alias(cached_path, specifier, &self.fallback, tsconfig, ctx)
+                .and_then(|value| value.ok_or(err))
         })
     }
 


### PR DESCRIPTION
## Summary

`require_without_parse` calls `load_alias_by_options` on the error path, which previously compiled `options.fallback` (`Vec<(String, Vec<AliasValue>)>` → `CompiledAlias`) on every resolve that fell through to the fallback. Even when `fallback` is empty (the default), the iterator chain still runs.

This PR:

- Caches a `fallback: CompiledAlias` on `ResolverGeneric` alongside the existing `alias: CompiledAlias`, computed once in `new`/`new_with_file_system`/`clone_with_options`.
- Short-circuits the fallback branch when `self.fallback.is_empty()`.
- Deletes the now unused `load_alias_by_options` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)