### PR TITLE
fix(tsconfig): resolve `rootDirs` against the config that declared them

### DIFF
--- a/fixtures/tsconfig/cases/root-dirs-extends/.svelte-kit/tsconfig.json
+++ b/fixtures/tsconfig/cases/root-dirs-extends/.svelte-kit/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "rootDirs": ["..", "./types"]
+  }
+}

--- a/fixtures/tsconfig/cases/root-dirs-extends/.svelte-kit/types/src/routes/$types.d.ts
+++ b/fixtures/tsconfig/cases/root-dirs-extends/.svelte-kit/types/src/routes/$types.d.ts
@@ -1,0 +1,1 @@
+export type PageLoad = () => unknown;

--- a/fixtures/tsconfig/cases/root-dirs-extends/src/routes/+page.ts
+++ b/fixtures/tsconfig/cases/root-dirs-extends/src/routes/+page.ts
@@ -1,0 +1,2 @@
+import type { PageLoad } from "./$types";
+export const load: PageLoad = () => undefined;

--- a/fixtures/tsconfig/cases/root-dirs-extends/tsconfig.json
+++ b/fixtures/tsconfig/cases/root-dirs-extends/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "./.svelte-kit/tsconfig.json" }

--- a/src/tests/tsconfig_root_dirs.rs
+++ b/src/tests/tsconfig_root_dirs.rs
@@ -101,3 +101,20 @@ fn test() {
         );
     }
 }
+
+#[test]
+fn test_root_dirs_via_extends() {
+    let f = super::fixture_root().join("tsconfig/cases/root-dirs-extends");
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: f.join("tsconfig.json"),
+            references: TsconfigReferences::Disabled,
+        })),
+        extensions: vec![".ts".into(), ".d.ts".into()],
+        ..ResolveOptions::default()
+    });
+    let from = f.join("src/routes/+page.ts");
+    let path = resolver.resolve(&from, "./$types").map(|r| r.full_path());
+    let expected = f.join(".svelte-kit/types/src/routes/$types.d.ts");
+    assert_eq!(path, Ok(expected), "from {from:?} resolve ./$types");
+}

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -121,6 +121,13 @@ impl TsConfig {
                     }
                 },
             );
+        if let Some(root_dirs) = &mut tsconfig.compiler_options.root_dirs {
+            for root_dir in root_dirs.iter_mut() {
+                if !root_dir.to_string_lossy().starts_with(TEMPLATE_VARIABLE) {
+                    *root_dir = canonical_directory.normalize_with(&root_dir);
+                }
+            }
+        }
         Ok(tsconfig)
     }
 
@@ -363,7 +370,11 @@ impl TsConfig {
 
         if let Some(root_dirs) = &mut self.compiler_options.root_dirs {
             for root_dir in root_dirs.iter_mut() {
-                *root_dir = config_dir.normalize_with(&root_dir);
+                if let Some(stripped_path) =
+                    root_dir.to_string_lossy().strip_prefix(TEMPLATE_VARIABLE)
+                {
+                    *root_dir = config_dir.join(stripped_path.trim_start_matches('/'));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Closes #1075.

`rootDirs` entries inherited via `extends` were being normalized against the caller tsconfig's directory at `build()` time, instead of against the directory of the config that actually declared them. This broke the SvelteKit pattern where `tsconfig.json` extends `.svelte-kit/tsconfig.json` and the latter declares `rootDirs: ["..", "./types"]` relative to itself.

## Fix

Mirror the established `paths_base` pattern: normalize non-template `rootDirs` entries at parse time against each config's own canonical directory (`canonical_path.parent()`). The `build()` step keeps `${configDir}` template substitution only, so templates still resolve against the root caller's directory as before.

After this change, `extend_tsconfig`'s existing clone-from-parent is correct without further work — the parent's entries are already absolute by the time the child inherits them.

## Verification

Cross-checked against TypeScript 6.0.3 via `tsc --traceResolution`:

- **SvelteKit case (no symlinks)** — TS resolves `rootDirs: ["..", "./types"]` declared in `.svelte-kit/tsconfig.json` against `.svelte-kit/`, exactly matching the fixed behavior.
- **Symlinked `extends`** (`node_modules/shared-config` → real-configs) — TS anchors inherited `rootDirs` at the **canonical** path of the parent config, matching the `paths_base` precedent landed in #1148.

Verified against typescript-go source (`internal/tsoptions/tsconfigparsing.go`): `rootDirs` is declared `IsFilePath: true` and `normalizeNonListOptionValue` calls `GetNormalizedAbsolutePath(value, basePath)` at parse time per config; `handleOptionConfigDirTemplateSubstitution` runs once afterward against the root caller's directory.

New fixture `fixtures/tsconfig/cases/root-dirs-extends/` mirrors the SvelteKit reproduction; new test `test_root_dirs_via_extends` fails on `main` (`NotFound("./$types")`) and passes after the fix.