### PR TITLE
fix(tsconfig): let project references take priority over their parent

### DIFF
--- a/fixtures/tsconfig/cases/project-references-priority/app/index.ts
+++ b/fixtures/tsconfig/cases/project-references-priority/app/index.ts
@@ -1,0 +1,3 @@
+import { foo } from "1/foo";
+
+foo();

--- a/fixtures/tsconfig/cases/project-references-priority/lib/foo.ts
+++ b/fixtures/tsconfig/cases/project-references-priority/lib/foo.ts
@@ -1,0 +1,1 @@
+export function foo() {}

--- a/fixtures/tsconfig/cases/project-references-priority/tsconfig.app.json
+++ b/fixtures/tsconfig/cases/project-references-priority/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "moduleResolution": "bundler",
+    "paths": {
+      "1/*": ["./lib/*"]
+    }
+  },
+  "include": ["app", "lib"]
+}

--- a/fixtures/tsconfig/cases/project-references-priority/tsconfig.json
+++ b/fixtures/tsconfig/cases/project-references-priority/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "./tsconfig.app.json" }]
+}

--- a/src/tests/tsconfck.rs
+++ b/src/tests/tsconfck.rs
@@ -65,8 +65,8 @@ fn part_of_solution() {
         ("mixed", "src/baz.cts", "tsconfig.src.json"),
         ("mixed", "src/foo.ts", "tsconfig.src.json"),
         ("mixed", "src/foo.spec.ts", "tsconfig.test.json"),
-        ("referenced-extends-original", "src/foo.ts", "tsconfig.json"),
-        ("referenced-extends-original", "tests/foo.test.ts", "tsconfig.json"),
+        ("referenced-extends-original", "src/foo.ts", "src/tsconfig.src.json"),
+        ("referenced-extends-original", "tests/foo.test.ts", "tests/tsconfig.test.json"),
         ("referenced-with-configDir", "src/foo.ts", "tsconfig.src.json"),
         (
             "referenced-with-configDir-and-extends",

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -152,3 +152,19 @@ fn references_with_extends() {
 
     assert_eq!(resolved_path, Ok(f.join("src/pages/index.tsx")));
 }
+
+#[test]
+fn referenced_paths_win_over_root_with_no_paths() {
+    let f = super::fixture_root().join("tsconfig/cases/project-references-priority");
+
+    let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".ts".into()],
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
+
+    let resolved_path =
+        resolver.resolve_file(f.join("app/index.ts"), "1/foo").map(|f| f.full_path());
+
+    assert_eq!(resolved_path, Ok(f.join("lib/foo.ts")));
+}

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -551,7 +551,6 @@ impl TsConfig {
     pub(crate) fn resolve_tsconfig_solution(tsconfig: Arc<Self>, path: &Path) -> Arc<Self> {
         if !tsconfig.references_resolved.is_empty()
             && tsconfig.is_file_extension_allowed_in_tsconfig(path)
-            && !tsconfig.is_file_included_in_tsconfig(path)
             && let Some(solution_tsconfig) = tsconfig
                 .references_resolved
                 .iter()


### PR DESCRIPTION
## Summary

Align with TypeScript's `isSourceOfProjectReferenceRedirect` semantics: when a parent tsconfig has `references`, a referenced sub-project that includes the file always wins, even when the parent's `include` / default `**/*` glob also covers it.

Previously the parent claimed ownership first and references were only consulted as a fallback. The biggest practical impact: a solution-style root (only `references`, no `include` / `files`) defaulted its include to `**/*`, claimed every file, and hid the referenced sub-project's `compilerOptions.paths` — exactly the bug in #1086 / rolldown/rolldown#8468.

## Changes

- **`src/tsconfig.rs`** — `resolve_tsconfig_solution` no longer requires that the file is *not* included in the parent; references are checked first whenever they exist.
- **`fixtures/tsconfig/cases/project-references-priority/`** — minimal repro: solution-style root + referenced `tsconfig.app.json` with `paths`; verified to match `tsgo` / `tsserver` behavior.
- **`src/tests/tsconfig_project_references.rs`** — new test `referenced_paths_win_over_root_with_no_paths` covering the fixture.
- **`src/tests/tsconfck.rs`** — `part_of_solution`'s two `referenced-extends-original` expectations updated from the root tsconfig to the matching referenced sub-projects. Verified against TypeScript 5.5.4 `tsserver` (`projectInfo` request); tsconfck's own behavior diverges from TypeScript here and we deliberately follow TypeScript per #1086.

## Verification

Probed all 18 `part_of_solution` cases against `tsserver`: 16/18 now match exactly (the two unrelated divergences pre-date this change and concern empty-include defaulting + solution-style fallback to inferredProject; left for follow-up).

Closes #1086. Helps rolldown/rolldown#8468.