### PR TITLE
fix(tsconfig): reject empty / whitespace-only tsconfig files

### DIFF
--- a/src/tests/tsconfck.rs
+++ b/src/tests/tsconfck.rs
@@ -18,6 +18,12 @@ fn parse_valid() {
     let dir = super::fixture_root().join("tsconfck").join("parse").join("valid");
     let resolver = Resolver::default();
     for path in walk(&dir).into_iter().filter(|path| path.file_name().unwrap() == "tsconfig.json") {
+        // tsconfck (the upstream JS package) considers an empty file valid,
+        // but typescript-go and oxc-resolver treat it as a parse error. Skip
+        // the lone empty fixture so we stay aligned with tsgo.
+        if path.parent().and_then(|p| p.file_name()).is_some_and(|n| n == "empty") {
+            continue;
+        }
         let tsconfig = resolver.resolve_tsconfig(&path);
         assert_eq!(tsconfig.map(|t| t.path().to_path_buf()), Ok(path));
     }

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -166,6 +166,10 @@ fn broken() {
 
 #[test]
 fn empty() {
+    // typescript-go errors with TS5083 on a 0-byte / whitespace-only tsconfig.
+    // oxc-resolver matches that behavior — opening the resolver against an
+    // empty config returns a JSON parse error rather than silently treating
+    // the file as `{}`.
     let f = super::fixture_root().join("tsconfig/cases/empty");
 
     let resolver = Resolver::new(ResolveOptions {
@@ -176,8 +180,8 @@ fn empty() {
         ..ResolveOptions::default()
     });
 
-    let resolved_path = resolver.resolve_file(f.join("index.js"), "./index").map(|f| f.full_path());
-    assert_eq!(resolved_path, Ok(f.join("index.js")));
+    let result = resolver.resolve_file(f.join("index.js"), "./index").map(|f| f.full_path());
+    assert!(matches!(result, Err(ResolveError::Json(_))), "expected JSON error, got {result:?}");
 }
 
 #[test]

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -100,11 +100,11 @@ impl TsConfig {
         let mut json = json.into_bytes();
         replace_bom_with_whitespace(&mut json);
         _ = json_strip_comments::strip_slice(&mut json);
-        let mut tsconfig: Self = if json.iter().all(u8::is_ascii_whitespace) {
-            Self::default()
-        } else {
-            serde_json::from_slice(&json)?
-        };
+        // typescript-go rejects empty/whitespace-only tsconfig files with
+        // TS5083 ("Cannot read file"). Forward serde_json's EOF error to keep
+        // behavior aligned. (Classic tsc, in contrast, treats empty as `{}`
+        // and only fails later on "no inputs found".)
+        let mut tsconfig: Self = serde_json::from_slice(&json)?;
         tsconfig.root = root;
         tsconfig.path = path.to_path_buf();
         let canonical_directory = canonical_path.parent().unwrap();


### PR DESCRIPTION
## Summary

typescript-go errors with **TS5083 "Cannot read file"** on a 0-byte (or whitespace/comment-only) tsconfig. oxc-resolver previously short-circuited to `Self::default()` for the same input, silently producing an "empty but successful" config.

Forward serde_json's EOF error instead, matching tsgo's behavior.

### Trade-off

Classic `tsc` is *more* lenient here — it treats empty as `{}` and only errors later on "no inputs were found". This change trades classic-tsc parity for typescript-go parity. Per the project's compat target (typescript-go), strict is the right side.

### Test / fixture updates

* `src/tests/tsconfig_paths.rs::empty` flipped from asserting success to asserting `ResolveError::Json`.
* `src/tests/tsconfck::parse_valid` skips the upstream `tsconfck/parse/valid/empty` fixture — tsconfck (the JS parser) considers empty files valid; typescript-go does not.

### Observable behavior change

`Resolver::resolve_tsconfig` on an empty/whitespace-only file now returns `Err(ResolveError::Json(_))` instead of `Ok(TsConfig::default())`. Tests asserting against `{}`-from-empty would need to update; the bundled tests do.