### PR TITLE
perf(cache): pack CachedPathImpl::meta into a CachedMeta byte

### DIFF
--- a/src/cache/cached_meta.rs
+++ b/src/cache/cached_meta.rs
@@ -1,0 +1,102 @@
+//! Single-byte cache slot for `Option<(is_file, is_dir)>` filesystem metadata.
+//!
+//! Replaces `OnceLock<Option<(bool, bool)>>` (16 bytes) with an `AtomicU8` (1 byte) — saving
+//! 15 bytes per cached path entry. The four possible `(is_file, is_dir)` combinations, the
+//! "not found" outcome, and the uninitialized state fit comfortably in a single byte.
+//!
+//! Filesystem metadata is idempotent, so the lack of `OnceLock`'s exactly-once semantics is
+//! harmless: if two threads race to populate the slot they both re-`stat` and store the same
+//! answer.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+const UNINIT: u8 = 0;
+const NONE: u8 = 1;
+const FALSE_FALSE: u8 = 2;
+const TRUE_FALSE: u8 = 3;
+const FALSE_TRUE: u8 = 4;
+const TRUE_TRUE: u8 = 5;
+
+/// Lazily-populated `Option<(is_file, is_dir)>` packed into one byte.
+pub struct CachedMeta(AtomicU8);
+
+impl CachedMeta {
+    pub const fn new() -> Self {
+        Self(AtomicU8::new(UNINIT))
+    }
+
+    /// Return the cached value if the slot has been populated, otherwise call `f`, store its
+    /// result, and return it. Multiple threads may race to populate; the last writer wins.
+    pub fn get_or_init<F>(&self, f: F) -> Option<(bool, bool)>
+    where
+        F: FnOnce() -> Option<(bool, bool)>,
+    {
+        let state = self.0.load(Ordering::Relaxed);
+        if state != UNINIT {
+            return decode(state);
+        }
+        let computed = f();
+        self.0.store(encode(computed), Ordering::Relaxed);
+        computed
+    }
+}
+
+impl Default for CachedMeta {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[inline]
+fn encode(value: Option<(bool, bool)>) -> u8 {
+    match value {
+        None => NONE,
+        Some((false, false)) => FALSE_FALSE,
+        Some((true, false)) => TRUE_FALSE,
+        Some((false, true)) => FALSE_TRUE,
+        Some((true, true)) => TRUE_TRUE,
+    }
+}
+
+#[inline]
+fn decode(state: u8) -> Option<(bool, bool)> {
+    match state {
+        NONE => None,
+        FALSE_FALSE => Some((false, false)),
+        TRUE_FALSE => Some((true, false)),
+        FALSE_TRUE => Some((false, true)),
+        TRUE_TRUE => Some((true, true)),
+        // UNINIT is filtered out by the caller; any other byte indicates corruption.
+        _ => unreachable!("invalid CachedMeta state"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn cached_meta_is_one_byte() {
+        assert_eq!(size_of::<CachedMeta>(), 1);
+    }
+
+    #[test]
+    fn returns_none_when_initializer_returns_none() {
+        let meta = CachedMeta::new();
+        assert!(meta.get_or_init(|| None).is_none());
+        // And on subsequent calls the initializer is not invoked.
+        assert!(meta.get_or_init(|| panic!("must not be called")).is_none());
+    }
+
+    #[test]
+    fn roundtrips_all_some_combinations() {
+        for (is_file, is_dir) in [(false, false), (true, false), (false, true), (true, true)] {
+            let meta = CachedMeta::new();
+            let got = meta.get_or_init(|| Some((is_file, is_dir)));
+            assert_eq!(got, Some((is_file, is_dir)));
+            let cached = meta.get_or_init(|| panic!("must not be called"));
+            assert_eq!(cached, Some((is_file, is_dir)));
+        }
+    }
+}

--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -11,6 +11,7 @@ use cfg_if::cfg_if;
 use once_cell::sync::OnceCell as OnceLock;
 
 use super::cache_impl::Cache;
+use super::cached_meta::CachedMeta;
 use super::thread_local::SCRATCH_PATH;
 use crate::{FileSystem, PackageJson, TsConfig, context::ResolveContext as Ctx};
 
@@ -23,7 +24,9 @@ pub struct CachedPathImpl {
     pub parent: Option<Weak<Self>>,
     pub is_node_modules: bool,
     pub inside_node_modules: bool,
-    pub meta: OnceLock<Option<(/* is_file */ bool, /* is_dir */ bool)>>, // None means not found.
+    /// Cached `(is_file, is_dir)` filesystem metadata packed into one byte. See
+    /// [`CachedMeta`] for the encoding and the rationale for skipping `OnceLock`.
+    pub meta: CachedMeta,
     /// Stored as `Box<Path>` (not `PathBuf`) to save 8 bytes per cached path entry —
     /// the canonical path is set once and never mutated.
     pub canonicalized: OnceLock<(Weak<Self>, Box<Path>)>,
@@ -49,7 +52,7 @@ impl CachedPathImpl {
             parent,
             is_node_modules,
             inside_node_modules,
-            meta: OnceLock::new(),
+            meta: CachedMeta::new(),
             canonicalized: OnceLock::new(),
             node_modules: OnceLock::new(),
             package_json: OnceLock::new(),
@@ -237,7 +240,7 @@ impl CachedPath {
 
 impl CachedPath {
     fn metadata<Fs: FileSystem>(&self, fs: &Fs) -> Option<(bool, bool)> {
-        *self.meta.get_or_init(|| fs.metadata(&self.path).ok().map(|r| (r.is_file, r.is_dir)))
+        self.meta.get_or_init(|| fs.metadata(&self.path).ok().map(|r| (r.is_file, r.is_dir)))
     }
 
     pub(crate) fn is_file<Fs: FileSystem>(&self, fs: &Fs) -> Option<bool> {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,5 +1,6 @@
 mod borrowed_path;
 mod cache_impl;
+mod cached_meta;
 mod cached_path;
 mod hasher;
 mod thread_local;


### PR DESCRIPTION
## Summary

`CachedPathImpl::meta` was a `OnceLock<Option<(bool, bool)>>` (16 bytes) recording whether the path is a file and/or directory. Filesystem metadata is idempotent — `OnceLock`'s exactly-once initialization is a nicety, not a correctness requirement: if two threads race they both re-`stat` and both store the same answer.

This PR introduces a `CachedMeta` struct in `src/cache/cached_meta.rs` that wraps an `AtomicU8`, encapsulates the encoding of the six possible states (uninitialized / `None` / the four `(is_file, is_dir)` combinations), and exposes a single `get_or_init` accessor.

`CachedPathImpl::meta` becomes:

```rust
pub meta: CachedMeta,
```

…and the accessor on `CachedPath` collapses to a one-liner:

```rust
fn metadata<Fs: FileSystem>(&self, fs: &Fs) -> Option<(bool, bool)> {
    self.meta.get_or_init(|| fs.metadata(&self.path).ok().map(|r| (r.is_file, r.is_dir)))
}
```

All encoding/decoding/`AtomicU8` plumbing is private to the new module.

## Size impact

The field shrinks from 16 bytes to 1, saving **15 bytes per cached path entry**. For sessions with 10k cached paths that's ~150 KB; with 100k it's ~1.5 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)