### PR TITLE
fix: strip query fragments when calling `find_tsconfig`

### DIFF
--- a/fixtures/tsconfig/cases/query-params/src/foo.js
+++ b/fixtures/tsconfig/cases/query-params/src/foo.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/fixtures/tsconfig/cases/query-params/src/index.ts
+++ b/fixtures/tsconfig/cases/query-params/src/index.ts
@@ -1,0 +1,2 @@
+import foo from "@alias/foo.js";
+export default foo;

--- a/fixtures/tsconfig/cases/query-params/tsconfig.app.json
+++ b/fixtures/tsconfig/cases/query-params/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "paths": {
+      "@alias/*": [
+        "./src/*"
+      ]
+    }
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/fixtures/tsconfig/cases/query-params/tsconfig.json
+++ b/fixtures/tsconfig/cases/query-params/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/src/tests/tsconfig_discovery.rs
+++ b/src/tests/tsconfig_discovery.rs
@@ -61,3 +61,23 @@ fn tsconfig_discovery_skips_unreadable_file() {
         "expected Ok(None) for unreadable tsconfig, got {result:?}",
     );
 }
+
+#[test]
+fn tsconfig_discovery_query_params() {
+    let f = super::fixture_root().join("tsconfig/cases/query-params");
+
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
+
+    let p = f.join("src/index.ts");
+    let expected_tsconfig = f.join("tsconfig.app.json");
+
+    let tsconfig = resolver.find_tsconfig(&p).unwrap().unwrap();
+    assert_eq!(tsconfig.path, expected_tsconfig);
+
+    let path_with_both = format!("{}?custom=foo#fragment", p.display());
+    let tsconfig = resolver.find_tsconfig(&path_with_both).unwrap().unwrap();
+    assert_eq!(tsconfig.path, expected_tsconfig,);
+}

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     CachedPath, Ctx, FileSystem, ResolveError, ResolveOptions, ResolveResult, ResolverGeneric,
-    SpecifierError, TsConfig, TsconfigDiscovery, TsconfigOptions, TsconfigReferences,
+    Specifier, SpecifierError, TsConfig, TsconfigDiscovery, TsconfigOptions, TsconfigReferences,
     path::PathUtil,
 };
 
@@ -53,7 +53,9 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         &self,
         path: P,
     ) -> Result<Option<Arc<TsConfig>>, ResolveError> {
-        let path = path.as_ref();
+        let path = path.as_ref().to_string_lossy();
+        let specifier = Specifier::parse(path.as_ref()).map_err(ResolveError::Specifier)?;
+        let path = Path::new(specifier.path());
         let cached_path = self.cache.value(path);
         self.find_tsconfig_tracing(&cached_path)
     }


### PR DESCRIPTION
closes #1081
