### PR TITLE
fix(ci): bypass vp on FreeBSD build

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -180,7 +180,8 @@ jobs:
             export COREPACK_INTEGRITY_KEYS=0
             sudo corepack enable
             pnpm install
-            pnpm build --target x86_64-unknown-freebsd
+            # Bypass `vp run`: vite-plus has no freebsd-x64 native binding.
+            pnpm run build:debug -- --features allocator --release --target x86_64-unknown-freebsd
             rm -rf node_modules
             rm -rf target
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- The FreeBSD job in `release-napi.yml` has been failing because `pnpm build` resolves to `vp run build:debug --features allocator --release`, and `vite-plus` has no `freebsd-x64` native binding (`Cannot find module '@voidzero-dev/vite-plus-freebsd-x64'`).
- The `build:debug` script itself is plain `napi build --platform --manifest-path napi/Cargo.toml` with no vite-plus dependency, so call it directly inside the FreeBSD VM and forward `--features allocator --release --target x86_64-unknown-freebsd`. Other matrix targets still go through `vp` unchanged.