### PR TITLE
fix(tsconfig): resolve base_url against the authoring config's directory

### DIFF
--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -355,15 +355,20 @@ impl TsConfig {
             self.exclude = Some(excludes.into_iter().map(|p| self.adjust_path(p)).collect());
         }
 
-        if let Some(base_url) = &self.compiler_options.base_url {
-            self.compiler_options.base_url = Some(self.adjust_path(base_url.clone()));
-        }
-
         if let Some(stripped_path) =
             self.compiler_options.paths_base.to_string_lossy().strip_prefix(TEMPLATE_VARIABLE)
         {
             self.compiler_options.paths_base =
                 config_dir.join(stripped_path.trim_start_matches('/'));
+        }
+
+        // `base_url`'s effective absolute value is `paths_base`, which was
+        // computed at parse time against the *originating* config's directory.
+        // The raw `base_url` PathBuf may still be the inherited authored value
+        // (e.g. "../src") and resolving it against `self.directory()` again
+        // produces the wrong path when extends crosses directory boundaries.
+        if self.compiler_options.base_url.is_some() {
+            self.compiler_options.base_url = Some(self.compiler_options.paths_base.clone());
         }
 
         if let Some(root_dirs) = &mut self.compiler_options.root_dirs {
@@ -469,6 +474,12 @@ impl TsConfig {
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompilerOptions {
+    /// After [`Resolver::resolve_tsconfig`] this holds the absolute resolved
+    /// `baseUrl` (equal to [`CompilerOptions::paths_base`]), not the raw
+    /// authored string. The raw value is only visible on the per-config
+    /// result of [`TsConfig::parse`] before `extends` merging.
+    ///
+    /// [`Resolver::resolve_tsconfig`]: crate::Resolver::resolve_tsconfig
     pub base_url: Option<PathBuf>,
 
     /// Path aliases.
@@ -526,6 +537,28 @@ pub struct CompilerOptions {
 
     /// <https://www.typescriptlang.org/tsconfig/#rootDirs>
     pub root_dirs: Option<Vec<PathBuf>>,
+}
+
+impl CompilerOptions {
+    /// The anchor against which `compilerOptions.paths` targets resolve.
+    ///
+    /// After [`Resolver::resolve_tsconfig`] this is always an absolute path.
+    /// The exact value depends on how `paths` and `baseUrl` interact across
+    /// `extends`:
+    ///
+    /// * When this tsconfig sets `baseUrl`, `paths_base` is that resolved
+    ///   absolute `baseUrl`.
+    /// * When `paths` is inherited from a parent via `extends` and neither
+    ///   the parent nor this tsconfig sets `baseUrl`, `paths_base` is the
+    ///   directory of the tsconfig that authored `paths`.
+    /// * Otherwise (no `baseUrl`, no inherited `paths`) it is this
+    ///   tsconfig's own directory.
+    ///
+    /// [`Resolver::resolve_tsconfig`]: crate::Resolver::resolve_tsconfig
+    #[must_use]
+    pub fn paths_base(&self) -> &Path {
+        &self.paths_base
+    }
 }
 
 /// Value for the "extends" field.


### PR DESCRIPTION
## Summary

Fix a cross-directory `extends` bug where inherited `baseUrl` resolves against the wrong anchor, plus expose the corresponding anchor publicly so downstream tools can use it.

### The bug

When a tsconfig inherits `baseUrl` through `extends` from a config in a different directory, e.g.

```
parent-base-url/
├── tsconfig.json           # extends "./tsconfigs/tsconfig.dev"
└── tsconfigs/
    ├── tsconfig.base.json  # { "baseUrl": "../src" }
    └── tsconfig.dev.json   # extends "./tsconfig.base"
```

the raw inherited `PathBuf("../src")` is anchored at the *originating* config's directory (`parent-base-url/tsconfigs/`), not the leaf's. `TsConfig::build` was calling `adjust_path` on it again, which re-resolved against `self.directory()` and produced a path one level too high — landing at `<workspace>/fixtures/tsconfig/cases/src` instead of `<workspace>/fixtures/tsconfig/cases/parent-base-url/src`.

### The fix

`paths_base` was already computed correctly at parse time (against the authoring config's `canonical_directory`), so use that as the effective absolute value of `base_url` after `build()`. This makes `base_url` and `paths_base` agree, which matches how `paths` target resolution already works internally.

### API additions

* `CompilerOptions::paths_base()` getter — downstream tools (formatters, language services, doc generators) can now see the same anchor used for `paths` targets.
* Docstring on `CompilerOptions::base_url` noting that after `build()` it is always the resolved absolute path, not the authored string.

### Observable behavior change

`compiler_options.base_url` after `Resolver::resolve_tsconfig` is now always an absolute path. Previously, in the cross-dir-extends case described above, callers could read a raw relative `PathBuf("../src")` that was wrong relative to either anchor — the value is now the resolved absolute path. Callers that were working around the bug (or weren't affected because they only ever used same-dir extends) keep working unchanged.