### PR TITLE
fix(ci): call napi directly on FreeBSD

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -180,8 +180,10 @@ jobs:
             export COREPACK_INTEGRITY_KEYS=0
             sudo corepack enable
             pnpm install
-            # Bypass `vp run`: vite-plus has no freebsd-x64 native binding.
-            pnpm run build:debug -- --features allocator --release --target x86_64-unknown-freebsd
+            # Call napi directly: vite-plus has no freebsd-x64 native binding,
+            # so the `vp run`-based `pnpm build` script can't be loaded here.
+            pnpm exec napi build --platform --manifest-path napi/Cargo.toml --features allocator --release --target x86_64-unknown-freebsd
+            node napi/patch.mjs
             rm -rf node_modules
             rm -rf target
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- Follow-up to #1173. The previous `pnpm run build:debug -- --features allocator --release --target x86_64-unknown-freebsd` form forwarded the `--` separator into the script, so the actual command became `napi build --platform --manifest-path napi/Cargo.toml -- --features allocator --release --target x86_64-unknown-freebsd`. napi-rs treats everything after `--` as cargo passthrough: cargo built into `target/x86_64-unknown-freebsd/release/`, but napi's artifact-copy step still looked in `target/x86_64-unknown-freebsd/debug/` and failed with `Failed to copy artifact`.
- Bypass the script indirection entirely: call `napi build` via `pnpm exec` so all flags reach napi directly, and run the `postbuild:debug` patch script manually.
- See the failing run for context: https://github.com/oxc-project/oxc-resolver/actions/runs/26520843549/job/78111153642