### PR TITLE
fix(tsconfig): walk past a tsconfig that doesn't claim the file

### DIFF
--- a/fixtures/tsconfig/cases/project-references-walk-up/exclude-pattern/pkg-a/src/excluded/bar.ts
+++ b/fixtures/tsconfig/cases/project-references-walk-up/exclude-pattern/pkg-a/src/excluded/bar.ts
@@ -1,0 +1,2 @@
+import { foo } from "@/foo";
+foo;

--- a/fixtures/tsconfig/cases/project-references-walk-up/exclude-pattern/pkg-a/src/foo.ts
+++ b/fixtures/tsconfig/cases/project-references-walk-up/exclude-pattern/pkg-a/src/foo.ts
@@ -1,0 +1,1 @@
+export const foo = 1;

--- a/fixtures/tsconfig/cases/project-references-walk-up/exclude-pattern/pkg-a/tsconfig.json
+++ b/fixtures/tsconfig/cases/project-references-walk-up/exclude-pattern/pkg-a/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/excluded/**/*"]
+}

--- a/fixtures/tsconfig/cases/project-references-walk-up/exclude-pattern/tsconfig.json
+++ b/fixtures/tsconfig/cases/project-references-walk-up/exclude-pattern/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "include": ["pkg-a/**/*"],
+  "references": [{ "path": "./pkg-a" }]
+}

--- a/fixtures/tsconfig/cases/project-references-walk-up/files-misses/pkg-a/src/bar.ts
+++ b/fixtures/tsconfig/cases/project-references-walk-up/files-misses/pkg-a/src/bar.ts
@@ -1,0 +1,2 @@
+import { foo } from "@/foo";
+foo;

--- a/fixtures/tsconfig/cases/project-references-walk-up/files-misses/pkg-a/src/foo.ts
+++ b/fixtures/tsconfig/cases/project-references-walk-up/files-misses/pkg-a/src/foo.ts
@@ -1,0 +1,1 @@
+export const foo = 1;

--- a/fixtures/tsconfig/cases/project-references-walk-up/files-misses/pkg-a/tsconfig.json
+++ b/fixtures/tsconfig/cases/project-references-walk-up/files-misses/pkg-a/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "files": ["src/foo.ts"]
+}

--- a/fixtures/tsconfig/cases/project-references-walk-up/files-misses/tsconfig.json
+++ b/fixtures/tsconfig/cases/project-references-walk-up/files-misses/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "include": ["pkg-a/**/*"],
+  "references": [{ "path": "./pkg-a" }]
+}

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -168,3 +168,39 @@ fn referenced_paths_win_over_root_with_no_paths() {
 
     assert_eq!(resolved_path, Ok(f.join("lib/foo.ts")));
 }
+
+#[test]
+fn walk_up_when_ref_files_does_not_cover_file() {
+    let f = super::fixture_root().join("tsconfig/cases/project-references-walk-up/files-misses");
+
+    let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".ts".into()],
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
+
+    let tsconfig = resolver.find_tsconfig(f.join("pkg-a/src/bar.ts")).unwrap().unwrap();
+    assert_eq!(tsconfig.path(), f.join("tsconfig.json"));
+
+    let resolved_path =
+        resolver.resolve_file(f.join("pkg-a/src/bar.ts"), "@/foo").map(|f| f.full_path());
+    assert_eq!(resolved_path, Err(ResolveError::NotFound("@/foo".into())));
+}
+
+#[test]
+fn walk_up_when_ref_excludes_file() {
+    let f = super::fixture_root().join("tsconfig/cases/project-references-walk-up/exclude-pattern");
+
+    let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".ts".into()],
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
+
+    let tsconfig = resolver.find_tsconfig(f.join("pkg-a/src/excluded/bar.ts")).unwrap().unwrap();
+    assert_eq!(tsconfig.path(), f.join("tsconfig.json"));
+
+    let resolved_path =
+        resolver.resolve_file(f.join("pkg-a/src/excluded/bar.ts"), "@/foo").map(|f| f.full_path());
+    assert_eq!(resolved_path, Err(ResolveError::NotFound("@/foo".into())));
+}

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -562,6 +562,33 @@ impl TsConfig {
         tsconfig
     }
 
+    /// Whether this tsconfig (directly or via a referenced sub-project) claims
+    /// ownership of `path`. Used by tsconfig auto-discovery to decide whether
+    /// to keep walking up to an ancestor `tsconfig.json` when the nearest one
+    /// doesn't actually cover the file via its `files` / `include` / `exclude`
+    /// or via a matching reference.
+    pub(crate) fn claims_ownership_of(&self, path: &Path) -> bool {
+        // Non-TS files aren't considered for project ownership; preserve the
+        // legacy behavior of using the nearest tsconfig for them.
+        if !self.is_file_extension_allowed_in_tsconfig(path) {
+            return true;
+        }
+        // Any matching reference claims ownership (consistent with
+        // resolve_tsconfig_solution).
+        if self.references_resolved.iter().any(|r| r.is_file_included_in_tsconfig(path)) {
+            return true;
+        }
+        // Solution-style configs (have `references` and no own `files` /
+        // `include`) never claim files themselves.
+        let is_solution_style = !self.references_resolved.is_empty()
+            && self.files.as_ref().is_none_or(Vec::is_empty)
+            && self.include.as_ref().is_none_or(Vec::is_empty);
+        if is_solution_style {
+            return false;
+        }
+        self.is_file_included_in_tsconfig(path)
+    }
+
     fn is_file_included_in_tsconfig(&self, path: &Path) -> bool {
         // 1. Check files array (highest priority - overrides exclude)
         if self.files.as_ref().is_some_and(|files| files.iter().any(|file| Path::new(file) == path))

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -110,6 +110,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     ) -> Result<Option<Arc<TsConfig>>, ResolveError> {
         let mut ctx = Ctx::default();
         let mut cache_value = Some(cached_path.clone());
+        let mut fallback: Option<Arc<TsConfig>> = None;
         while let Some(cv) = cache_value {
             if let Some(tsconfig) = cv.tsconfig.get_or_try_init(|| {
                 let tsconfig_path = cv.path.join("tsconfig.json");
@@ -126,11 +127,18 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                     Ok(None)
                 }
             })? {
-                return Ok(Some(Arc::clone(tsconfig)));
+                if tsconfig.claims_ownership_of(cached_path.path()) {
+                    return Ok(Some(Arc::clone(tsconfig)));
+                }
+                // Remember the OUTERMOST non-claiming tsconfig as the fallback.
+                // typescript-go would return null here (no project owns), but
+                // TypeScript 6.0's tsserver returns the solution root, which we
+                // approximate by always preferring the topmost ancestor.
+                fallback = Some(Arc::clone(tsconfig));
             }
             cache_value = cv.parent(&self.cache);
         }
-        Ok(None)
+        Ok(fallback)
     }
 
     pub(crate) fn find_tsconfig_manual(


### PR DESCRIPTION
## Summary

`find_tsconfig_auto` previously returned the nearest `tsconfig.json` unconditionally. If that nearest tsconfig had narrow `files` / `include` / `exclude` that didn't cover the file under resolution, its `compilerOptions.paths` were still applied — leaking the project's aliases into files the project doesn't actually own.

The fix: after finding a `tsconfig.json`, check `claims_ownership_of` (does its `files`/`include`/`exclude` cover the file, or does any matching reference?). If no, remember it as a fallback and walk up to the next ancestor. Mirrors TypeScript 6.0 tsserver and typescript-go's `findDefaultConfiguredProjectWorker`.

## Concrete repros (now fixed)

```
fixtures/tsconfig/cases/project-references-walk-up/
├── files-misses/      pkg-a has files: ["src/foo.ts"] + paths: { "@/*": [...] }
│                      → import "@/foo" from pkg-a/src/bar.ts no longer resolves
│                        via pkg-a's paths (bar.ts isn't in pkg-a's program)
└── exclude-pattern/   pkg-a has include + exclude that removes src/excluded/bar.ts
                       → same fix
```

## Alignment with TypeScript 6.0

Verified all 15 hand-crafted probe scenarios against `tsserver` from TypeScript 6.0.3 — **15 / 15 match**, including:

- solution-style root with matching / non-matching reference
- multi-ref priority (first declared wins)
- nested / cross-directory `include`
- `files` / `include` + `exclude` permutations

## Known divergences from typescript-go (out of scope here)

- **Transitive references** — typescript-go does BFS through the full reference graph; we only check direct `references_resolved`. Triggers only with deep nested references claiming cross-directory files; not observed in real projects.
- **Fallback in the no-claim-anywhere case** — typescript-go returns `nil` (inferred project); we return the topmost ancestor tsconfig. This matches TypeScript 6.0 tsserver but not typescript-go.