### PR TITLE
perf(cache): drop the canonicalized path fallback, keep only the Weak

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -330,18 +330,13 @@ impl<Fs: FileSystem> Cache<Fs> {
         path: &CachedPath,
         visited: &mut StdHashSet<u64, BuildHasherDefault<IdentityHasher>>,
     ) -> Result<CachedPath, ResolveError> {
-        // Check cache first - if this path was already canonicalized, return the cached result
-        if let Some((weak, path_box)) = path.canonicalized.get() {
-            return weak
-                .upgrade()
-                .map(CachedPath)
-                .or_else(|| {
-                    // Weak pointer upgrade failed - recreate from the stored canonical path
-                    Some(self.value(path_box))
-                })
-                .ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::NotFound, "Cached path no longer exists").into()
-                });
+        // Check cache first - if this path was already canonicalized, return the cached result.
+        // If the weak upgrade fails (cache was cleared concurrently), surface a `NotFound`
+        // so `canonicalize_impl`'s outer fallback re-runs `fs.canonicalize`.
+        if let Some(weak) = path.canonicalized.get() {
+            return weak.upgrade().map(CachedPath).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, "Cached path no longer exists").into()
+            });
         }
 
         // Check for circular symlink by tracking visited paths in the current canonicalization chain
@@ -385,7 +380,7 @@ impl<Fs: FileSystem> Cache<Fs> {
 
         // Cache the result before removing from visited set
         // This ensures parent canonicalization results are cached and reused
-        let _ = path.canonicalized.set((Arc::downgrade(&res.0), res.0.path.clone()));
+        let _ = path.canonicalized.set(Arc::downgrade(&res.0));
 
         // Remove from visited set when unwinding the recursion
         visited.remove(&path.hash);

--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -24,9 +24,10 @@ pub struct CachedPathImpl {
     pub is_node_modules: bool,
     pub inside_node_modules: bool,
     pub meta: OnceLock<Option<(/* is_file */ bool, /* is_dir */ bool)>>, // None means not found.
-    /// Stored as `Box<Path>` (not `PathBuf`) to save 8 bytes per cached path entry —
-    /// the canonical path is set once and never mutated.
-    pub canonicalized: OnceLock<(Weak<Self>, Box<Path>)>,
+    /// `Weak` reference to this path's canonical `CachedPath`. May point at `self` when no
+    /// symlinks are involved. If the weak upgrade fails (the cache was cleared concurrently),
+    /// [`Cache::canonicalize_impl`] recovers by re-running `fs.canonicalize`.
+    pub canonicalized: OnceLock<Weak<Self>>,
     pub node_modules: OnceLock<Option<Weak<Self>>>,
     pub package_json: OnceLock<Option<Arc<PackageJson>>>,
     /// `tsconfig.json` found at path.


### PR DESCRIPTION
## Summary

`CachedPathImpl::canonicalized` was an `OnceLock<(Weak<Self>, Box<Path>)>`. The boxed canonical path is only consulted when the weak upgrade fails — which only happens when `Cache::clear` races with an in-flight canonicalization, and `Cache::clear` is already documented as needing no concurrent resolutions.

`Cache::canonicalize_impl` already has an outer fallback that recovers by re-running `fs.canonicalize` when the inner `canonicalize_with_visited` returns an error. So the inner can now just surface a `NotFound` on weak-upgrade failure and let the outer fallback take over — no behavior change for any valid usage pattern.

## Wins

- **−16 bytes per cached path entry.** `OnceLock<(Weak, Box<Path>)>` (32 bytes) shrinks to `OnceLock<Weak>` (16 bytes). 10k cached paths → ~150 KB; 100k → ~1.5 MB.
- **One fewer heap allocation per canonicalize call.** The setter no longer clones the canonical entry's `Box<Path>` — the parked `Weak` is enough to reach the cached canonical `CachedPath`.

## Validation

- `cargo check`, `cargo clippy --all-features --all-targets -- --deny warnings`: clean.
- `cargo test --lib -- --skip symlink`: 214 passed (the only failure is the pre-existing `tests::symlink::test` for stale local fixtures, fails on `main` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)