### PR TITLE
fix(ci): invoke napi binary directly in publish job

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -223,15 +223,18 @@ jobs:
       - run: npm install -g npm@latest # For trusted publishing support
 
       - name: Prepare dirs and artifacts
+        # Invoke napi directly. Going through `pnpm napi ...` triggers pnpm 11's
+        # verify-deps-before-run check, which fails after `cp package.json
+        # napi/package.json` introduces deps the lockfile doesn't know about.
         run: |
           cp package.json napi/package.json
-          pnpm napi create-npm-dirs
-          pnpm napi artifacts --npm-dir npm --build-output-dir napi
+          ./node_modules/.bin/napi create-npm-dirs
+          ./node_modules/.bin/napi artifacts --npm-dir npm --build-output-dir napi
 
       - name: Publish npm packages as latest
         run: |
           # Using trusted publishing, no token is required.
-          pnpm napi pre-publish --no-gh-release --tagstyle npm --npm-dir npm
+          ./node_modules/.bin/napi pre-publish --no-gh-release --tagstyle npm --npm-dir npm
 
           # Publish root package
           cp package.json napi/package.json


### PR DESCRIPTION
## Summary
- The Publish step copies the root `package.json` over `napi/package.json` (an empty workspace package in `pnpm-workspace.yaml`), suddenly adding 8 deps the lockfile doesn't know about. pnpm 11's `verify-deps-before-run` then aborts `pnpm napi ...` with `ERR_PNPM_OUTDATED_LOCKFILE` before the napi CLI even runs — see https://github.com/oxc-project/oxc-resolver/actions/runs/26550153122/job/78210818021.
- Invoke `./node_modules/.bin/napi` directly so the napi CLI runs without going through pnpm's command wrapper and its deps check.