### PR TITLE
feat(tsconfig): surface loaded tsconfig files via ResolveContext

### DIFF
--- a/fixtures/tsconfig/cases/extends-with-broken-base/tsconfig.base.json
+++ b/fixtures/tsconfig/cases/extends-with-broken-base/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl":,
+  }
+}

--- a/fixtures/tsconfig/cases/extends-with-broken-base/tsconfig.json
+++ b/fixtures/tsconfig/cases/extends-with-broken-base/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.base.json"
+}

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -192,16 +192,32 @@ impl<Fs: FileSystem> Cache<Fs> {
             .cloned()
     }
 
-    pub(crate) fn get_tsconfig<F: FnOnce(&mut TsConfig) -> Result<(), ResolveError>>(
+    /// Walk a cached tsconfig and record every file that contributed to it
+    /// (the tsconfig itself, any `extends` targets, and any project references)
+    /// as a file dependency on `ctx`. Used on cache hits so dependency tracking
+    /// stays correct without re-running the load.
+    pub(crate) fn record_tsconfig_dependencies(tsconfig: &TsConfig, ctx: &mut Ctx) {
+        ctx.add_file_dependency(tsconfig.path());
+        for extended_path in &tsconfig.extended_paths {
+            ctx.add_file_dependency(extended_path);
+        }
+        for referenced in &tsconfig.references_resolved {
+            Self::record_tsconfig_dependencies(referenced, ctx);
+        }
+    }
+
+    pub(crate) fn get_tsconfig<F: FnOnce(&mut TsConfig, &mut Ctx) -> Result<(), ResolveError>>(
         &self,
         root: bool,
         path: &Path,
+        ctx: &mut Ctx,
         callback: F, // callback for modifying tsconfig with `extends`
     ) -> Result<Arc<TsConfig>, ResolveError> {
         // For root=true (caller tsconfig), check built cache first
         if root {
             let tsconfigs_built = self.tsconfigs_built.pin();
             if let Some(tsconfig) = tsconfigs_built.get(path) {
+                Self::record_tsconfig_dependencies(tsconfig, ctx);
                 return Ok(Arc::clone(tsconfig));
             }
         }
@@ -211,6 +227,7 @@ impl<Fs: FileSystem> Cache<Fs> {
         if !root {
             let tsconfigs_raw = self.tsconfigs_raw.pin();
             if let Some(tsconfig) = tsconfigs_raw.get(path) {
+                Self::record_tsconfig_dependencies(tsconfig, ctx);
                 return Ok(Arc::clone(tsconfig));
             }
         }
@@ -228,11 +245,17 @@ impl<Fs: FileSystem> Cache<Fs> {
         };
         let tsconfig_string = self.fs.read_to_string(&tsconfig_path).map_err(|err| {
             if err.kind() == io::ErrorKind::NotFound {
+                ctx.add_missing_dependency(&tsconfig_path);
                 ResolveError::TsconfigNotFound(path.to_path_buf())
             } else {
+                ctx.add_file_dependency(&tsconfig_path);
                 ResolveError::from(err)
             }
         })?;
+        // The file was read successfully — record it as a dependency even if
+        // JSON parsing or downstream processing fails, so callers watching the
+        // file can re-run when it's edited.
+        ctx.add_file_dependency(&tsconfig_path);
         let canonical_path = self
             .canonicalize(&self.value(&tsconfig_path))
             .unwrap_or_else(|_| tsconfig_path.to_path_buf());
@@ -242,7 +265,7 @@ impl<Fs: FileSystem> Cache<Fs> {
             })?;
 
         // Run callback (extends/references processing)
-        callback(&mut tsconfig)?;
+        callback(&mut tsconfig, ctx)?;
 
         // Cache raw version (callback applied, not built)
         tsconfig.set_should_build(false);

--- a/src/dts_resolver.rs
+++ b/src/dts_resolver.rs
@@ -710,7 +710,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     ) -> ResolveResult {
         // Reuse the existing tsconfig resolution
         let tsconfig = match &self.options.tsconfig {
-            Some(crate::TsconfigDiscovery::Manual(o)) => self.find_tsconfig_manual(o)?,
+            Some(crate::TsconfigDiscovery::Manual(o)) => self.find_tsconfig_manual(o, ctx)?,
             _ => None,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         let mut ctx = Ctx::default();
         let path = directory.as_ref();
         let tsconfig = match &self.options.tsconfig {
-            Some(TsconfigDiscovery::Manual(o)) => self.find_tsconfig_manual(o)?,
+            Some(TsconfigDiscovery::Manual(o)) => self.find_tsconfig_manual(o, &mut ctx)?,
             _ => None,
         };
         self.resolve_tracing(path, specifier, tsconfig.as_deref(), &mut ctx)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -27,6 +27,7 @@ mod scoped_packages;
 mod simple;
 mod symlink;
 mod tsconfck;
+mod tsconfig_dependencies;
 mod tsconfig_discovery;
 mod tsconfig_extends;
 mod tsconfig_lookup;

--- a/src/tests/tsconfig_dependencies.rs
+++ b/src/tests/tsconfig_dependencies.rs
@@ -1,0 +1,155 @@
+use crate::{
+    ResolveContext, ResolveError, ResolveOptions, Resolver, TsconfigDiscovery, TsconfigOptions,
+    TsconfigReferences,
+};
+
+#[test]
+fn resolve_tsconfig_with_context_records_self_and_extends() {
+    let f = super::fixture_root().join("tsconfig/cases/extends");
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: f.join("tsconfig.json"),
+            references: TsconfigReferences::Disabled,
+        })),
+        ..ResolveOptions::default()
+    });
+
+    let mut ctx = ResolveContext::default();
+    resolver.resolve_tsconfig_with_context(f.join("tsconfig.json"), &mut ctx).expect("resolved");
+
+    assert!(
+        ctx.file_dependencies.contains(&f.join("tsconfig.json")),
+        "expected root tsconfig in deps: {:?}",
+        ctx.file_dependencies
+    );
+    assert!(
+        ctx.file_dependencies.contains(&f.join("base-tsconfig.json")),
+        "expected extended tsconfig in deps: {:?}",
+        ctx.file_dependencies
+    );
+}
+
+#[test]
+fn resolve_tsconfig_with_context_records_extends_on_parse_error() {
+    let f = super::fixture_root().join("tsconfig/cases/extends-with-broken-base");
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: f.join("tsconfig.json"),
+            references: TsconfigReferences::Disabled,
+        })),
+        ..ResolveOptions::default()
+    });
+
+    let mut ctx = ResolveContext::default();
+    let result = resolver.resolve_tsconfig_with_context(f.join("tsconfig.json"), &mut ctx);
+
+    assert!(matches!(result, Err(ResolveError::Json(_))), "expected JSON error, got {result:?}");
+    assert!(
+        ctx.file_dependencies.contains(&f.join("tsconfig.json")),
+        "expected root tsconfig in deps: {:?}",
+        ctx.file_dependencies
+    );
+    assert!(
+        ctx.file_dependencies.contains(&f.join("tsconfig.base.json")),
+        "expected broken extended tsconfig in deps: {:?}",
+        ctx.file_dependencies
+    );
+}
+
+#[test]
+fn resolve_tsconfig_with_context_records_missing_extends() {
+    let f = super::fixture_root().join("tsconfig/cases/extends-not-found");
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: f.join("tsconfig.json"),
+            references: TsconfigReferences::Disabled,
+        })),
+        ..ResolveOptions::default()
+    });
+
+    let mut ctx = ResolveContext::default();
+    let result = resolver.resolve_tsconfig_with_context(f.join("tsconfig.json"), &mut ctx);
+
+    assert!(matches!(result, Err(ResolveError::TsconfigNotFound(_))));
+    assert!(
+        ctx.file_dependencies.contains(&f.join("tsconfig.json")),
+        "expected root tsconfig in deps: {:?}",
+        ctx.file_dependencies
+    );
+}
+
+#[test]
+fn find_tsconfig_with_context_records_deps_for_auto_discovery() {
+    let f = super::fixture_root().join("tsconfig/cases/extends");
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
+
+    let mut ctx = ResolveContext::default();
+    resolver.find_tsconfig_with_context(f.join("src.ts"), &mut ctx).expect("resolved");
+
+    assert!(
+        ctx.file_dependencies.contains(&f.join("tsconfig.json")),
+        "expected discovered tsconfig in deps: {:?}",
+        ctx.file_dependencies
+    );
+    assert!(
+        ctx.file_dependencies.contains(&f.join("base-tsconfig.json")),
+        "expected extended tsconfig in deps: {:?}",
+        ctx.file_dependencies
+    );
+}
+
+#[test]
+fn resolve_tsconfig_with_context_records_transitive_extends() {
+    let f = super::fixture_root().join("tsconfig/cases/extends-chain");
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: f.join("tsconfig.json"),
+            references: TsconfigReferences::Disabled,
+        })),
+        ..ResolveOptions::default()
+    });
+
+    resolver.resolve_tsconfig(f.join("tsconfig.json")).expect("resolved");
+
+    let mut ctx = ResolveContext::default();
+    resolver.resolve_tsconfig_with_context(f.join("tsconfig.json"), &mut ctx).expect("resolved");
+
+    for name in ["tsconfig.json", "intermediate-tsconfig.json", "base-tsconfig.json"] {
+        assert!(
+            ctx.file_dependencies.contains(&f.join(name)),
+            "expected {name} in deps after warm-cache call: {:?}",
+            ctx.file_dependencies
+        );
+    }
+}
+
+#[test]
+fn resolve_tsconfig_with_context_replays_deps_on_cache_hit() {
+    let f = super::fixture_root().join("tsconfig/cases/extends");
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: f.join("tsconfig.json"),
+            references: TsconfigReferences::Disabled,
+        })),
+        ..ResolveOptions::default()
+    });
+
+    resolver.resolve_tsconfig(f.join("tsconfig.json")).expect("resolved");
+
+    let mut ctx = ResolveContext::default();
+    resolver.resolve_tsconfig_with_context(f.join("tsconfig.json"), &mut ctx).expect("resolved");
+
+    assert!(
+        ctx.file_dependencies.contains(&f.join("tsconfig.json")),
+        "expected root tsconfig in deps after cache hit: {:?}",
+        ctx.file_dependencies
+    );
+    assert!(
+        ctx.file_dependencies.contains(&f.join("base-tsconfig.json")),
+        "expected extended tsconfig in deps after cache hit: {:?}",
+        ctx.file_dependencies
+    );
+}

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     JSONError, ResolveError, ResolveOptions, Resolver, TsconfigDiscovery, TsconfigOptions,
-    TsconfigReferences,
+    TsconfigReferences, context::ResolveContext as Ctx,
 };
 
 // <https://github.com/parcel-bundler/parcel/blob/b6224fd519f95e68d8b93ba90376fd94c8b76e69/packages/utils/node-resolver-rs/src/lib.rs#L2303>
@@ -304,7 +304,10 @@ fn test_tsconfig_mixed_root_non_root_cache() {
         tsconfig: Some(TsconfigDiscovery::Auto),
         ..ResolveOptions::default()
     });
-    resolver.cache.get_tsconfig(false, &f2.join("tsconfig.json"), |_| Ok(())).unwrap();
+    resolver
+        .cache
+        .get_tsconfig(false, &f2.join("tsconfig.json"), &mut Ctx::default(), |_, _| Ok(()))
+        .unwrap();
     let resolved_path =
         resolver.resolve_file(f2.join("foo.ts"), "bar/index.ts").map(|f| f.full_path());
     assert_eq!(resolved_path, Ok(f2.join("bar/index.ts")));
@@ -319,7 +322,10 @@ fn test_tsconfig_mixed_root_non_root_cache2() {
         tsconfig: Some(TsconfigDiscovery::Auto),
         ..ResolveOptions::default()
     });
-    resolver.cache.get_tsconfig(true, &f2.join("tsconfig.base.json"), |_| Ok(())).unwrap();
+    resolver
+        .cache
+        .get_tsconfig(true, &f2.join("tsconfig.base.json"), &mut Ctx::default(), |_, _| Ok(()))
+        .unwrap();
     let resolved_path =
         resolver.resolve_file(f2.join("test.ts"), "@/index.js").map(|f| f.full_path());
     assert_eq!(resolved_path, Ok(f2.join("src/index.js")));
@@ -334,7 +340,10 @@ fn test_tsconfig_mixed_root_non_root_cache3() {
         tsconfig: Some(TsconfigDiscovery::Auto),
         ..ResolveOptions::default()
     });
-    resolver.cache.get_tsconfig(false, &f2.join("tsconfig.json"), |_| Ok(())).unwrap();
+    resolver
+        .cache
+        .get_tsconfig(false, &f2.join("tsconfig.json"), &mut Ctx::default(), |_, _| Ok(()))
+        .unwrap();
     let resolved_path =
         resolver.resolve_file(f2.join("test.ts"), "@/index.js").map(|f| f.full_path());
     assert_eq!(resolved_path, Ok(f2.join("src/index.js")));

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -76,6 +76,13 @@ pub struct TsConfig {
     /// Corresponds to each item in [TsConfig::references].
     #[serde(skip)]
     pub references_resolved: Vec<Arc<Self>>,
+
+    /// Resolved file paths from the [`extends`](TsConfig::extends) field.
+    ///
+    /// Populated during loading so dependency-tracking callers can replay the
+    /// full set of files that contributed to a cached tsconfig.
+    #[serde(skip)]
+    pub(crate) extended_paths: Vec<PathBuf>,
 }
 
 impl TsConfig {

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -4,10 +4,19 @@ use std::{
 };
 
 use crate::{
-    CachedPath, Ctx, FileSystem, ResolveError, ResolveOptions, ResolveResult, ResolverGeneric,
-    Specifier, SpecifierError, TsConfig, TsconfigDiscovery, TsconfigOptions, TsconfigReferences,
-    path::PathUtil,
+    CachedPath, Ctx, FileSystem, ResolveContext, ResolveError, ResolveOptions, ResolveResult,
+    ResolverGeneric, Specifier, SpecifierError, TsConfig, TsconfigDiscovery, TsconfigOptions,
+    TsconfigReferences, path::PathUtil,
 };
+
+fn merge_dependencies(ctx: &mut Ctx, resolve_context: &mut ResolveContext) {
+    if let Some(deps) = &mut ctx.file_dependencies {
+        resolve_context.file_dependencies.extend(deps.drain(..));
+    }
+    if let Some(deps) = &mut ctx.missing_dependencies {
+        resolve_context.missing_dependencies.extend(deps.drain(..));
+    }
+}
 
 #[derive(Default)]
 pub struct TsconfigResolveContext {
@@ -53,16 +62,46 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         &self,
         path: P,
     ) -> Result<Option<Arc<TsConfig>>, ResolveError> {
-        let path = path.as_ref().to_string_lossy();
+        self.find_tsconfig_impl_entry(path.as_ref(), &mut Ctx::default())
+    }
+
+    /// Same as [`Self::find_tsconfig`], but also records every tsconfig file
+    /// that was read (or attempted) on `resolve_context`.
+    ///
+    /// Dependencies are populated even when this method returns an error, so
+    /// callers can watch every file that contributed to the failed load.
+    ///
+    /// # Errors
+    ///
+    /// * Returns an error if the tsconfig is invalid, including any extended or referenced tsconfigs.
+    pub fn find_tsconfig_with_context<P: AsRef<Path>>(
+        &self,
+        path: P,
+        resolve_context: &mut ResolveContext,
+    ) -> Result<Option<Arc<TsConfig>>, ResolveError> {
+        let mut ctx = Ctx::default();
+        ctx.init_file_dependencies();
+        let result = self.find_tsconfig_impl_entry(path.as_ref(), &mut ctx);
+        merge_dependencies(&mut ctx, resolve_context);
+        result
+    }
+
+    fn find_tsconfig_impl_entry(
+        &self,
+        path: &Path,
+        ctx: &mut Ctx,
+    ) -> Result<Option<Arc<TsConfig>>, ResolveError> {
+        let path = path.to_string_lossy();
         let specifier = Specifier::parse(path.as_ref()).map_err(ResolveError::Specifier)?;
         let path = Path::new(specifier.path());
         let cached_path = self.cache.value(path);
-        self.find_tsconfig_tracing(&cached_path)
+        self.find_tsconfig_tracing(&cached_path, ctx)
     }
 
     fn find_tsconfig_tracing(
         &self,
         cached_path: &CachedPath,
+        ctx: &mut Ctx,
     ) -> Result<Option<Arc<TsConfig>>, ResolveError> {
         // Don't discover tsconfig for paths inside node_modules
         if cached_path.inside_node_modules() {
@@ -74,10 +113,10 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         }
         let span = tracing::debug_span!("find_tsconfig", path = %cached_path);
         let _enter = span.enter();
-        cached_path
+        let result = cached_path
             .resolved_tsconfig
             .get_or_try_init(|| {
-                self.find_tsconfig_impl(cached_path).map(|option_tsconfig| {
+                self.find_tsconfig_impl(cached_path, ctx).map(|option_tsconfig| {
                     option_tsconfig.map(|tsconfig| {
                         let r = TsConfig::resolve_tsconfig_solution(tsconfig, cached_path.path());
                         tracing::debug!(path = %cached_path, ret = ?r);
@@ -85,7 +124,15 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                     })
                 })
             })
-            .cloned()
+            .cloned()?;
+        // On cache hit, the closure above didn't run, so dependencies were
+        // never recorded against this ctx. Walk the cached tsconfig and emit
+        // them explicitly. Recording is idempotent because callers dedupe via
+        // FxHashSet at the boundary.
+        if let Some(tsconfig) = &result {
+            crate::Cache::<Fs>::record_tsconfig_dependencies(tsconfig, ctx);
+        }
+        Ok(result)
     }
 
     /// Find tsconfig.json of a path by traversing parent directories.
@@ -96,27 +143,28 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     fn find_tsconfig_impl(
         &self,
         cached_path: &CachedPath,
+        ctx: &mut Ctx,
     ) -> Result<Option<Arc<TsConfig>>, ResolveError> {
         match &self.options.tsconfig {
             None => Ok(None),
-            Some(TsconfigDiscovery::Auto) => self.find_tsconfig_auto(cached_path),
-            Some(TsconfigDiscovery::Manual(o)) => self.find_tsconfig_manual(o),
+            Some(TsconfigDiscovery::Auto) => self.find_tsconfig_auto(cached_path, ctx),
+            Some(TsconfigDiscovery::Manual(o)) => self.find_tsconfig_manual(o, ctx),
         }
     }
 
     fn find_tsconfig_auto(
         &self,
         cached_path: &CachedPath,
+        ctx: &mut Ctx,
     ) -> Result<Option<Arc<TsConfig>>, ResolveError> {
-        let mut ctx = Ctx::default();
         let mut cache_value = Some(cached_path.clone());
         let mut fallback: Option<Arc<TsConfig>> = None;
         while let Some(cv) = cache_value {
-            if let Some(tsconfig) = cv.tsconfig.get_or_try_init(|| {
+            let entry = cv.tsconfig.get_or_try_init(|| {
                 let tsconfig_path = cv.path.join("tsconfig.json");
                 let tsconfig_path = self.cache.value(&tsconfig_path);
-                if self.cache.is_file(&tsconfig_path, &mut ctx) {
-                    match self.resolve_tsconfig(tsconfig_path.path()) {
+                if self.cache.is_file(&tsconfig_path, ctx) {
+                    match self.resolve_tsconfig_with_ctx(tsconfig_path.path(), ctx) {
                         Ok(tsconfig) => Ok(Some(tsconfig)),
                         // Skip unreadable tsconfig files (e.g. permission denied)
                         // and continue walking parent directories
@@ -126,7 +174,11 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 } else {
                     Ok(None)
                 }
-            })? {
+            })?;
+            if let Some(tsconfig) = entry {
+                // Always re-emit deps for cache hits — see comment in
+                // `find_tsconfig_tracing`.
+                crate::Cache::<Fs>::record_tsconfig_dependencies(tsconfig, ctx);
                 if tsconfig.claims_ownership_of(cached_path.path()) {
                     return Ok(Some(Arc::clone(tsconfig)));
                 }
@@ -144,22 +196,29 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     pub(crate) fn find_tsconfig_manual(
         &self,
         tsconfig_options: &TsconfigOptions,
+        ctx: &mut Ctx,
     ) -> Result<Option<Arc<TsConfig>>, ResolveError> {
         // Cache the loaded tsconfig in /
-        self.cache
+        let result = self
+            .cache
             .value(Path::new("/"))
             .tsconfig
             .get_or_try_init(|| {
-                let mut ctx = TsconfigResolveContext::default();
+                let mut tctx = TsconfigResolveContext::default();
                 self.load_tsconfig(
                     true,
                     &tsconfig_options.config_file,
                     tsconfig_options.references,
-                    &mut ctx,
+                    &mut tctx,
+                    ctx,
                 )
                 .map(Some)
             })
-            .cloned()
+            .cloned()?;
+        if let Some(tsconfig) = &result {
+            crate::Cache::<Fs>::record_tsconfig_dependencies(tsconfig, ctx);
+        }
+        Ok(result)
     }
 
     /// Resolve `tsconfig`.
@@ -174,13 +233,40 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     ///
     /// * See [ResolveError]
     pub fn resolve_tsconfig<P: AsRef<Path>>(&self, path: P) -> Result<Arc<TsConfig>, ResolveError> {
-        let path = path.as_ref();
+        self.resolve_tsconfig_with_ctx(path.as_ref(), &mut Ctx::default())
+    }
+
+    /// Same as [`Self::resolve_tsconfig`], but also records every tsconfig
+    /// file that was read (or attempted) on `resolve_context`.
+    ///
+    /// Dependencies are populated even when this method returns an error.
+    ///
+    /// # Errors
+    ///
+    /// * See [ResolveError]
+    pub fn resolve_tsconfig_with_context<P: AsRef<Path>>(
+        &self,
+        path: P,
+        resolve_context: &mut ResolveContext,
+    ) -> Result<Arc<TsConfig>, ResolveError> {
+        let mut ctx = Ctx::default();
+        ctx.init_file_dependencies();
+        let result = self.resolve_tsconfig_with_ctx(path.as_ref(), &mut ctx);
+        merge_dependencies(&mut ctx, resolve_context);
+        result
+    }
+
+    fn resolve_tsconfig_with_ctx(
+        &self,
+        path: &Path,
+        ctx: &mut Ctx,
+    ) -> Result<Arc<TsConfig>, ResolveError> {
         let references = match &self.options.tsconfig {
             Some(TsconfigDiscovery::Manual(o)) => o.references,
             Some(TsconfigDiscovery::Auto) => TsconfigReferences::Auto,
             None => TsconfigReferences::Disabled,
         };
-        self.load_tsconfig(true, path, references, &mut TsconfigResolveContext::default())
+        self.load_tsconfig(true, path, references, &mut TsconfigResolveContext::default(), ctx)
     }
 
     fn load_tsconfig(
@@ -188,15 +274,16 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         root: bool,
         path: &Path,
         references: TsconfigReferences,
-        ctx: &mut TsconfigResolveContext,
+        tctx: &mut TsconfigResolveContext,
+        ctx: &mut Ctx,
     ) -> Result<Arc<TsConfig>, ResolveError> {
-        self.cache.get_tsconfig(root, path, |tsconfig| {
+        self.cache.get_tsconfig(root, path, ctx, |tsconfig, ctx| {
             let directory = self.cache.value(tsconfig.directory());
             tracing::trace!(tsconfig = ?tsconfig, "load_tsconfig");
 
-            if ctx.is_already_extended(tsconfig.path()) {
+            if tctx.is_already_extended(tsconfig.path()) {
                 return Err(ResolveError::TsconfigCircularExtend(
-                    ctx.get_extended_configs_with(tsconfig.path().to_path_buf()).into(),
+                    tctx.get_extended_configs_with(tsconfig.path().to_path_buf()).into(),
                 ));
             }
 
@@ -211,15 +298,27 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 .extends()
                 .map(|specifier| self.get_extended_tsconfig_path(&directory, tsconfig, specifier))
                 .collect::<Result<Vec<_>, _>>()?;
+            // Seed with the direct `extends` targets up front so paths that
+            // fail to load (e.g. NotFound, JSON parse error) are still
+            // surfaced as dependencies. Transitive bases are appended after
+            // each successful load below.
+            tsconfig.extended_paths.clone_from(&extended_tsconfig_paths);
             if !extended_tsconfig_paths.is_empty() {
-                ctx.with_extended_file(tsconfig.path().to_owned(), |ctx| {
+                tctx.with_extended_file(tsconfig.path().to_owned(), |tctx| {
                     for extended_tsconfig_path in extended_tsconfig_paths.into_iter().rev() {
                         let extended_tsconfig = self.load_tsconfig(
                             /* root */ false,
                             &extended_tsconfig_path,
                             TsconfigReferences::Disabled,
+                            tctx,
                             ctx,
                         )?;
+                        // Flatten the base's own transitive extends so a
+                        // cache-hit replay of this tsconfig emits the whole
+                        // chain (A→B→C must surface C too).
+                        tsconfig
+                            .extended_paths
+                            .extend(extended_tsconfig.extended_paths.iter().cloned());
                         tsconfig.extend_tsconfig(&extended_tsconfig);
                     }
                     Result::Ok::<(), ResolveError>(())
@@ -234,7 +333,8 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                     let referenced_tsconfig = self.cache.get_tsconfig(
                         /* root */ true,
                         &reference_tsconfig_path,
-                        |reference_tsconfig| {
+                        ctx,
+                        |reference_tsconfig, ctx| {
                             if reference_tsconfig.path() == path {
                                 return Err(ResolveError::TsconfigSelfReference(
                                     reference_tsconfig.path().to_path_buf(),
@@ -243,6 +343,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                             self.extend_tsconfig(
                                 &self.cache.value(reference_tsconfig.directory()),
                                 reference_tsconfig,
+                                tctx,
                                 ctx,
                             )?;
                             Ok(())
@@ -259,12 +360,16 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         &self,
         directory: &CachedPath,
         tsconfig: &mut TsConfig,
-        ctx: &mut TsconfigResolveContext,
+        tctx: &mut TsconfigResolveContext,
+        ctx: &mut Ctx,
     ) -> Result<(), ResolveError> {
         let extended_tsconfig_paths = tsconfig
             .extends()
             .map(|specifier| self.get_extended_tsconfig_path(directory, tsconfig, specifier))
             .collect::<Result<Vec<_>, _>>()?;
+        // See `load_tsconfig`: seed with direct extends, flatten transitive
+        // bases after each successful load.
+        tsconfig.extended_paths.clone_from(&extended_tsconfig_paths);
         // Iterate in reverse so that later `extends` entries take precedence —
         // see comment in `load_tsconfig`.
         for extended_tsconfig_path in extended_tsconfig_paths.into_iter().rev() {
@@ -272,8 +377,10 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 /* root */ false,
                 &extended_tsconfig_path,
                 TsconfigReferences::Disabled,
+                tctx,
                 ctx,
             )?;
+            tsconfig.extended_paths.extend(extended_tsconfig.extended_paths.iter().cloned());
             tsconfig.extend_tsconfig(&extended_tsconfig);
         }
         Ok(())


### PR DESCRIPTION
## Summary

- Adds `find_tsconfig_with_context` and `resolve_tsconfig_with_context` that populate `ResolveContext.file_dependencies` / `missing_dependencies` with every tsconfig file read during loading — the tsconfig itself, transitively extended bases, and resolved project references.
- Dependencies are recorded even when the load errors mid-way (e.g. an extended tsconfig has a JSON parse error), so callers can watch every file that contributed to the failed result.
- New `TsConfig::extended_paths` field (`#[serde(skip)]`, `pub(crate)`) flattens the transitive extends chain so cache hits replay the full set of files without re-running the loader.

Closes #1011

## Known limitations

- `find_tsconfig_with_context` with `TsconfigDiscovery::Auto`: on warm calls, only the final resolved tsconfig's deps are replayed — intermediate non-claiming tsconfigs visited during the walk, and missing-tsconfig.json probes, are not re-emitted from the per-`CachedPath` `resolved_tsconfig` cache layer. Cold calls record everything correctly.
- Bare-specifier `extends` (e.g. `"extends": "@tsconfig/node20/tsconfig.json"`): the package-style sub-resolution uses a throwaway `Ctx`, so traversed `package.json` files are not currently recorded; the final tsconfig file is.

These can be tightened in follow-ups.