### PR TITLE
perf(cache): move package.json path into parse instead of cloning

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -200,23 +200,24 @@ impl<Fs: FileSystem> Cache<Fs> {
                 } else {
                     package_json_path.clone()
                 };
-                PackageJson::parse(
-                    &self.fs,
-                    package_json_path.clone(),
-                    real_path,
-                    package_json_bytes,
-                )
-                .map(|package_json| Some(Arc::new(package_json)))
-                .map_err(ResolveError::Json)
+                // Move `package_json_path` into `parse` instead of cloning it: the parsed
+                // `PackageJson` stores the path verbatim (`package_json.path()`), and on error
+                // `JSONError.path` carries the same path, so the file-dependency record reads it
+                // back without a second allocation.
                 // https://github.com/webpack/enhanced-resolve/blob/58464fc7cb56673c9aa849e68e6300239601e615/lib/DescriptionFileUtils.js#L68-L82
-                .inspect(|_| {
-                    ctx.add_file_dependency(&package_json_path);
-                })
-                .inspect_err(|_| {
-                    if let Some(deps) = &mut ctx.file_dependencies {
-                        deps.push(package_json_path.clone());
+                match PackageJson::parse(&self.fs, package_json_path, real_path, package_json_bytes)
+                {
+                    Ok(package_json) => {
+                        ctx.add_file_dependency(package_json.path());
+                        Ok(Some(Arc::new(package_json)))
                     }
-                })
+                    Err(error) => {
+                        if let Some(deps) = &mut ctx.file_dependencies {
+                            deps.push(error.path.clone());
+                        }
+                        Err(ResolveError::Json(error))
+                    }
+                }
             })
             .cloned()
     }


### PR DESCRIPTION
`find_package_json_impl` cloned `package_json_path` to pass into `PackageJson::parse` so the original could outlive the call for the `.inspect`/`.inspect_err` closures that record the file dependency.

This replaces the combinator chain with a `match` that **moves** `package_json_path` into `parse` and reads the dependency path back from:
- `package_json.path()` on success — `PackageJson` stores the path verbatim, and
- `JSONError.path` on error — set from the same input path,

dropping one unconditional `PathBuf` allocation on the parse-success path. The whole block is behind `path.package_json.get_or_try_init`, so this only fires on the first parse of each unique `package.json` over the resolver's lifetime (a cache miss).

Behavior is unchanged: file/missing-dependency recording, error contents, and return values are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)