### PR TITLE
perf(cache): store canonical path as Box<Path> instead of PathBuf

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -331,13 +331,13 @@ impl<Fs: FileSystem> Cache<Fs> {
         visited: &mut StdHashSet<u64, BuildHasherDefault<IdentityHasher>>,
     ) -> Result<CachedPath, ResolveError> {
         // Check cache first - if this path was already canonicalized, return the cached result
-        if let Some((weak, path_buf)) = path.canonicalized.get() {
+        if let Some((weak, path_box)) = path.canonicalized.get() {
             return weak
                 .upgrade()
                 .map(CachedPath)
                 .or_else(|| {
-                    // Weak pointer upgrade failed - recreate from stored PathBuf
-                    Some(self.value(path_buf))
+                    // Weak pointer upgrade failed - recreate from the stored canonical path
+                    Some(self.value(path_box))
                 })
                 .ok_or_else(|| {
                     io::Error::new(io::ErrorKind::NotFound, "Cached path no longer exists").into()
@@ -385,7 +385,7 @@ impl<Fs: FileSystem> Cache<Fs> {
 
         // Cache the result before removing from visited set
         // This ensures parent canonicalization results are cached and reused
-        let _ = path.canonicalized.set((Arc::downgrade(&res.0), res.to_path_buf()));
+        let _ = path.canonicalized.set((Arc::downgrade(&res.0), res.0.path.clone()));
 
         // Remove from visited set when unwinding the recursion
         visited.remove(&path.hash);

--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -24,7 +24,9 @@ pub struct CachedPathImpl {
     pub is_node_modules: bool,
     pub inside_node_modules: bool,
     pub meta: OnceLock<Option<(/* is_file */ bool, /* is_dir */ bool)>>, // None means not found.
-    pub canonicalized: OnceLock<(Weak<Self>, PathBuf)>,
+    /// Stored as `Box<Path>` (not `PathBuf`) to save 8 bytes per cached path entry —
+    /// the canonical path is set once and never mutated.
+    pub canonicalized: OnceLock<(Weak<Self>, Box<Path>)>,
     pub node_modules: OnceLock<Option<Weak<Self>>>,
     pub package_json: OnceLock<Option<Arc<PackageJson>>>,
     /// `tsconfig.json` found at path.


### PR DESCRIPTION
## Summary

`CachedPathImpl::canonicalized` cached the canonical path as `PathBuf` even though it's set once and never mutated. `PathBuf` is `Vec<u8>`-sized (`ptr + len + cap` = 24 bytes); `Box<Path>` only needs `ptr + len` = 16 bytes. The capacity word was dead weight.

Switching the field type shrinks the `OnceLock<(Weak<Self>, ...)>` tuple from 40 to 32 bytes — saving **8 bytes per cached path entry**. For a resolver session with 10k cached paths that's ~80 KB; with 100k it's ~800 KB.

The setter now clones the existing `Box<Path>` of the canonical entry instead of calling `to_path_buf()`, so we don't take a PathBuf detour either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)