### PR TITLE
fix(tsconfig): apply later-wins semantics for extends array

### DIFF
--- a/src/tests/tsconfig_lookup.rs
+++ b/src/tests/tsconfig_lookup.rs
@@ -193,7 +193,6 @@ fn extends_folder_resolves_to_tsconfig_json() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "bug: oxc-resolver merges extends array with first-wins instead of TypeScript's spec'd later-wins"]
 fn extends_array_last_wins() {
     let f = super::fixture_root().join("tsconfig/cases/extends-array-last-wins");
 

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -200,14 +200,20 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 ));
             }
 
-            // Extend tsconfig
+            // Extend tsconfig.
+            //
+            // Per TypeScript spec, when the `extends` field is an array later
+            // configurations take precedence over earlier ones. Since
+            // `extend_tsconfig` only fills `None` fields, we iterate in reverse
+            // so that the last base sets fields first and earlier bases can no
+            // longer override them — net effect: later wins.
             let extended_tsconfig_paths = tsconfig
                 .extends()
                 .map(|specifier| self.get_extended_tsconfig_path(&directory, tsconfig, specifier))
                 .collect::<Result<Vec<_>, _>>()?;
             if !extended_tsconfig_paths.is_empty() {
                 ctx.with_extended_file(tsconfig.path().to_owned(), |ctx| {
-                    for extended_tsconfig_path in extended_tsconfig_paths {
+                    for extended_tsconfig_path in extended_tsconfig_paths.into_iter().rev() {
                         let extended_tsconfig = self.load_tsconfig(
                             /* root */ false,
                             &extended_tsconfig_path,
@@ -259,7 +265,9 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             .extends()
             .map(|specifier| self.get_extended_tsconfig_path(directory, tsconfig, specifier))
             .collect::<Result<Vec<_>, _>>()?;
-        for extended_tsconfig_path in extended_tsconfig_paths {
+        // Iterate in reverse so that later `extends` entries take precedence —
+        // see comment in `load_tsconfig`.
+        for extended_tsconfig_path in extended_tsconfig_paths.into_iter().rev() {
             let extended_tsconfig = self.load_tsconfig(
                 /* root */ false,
                 &extended_tsconfig_path,


### PR DESCRIPTION
## Summary

Per TypeScript spec, when `extends` is an array, later configurations override earlier ones. typescript-go implements this by accumulating into a result that each base overwrites in turn (`applyExtendedConfig` → `mergeCompilerOptions`).

oxc-resolver's `extend_tsconfig` only fills `None` fields, so iterating forward made the first base set a value, blocking later bases from overriding it — **first-wins** instead of later-wins.

**Fix:** iterate `extended_tsconfig_paths` in reverse in both extend sites (`load_tsconfig` and the project-references `extend_tsconfig`). The last base now sets fields first; earlier bases see them set and skip; the child's own explicit fields (set before any extend) still win because they're populated before either loop runs.

Removes the `#[ignore]` on `tsconfig_lookup::extends_array_last_wins` (added in #1155) which now passes. The existing `extends-multiple` test still passes because it resolves via `baseUrl` fall-through, not via the order of inherited `paths`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)