### PR TITLE
fix(tsconfig): match typescript-go's strict extends resolution

### DIFF
--- a/fixtures/tsconfig/cases/extends-multiple/tsconfig.json
+++ b/fixtures/tsconfig/cases/extends-multiple/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../extends-extension", "../extends-paths"],
+  "extends": ["../extends-extension/tsconfig.json", "../extends-paths/tsconfig.json"],
   "compilerOptions": {
     "baseUrl": ".",
   },

--- a/fixtures/tsconfig/nested/tsconfig.json
+++ b/fixtures/tsconfig/nested/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "..",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "paths": {
       "ts-path": ["test.js"]

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -215,11 +215,17 @@ impl<Fs: FileSystem> Cache<Fs> {
             }
         }
 
-        // Not in any cache, parse from file
+        // Not in any cache, parse from file.
+        //
+        // `root` distinguishes the caller's tsconfig (top-level resolve_tsconfig
+        // or a project reference) from one loaded via `extends`. typescript-go
+        // and tsc do NOT support folder-form extends (`extends: "./base"` does
+        // not look for `./base/tsconfig.json` — only `./base.json` is tried),
+        // so we restrict the directory fallback to `root=true` callers.
         let meta = self.fs.metadata(path).ok();
         let tsconfig_path = if meta.is_some_and(|m| m.is_file) {
             Cow::Borrowed(path)
-        } else if meta.is_some_and(|m| m.is_dir) {
+        } else if root && meta.is_some_and(|m| m.is_dir) {
             Cow::Owned(path.join("tsconfig.json"))
         } else {
             let mut os_string = path.to_path_buf().into_os_string();

--- a/src/tests/tsconfig_extends.rs
+++ b/src/tests/tsconfig_extends.rs
@@ -348,9 +348,12 @@ fn test_references_unreadable_file() {
 
 #[test]
 fn test_extend_package() {
+    // typescript-go / tsc honor a node_modules package's `exports` map when
+    // resolving a tsconfig extends, but NOT the package's `main` field — the
+    // latter is for runtime imports, not for tsconfig discovery. Only the
+    // `exports`-using fixture should resolve; `extends-main` (which routes
+    // through `main: "src/tsconfig.json"`) must fail to match.
     let f = super::fixture_root().join("tsconfig/cases");
-
-    let data = ["extends-esm", "extends-main"];
 
     let resolver = Resolver::new(ResolveOptions {
         tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
@@ -360,11 +363,16 @@ fn test_extend_package() {
         ..ResolveOptions::default()
     });
 
-    for dir in data {
-        let resolution = resolver.resolve_tsconfig(f.join(dir)).expect("resolved");
-        let compiler_options = &resolution.compiler_options;
-        assert_eq!(compiler_options.target, Some("ES2020".to_string()));
-    }
+    // extends-esm: package.json has `exports` → resolves.
+    let resolution = resolver.resolve_tsconfig(f.join("extends-esm")).expect("resolved");
+    assert_eq!(resolution.compiler_options.target, Some("ES2020".to_string()));
+
+    // extends-main: package.json has only `main` → must NOT resolve.
+    let result = resolver.resolve_tsconfig(f.join("extends-main"));
+    assert!(
+        matches!(result, Err(crate::ResolveError::TsconfigNotFound(_))),
+        "package `main` should not be used for tsconfig extends, got: {result:?}",
+    );
 }
 
 fn assert_extends_symlink_resolves_to_canonical(config_file: &Path) {

--- a/src/tests/tsconfig_lookup.rs
+++ b/src/tests/tsconfig_lookup.rs
@@ -171,7 +171,11 @@ fn extends_with_json_extension() {
 }
 
 #[test]
-fn extends_folder_resolves_to_tsconfig_json() {
+fn extends_folder_form_is_rejected() {
+    // Folder-form `extends` (e.g. `extends: "./base"` resolving to
+    // `./base/tsconfig.json`) is NOT part of the TypeScript spec. Both `tsc`
+    // and `typescript-go` only auto-append `.json` to the extends specifier.
+    // oxc-resolver matches that behavior.
     let f = super::fixture_root().join("tsconfig/cases/extends-folder-tsconfig");
 
     let resolver = Resolver::new(ResolveOptions {
@@ -182,10 +186,11 @@ fn extends_folder_resolves_to_tsconfig_json() {
         ..ResolveOptions::default()
     });
 
-    let resolution = resolver
-        .resolve_tsconfig(&f)
-        .expect("relative folder extends should resolve tsconfig.json");
-    assert_eq!(resolution.compiler_options.target, Some("ES2019".to_string()));
+    let result = resolver.resolve_tsconfig(&f);
+    assert!(
+        matches!(result, Err(crate::ResolveError::TsconfigNotFound(_))),
+        "folder-form extends should not resolve, got: {result:?}",
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -402,30 +402,49 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         tsconfig: &TsConfig,
         specifier: &str,
     ) -> Result<PathBuf, ResolveError> {
-        match specifier.as_bytes().first() {
-            None => Err(ResolveError::Specifier(SpecifierError::Empty(specifier.to_string()))),
-            Some(b'/') => Ok(PathBuf::from(specifier)),
-            Some(b'.') => Ok(tsconfig.directory().normalize_with(specifier)),
-            _ => self
-                .clone_with_options(ResolveOptions {
-                    tsconfig: None,
-                    condition_names: vec!["node".into(), "import".into()],
-                    extensions: vec![".json".into()],
-                    main_files: vec!["tsconfig".into()],
-                    #[cfg(feature = "yarn_pnp")]
-                    yarn_pnp: self.options.yarn_pnp,
-                    #[cfg(feature = "yarn_pnp")]
-                    cwd: self.options.cwd.clone(),
-                    ..ResolveOptions::default()
-                })
-                .load_package_self_or_node_modules(directory, specifier, None, &mut Ctx::default())
-                .map(|p| p.to_path_buf())
-                .map_err(|err| match err {
-                    ResolveError::NotFound(_) => {
-                        ResolveError::TsconfigNotFound(PathBuf::from(specifier))
-                    }
-                    _ => err,
-                }),
+        // Match typescript-go's `getExtendsConfigPath`
+        // (internal/tsoptions/tsconfigparsing.go):
+        //   * `/abs` → use as-is.
+        //   * `./xxx` / `../xxx` → relative file (`.json` auto-appended when missing).
+        //                          Folder-form like `./base` → `./base/tsconfig.json`
+        //                          is NOT supported.
+        //   * Bare `.` / `..` → fall through to module resolution; tsgo's
+        //                       resolver treats them as "the tsconfig.json in
+        //                       this dir / parent dir".
+        //   * anything else → module resolution (node_modules package).
+        if specifier.is_empty() {
+            return Err(ResolveError::Specifier(SpecifierError::Empty(specifier.to_string())));
         }
+        if specifier.starts_with('/') {
+            return Ok(PathBuf::from(specifier));
+        }
+        if specifier.starts_with("./") || specifier.starts_with("../") {
+            return Ok(tsconfig.directory().normalize_with(specifier));
+        }
+        if specifier == "." || specifier == ".." {
+            return Ok(tsconfig.directory().normalize_with(specifier).join("tsconfig.json"));
+        }
+        self.clone_with_options(ResolveOptions {
+            tsconfig: None,
+            condition_names: vec!["node".into(), "import".into()],
+            extensions: vec![".json".into()],
+            main_files: vec!["tsconfig".into()],
+            // tsc / typescript-go honor `exports` and the package.json
+            // `tsconfig` field (NOT `main`) when resolving a tsconfig
+            // extends to a node_modules package. `main_fields` here
+            // overrides the default `main` lookup.
+            main_fields: vec!["tsconfig".into()],
+            #[cfg(feature = "yarn_pnp")]
+            yarn_pnp: self.options.yarn_pnp,
+            #[cfg(feature = "yarn_pnp")]
+            cwd: self.options.cwd.clone(),
+            ..ResolveOptions::default()
+        })
+        .load_package_self_or_node_modules(directory, specifier, None, &mut Ctx::default())
+        .map(|p| p.to_path_buf())
+        .map_err(|err| match err {
+            ResolveError::NotFound(_) => ResolveError::TsconfigNotFound(PathBuf::from(specifier)),
+            _ => err,
+        })
     }
 }


### PR DESCRIPTION
## Summary

Tighten three corners of `extends` to match `tsc` / `typescript-go` exactly. Each corresponds to oxc-resolver previously accepting a form that the TypeScript spec rejects.

### 1. Folder-form `extends` rejected

`extends: "./base"` no longer silently falls back to `./base/tsconfig.json`. typescript-go's [`getExtendsConfigPath`](https://github.com/microsoft/typescript-go/blob/main/internal/tsoptions/tsconfigparsing.go) only auto-appends `.json` to the extends specifier — it does **not** look up `tsconfig.json` inside a directory. Classic `tsc 6.0.3` agrees: it errors with `TS6053: File './base' not found`.

`Cache::get_tsconfig` now restricts the `<dir>/tsconfig.json` fallback to `root=true` callers (top-level `resolve_tsconfig` or project references). The `extends` recursion path goes through with `root=false` and gets only the `.json`-append behavior.

### 2. Extends specifier dispatch matches tsgo exactly

| Specifier | Resolution |
|---|---|
| `/abs` | use as-is |
| `./x` / `../x` | relative file; `.json` auto-appended |
| `.` / `..` | `<dir>/tsconfig.json` / `<parent>/tsconfig.json` |
| `pkg` / `pkg/sub` | module resolution |

`./xxx` / `../xxx` remain relative file paths, but bare `.` and `..` (without trailing path) now resolve to `<dir>/tsconfig.json` and `<parent>/tsconfig.json`. tsgo routes these through module resolution, which happens to land at the same files; we hard-wire the equivalent result.

### 3. Package `extends` honors the `tsconfig` field, not `main`

When an extends specifier resolves to a node_modules package, the resolver now uses `main_fields: ["tsconfig"]`. `main` is for runtime imports; both `tsc` and `tsgo` ignore it for tsconfig discovery and consult `exports` and the `tsconfig` field instead.

### Test / fixture updates

* `extends_folder_resolves_to_tsconfig_json` → renamed to `extends_folder_form_is_rejected` and inverted: asserts `TsconfigNotFound`.
* `test_extend_package` split into two assertions: `extends-esm` (uses `exports`) still resolves; `extends-main` (only `main`) is now asserted to fail.
* `fixtures/tsconfig/cases/extends-multiple/tsconfig.json` — array entries now include `/tsconfig.json` (folder lookup is gone).
* `fixtures/tsconfig/nested/tsconfig.json` — `".."` → `"../tsconfig.json"`.

### Observable behavior changes for downstream

`Resolver::resolve_tsconfig` now returns `TsconfigNotFound` for tsconfigs that use:
* `extends: "./base"` (folder form) — they need `"./base/tsconfig.json"` or `"./base.json"`.
* `extends: "pkg-name"` where the package's `package.json` only has a `main` field pointing at a tsconfig — they need an `exports` entry or a top-level `tsconfig.json` or a `tsconfig` field.

Both forms were always invalid per the TypeScript spec; this change surfaces the error instead of silently using a config that other tools wouldn't.