### PR TITLE
fix(tsconfig): scope default `**/*` include to the tsconfig directory

### DIFF
--- a/fixtures/tsconfig/cases/project-references-default-include/index.ts
+++ b/fixtures/tsconfig/cases/project-references-default-include/index.ts
@@ -1,0 +1,3 @@
+import { util } from "@app/util";
+
+util();

--- a/fixtures/tsconfig/cases/project-references-default-include/pkg/thing.ts
+++ b/fixtures/tsconfig/cases/project-references-default-include/pkg/thing.ts
@@ -1,0 +1,1 @@
+export const thing = () => "thing";

--- a/fixtures/tsconfig/cases/project-references-default-include/pkg/tsconfig.json
+++ b/fixtures/tsconfig/cases/project-references-default-include/pkg/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "composite": true
+  }
+}

--- a/fixtures/tsconfig/cases/project-references-default-include/src/util.ts
+++ b/fixtures/tsconfig/cases/project-references-default-include/src/util.ts
@@ -1,0 +1,1 @@
+export const util = () => "util";

--- a/fixtures/tsconfig/cases/project-references-default-include/tsconfig.json
+++ b/fixtures/tsconfig/cases/project-references-default-include/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@app/*": ["./src/*"] }
+  },
+  "references": [{ "path": "./pkg" }]
+}

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -204,3 +204,18 @@ fn walk_up_when_ref_excludes_file() {
         resolver.resolve_file(f.join("pkg-a/src/excluded/bar.ts"), "@/foo").map(|f| f.full_path());
     assert_eq!(resolved_path, Err(ResolveError::NotFound("@/foo".into())));
 }
+
+#[test]
+fn root_paths_apply_to_default_include_files() {
+    let f = super::fixture_root().join("tsconfig/cases/project-references-default-include");
+
+    let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".ts".into()],
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
+
+    let resolved_path =
+        resolver.resolve_file(f.join("index.ts"), "@app/util").map(|f| f.full_path());
+    assert_eq!(resolved_path, Ok(f.join("src/util.ts")));
+}

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -24,8 +24,6 @@ use crate::{TsconfigReferences, path::PathUtil, replace_bom_with_whitespace};
 /// Allow list: <https://github.com/microsoft/TypeScript/issues/57485#issuecomment-2027787456>
 const TEMPLATE_VARIABLE: &str = "${configDir}";
 
-const GLOB_ALL_PATTERN: &str = "**/*";
-
 pub type CompilerOptionsPathsMap = IndexMap<String, Vec<PathBuf>, BuildHasherDefault<FxHasher>>;
 
 /// Project Reference
@@ -578,11 +576,14 @@ impl TsConfig {
         if self.references_resolved.iter().any(|r| r.is_file_included_in_tsconfig(path)) {
             return true;
         }
-        // Solution-style configs (have `references` and no own `files` /
-        // `include`) never claim files themselves.
+        // Solution-style configs (have `references` and explicit empty
+        // `files` / `include`) never claim files themselves. Per the
+        // TypeScript spec, an *omitted* `include` defaults to `**/*`, so it
+        // must fall through to `is_file_included_in_tsconfig`; only an
+        // explicit empty array means "own no files".
         let is_solution_style = !self.references_resolved.is_empty()
-            && self.files.as_ref().is_none_or(Vec::is_empty)
-            && self.include.as_ref().is_none_or(Vec::is_empty);
+            && matches!(self.files.as_deref(), Some([]))
+            && matches!(self.include.as_deref(), Some([]));
         if is_solution_style {
             return false;
         }
@@ -618,7 +619,8 @@ impl TsConfig {
     fn is_glob_matches(&self, path: &Path, pattern: GlobPattern) -> bool {
         let path_str = path.to_string_lossy().replace('\\', "/");
         match pattern {
-            GlobPattern::All => self.is_glob_match(GLOB_ALL_PATTERN, path, &path_str),
+            // The default include `**/*` is scoped to the tsconfig directory.
+            GlobPattern::All => path.starts_with(self.directory()),
             GlobPattern::Pattern(patterns) => patterns.iter().any(|pattern| {
                 let pattern = pattern.to_string_lossy().replace('\\', "/");
                 self.is_glob_match(pattern.as_ref(), path, &path_str)
@@ -628,10 +630,6 @@ impl TsConfig {
 
     fn is_glob_match(&self, pattern: &str, path: &Path, path_str: &str) -> bool {
         if pattern == path_str {
-            return true;
-        }
-        // Special case: **/* matches everything
-        if pattern == GLOB_ALL_PATTERN {
             return true;
         }
         // Normalize pattern: add implicit /**/* for directory patterns


### PR DESCRIPTION
## Summary

The default `include = **/*` was matching every path regardless of where the tsconfig sat, so a referenced sub-project with no `files`/`include` of its own claimed files *outside* its own directory and shadowed the parent's `compilerOptions.paths`. Combined with the solution-style heuristic treating omitted `files`/`include` the same as explicit `[]`, a root tsconfig with `references` and `paths` but no `include` lost its own paths for files it owns via the default glob.

## Repro

```
repro/
├── tsconfig.json        compilerOptions: { paths: { "@app/*": ["./src/*"] } }, references: [{ path: "./pkg" }]
├── index.ts             import { util } from "@app/util";
├── src/util.ts
└── pkg/
    ├── tsconfig.json    compilerOptions: { composite: true }
    └── thing.ts
```

`tsc 6.0.3` and `tsgo 7.0.0-dev` both resolve `@app/util` → `src/util.ts`. oxc-resolver 11.19.1 did too; 11.19.2 returns `Cannot find module`.

## Root cause

Two interacting bugs:

1. `is_glob_matches(_, GlobPattern::All)` short-circuited `**/*` to `true` regardless of which tsconfig owned the pattern. Fine when the only caller was the walked-up parent tsconfig, broken after #1151 started asking *references* the same question — their `**/*` then matched files outside the reference's directory.
2. `claims_ownership_of`'s solution-style check used `is_none_or(Vec::is_empty)`, conflating omitted and explicit-empty `files`/`include`. Per the TS spec only an explicit `[]` means "own no files"; an omitted `include` defaults to `**/*` and should fall through.

This mirrors typescript-go's structure: `getFileNamesFromConfigSpecs` expands the default `**/*` via `ReadDirectory(basePath, ...)`, which is naturally scoped to the project directory — no equivalent "literal `**/*` matches everywhere" code path exists there.

## Changes

- `src/tsconfig.rs` — `GlobPattern::All` now checks `path.starts_with(self.directory())`; `is_solution_style` requires explicit `Some([])` for both `files` and `include`. Dead `GLOB_ALL_PATTERN` constant removed.
- `src/tests/tsconfig_project_references.rs` — `root_paths_apply_to_default_include_files` covers the repro.
- `fixtures/tsconfig/cases/project-references-default-include/` — minimal fixture matching the issue.

All 294 existing tests still pass.

Closes #1159.