### PR TITLE
chore: drop i686-pc-windows-msvc target

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -53,11 +53,6 @@ jobs:
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             build: pnpm build
-          - os: windows-latest
-            target: i686-pc-windows-msvc
-            architecture: x86
-            cpu: ia32
-            build: pnpm build
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             build: pnpm build --use-napi-cross

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
-      "i686-pc-windows-msvc",
       "powerpc64le-unknown-linux-gnu",
       "riscv64gc-unknown-linux-gnu",
       "riscv64gc-unknown-linux-musl",


### PR DESCRIPTION
## Summary
- Node.js stopped shipping `win-x86` binaries in v23, so `actions/setup-node` cannot install the pinned Node 24.14.0 for `win32/x86` — the i686 row of the release-napi matrix has been failing since v11.19.2 with `Unable to find Node version '24.14.0' for platform win32 and architecture x86`.
- Rust is also demoting 32-bit Windows targets — see https://blog.rust-lang.org/2025/05/26/demoting-i686-pc-windows-gnu/.
- Removes the target from `napi.targets` in `package.json` and from the release-napi matrix.