### PR TITLE
perf: node_modules-anchor fast paths

### DIFF
--- a/benches/package_managers.rs
+++ b/benches/package_managers.rs
@@ -191,10 +191,16 @@ mod workload {
         candidates.iter().any(|c| resolved_path.contains(c.as_str()))
     }
 
+    #[allow(clippy::too_many_lines)]
     pub fn requests(root: &std::path::Path) -> Vec<Request> {
         // The resolver takes the containing directory of the importer, not the file path itself.
         let deep = root.join("apps/web/nested/deep/src");
         let shallow = root.join("apps/web/src");
+        // Monorepo workspace packages: `packages/ui` depends on a conflicting `react@17` (the app
+        // uses `react@18`), so resolving from inside it exercises a nested `node_modules`;
+        // `packages/utils` links `@bench/ui`, exercising a workspace-to-workspace resolution.
+        let ui = root.join("packages/ui/src");
+        let utils = root.join("packages/utils/src");
         vec![
             // Bare unscoped, exports field with conditions
             Request {
@@ -306,6 +312,21 @@ mod workload {
                 importer: shallow,
                 specifier: "../../../packages/utils",
                 pkg_dir: "packages/utils",
+                internal_path: "/src/index.js",
+            },
+            // Nested node_modules: `react` from `packages/ui` resolves to its own conflicting
+            // `react@17`, not the app's hoisted `react@18`.
+            Request {
+                importer: ui,
+                specifier: "react",
+                pkg_dir: "react",
+                internal_path: "/index.js",
+            },
+            // Workspace-to-workspace: `@bench/ui` from `packages/utils`.
+            Request {
+                importer: utils,
+                specifier: "@bench/ui",
+                pkg_dir: "packages/ui",
                 internal_path: "/src/index.js",
             },
         ]

--- a/fixtures/bench-pm/configs/bun-flat/bun.lock
+++ b/fixtures/bench-pm/configs/bun-flat/bun.lock
@@ -32,10 +32,16 @@
     "packages/ui": {
       "name": "@bench/ui",
       "version": "1.0.0",
+      "dependencies": {
+        "react": "17.0.2",
+      },
     },
     "packages/utils": {
       "name": "@bench/utils",
       "version": "1.0.0",
+      "dependencies": {
+        "@bench/ui": "workspace:*",
+      },
     },
   },
   "packages": {
@@ -101,6 +107,8 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
@@ -110,5 +118,7 @@
     "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 
     "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@bench/ui/react": ["react@17.0.2", "", { "dependencies": { "loose-envify": "^1.1.0", "object-assign": "^4.1.1" } }, "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="],
   }
 }

--- a/fixtures/bench-pm/configs/bun-isolated/bun.lock
+++ b/fixtures/bench-pm/configs/bun-isolated/bun.lock
@@ -32,10 +32,16 @@
     "packages/ui": {
       "name": "@bench/ui",
       "version": "1.0.0",
+      "dependencies": {
+        "react": "17.0.2",
+      },
     },
     "packages/utils": {
       "name": "@bench/utils",
       "version": "1.0.0",
+      "dependencies": {
+        "@bench/ui": "workspace:*",
+      },
     },
   },
   "packages": {
@@ -101,6 +107,8 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
@@ -110,5 +118,7 @@
     "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 
     "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@bench/ui/react": ["react@17.0.2", "", { "dependencies": { "loose-envify": "^1.1.0", "object-assign": "^4.1.1" } }, "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="],
   }
 }

--- a/fixtures/bench-pm/configs/npm-flat/package-lock.json
+++ b/fixtures/bench-pm/configs/npm-flat/package-lock.json
@@ -379,6 +379,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -424,11 +433,30 @@
     },
     "packages/ui": {
       "name": "@bench/ui",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dependencies": {
+        "react": "17.0.2"
+      }
+    },
+    "packages/ui/node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "packages/utils": {
       "name": "@bench/utils",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dependencies": {
+        "@bench/ui": "*"
+      }
     }
   }
 }

--- a/fixtures/bench-pm/configs/npm-flat/packages/utils/package.json
+++ b/fixtures/bench-pm/configs/npm-flat/packages/utils/package.json
@@ -8,6 +8,6 @@
     "./hash": "./src/hash.js"
   },
   "dependencies": {
-    "@bench/ui": "workspace:*"
+    "@bench/ui": "*"
   }
 }

--- a/fixtures/bench-pm/configs/pnpm-hoisted/pnpm-lock.yaml
+++ b/fixtures/bench-pm/configs/pnpm-hoisted/pnpm-lock.yaml
@@ -60,9 +60,17 @@ importers:
         specifier: 5.6.3
         version: 5.6.3
 
-  packages/ui: {}
+  packages/ui:
+    dependencies:
+      react:
+        specifier: 17.0.2
+        version: 17.0.2
 
-  packages/utils: {}
+  packages/utils:
+    dependencies:
+      '@bench/ui':
+        specifier: workspace:*
+        version: link:../ui
 
 packages:
 
@@ -177,8 +185,16 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  react@17.0.2:
+    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
+    engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -307,7 +323,14 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  object-assign@4.1.1: {}
+
   proxy-from-env@1.1.0: {}
+
+  react@17.0.2:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
 
   react@18.3.1:
     dependencies:

--- a/fixtures/bench-pm/configs/pnpm-isolated/pnpm-lock.yaml
+++ b/fixtures/bench-pm/configs/pnpm-isolated/pnpm-lock.yaml
@@ -60,9 +60,17 @@ importers:
         specifier: 5.6.3
         version: 5.6.3
 
-  packages/ui: {}
+  packages/ui:
+    dependencies:
+      react:
+        specifier: 17.0.2
+        version: 17.0.2
 
-  packages/utils: {}
+  packages/utils:
+    dependencies:
+      '@bench/ui':
+        specifier: workspace:*
+        version: link:../ui
 
 packages:
 
@@ -177,8 +185,16 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  react@17.0.2:
+    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
+    engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -307,7 +323,14 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  object-assign@4.1.1: {}
+
   proxy-from-env@1.1.0: {}
+
+  react@17.0.2:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
 
   react@18.3.1:
     dependencies:

--- a/fixtures/bench-pm/configs/yarn-flat/yarn.lock
+++ b/fixtures/bench-pm/configs/yarn-flat/yarn.lock
@@ -17,12 +17,16 @@ __metadata:
 "@bench/ui@workspace:*, @bench/ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@bench/ui@workspace:packages/ui"
+  dependencies:
+    react: "npm:17.0.2"
   languageName: unknown
   linkType: soft
 
 "@bench/utils@workspace:*, @bench/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@bench/utils@workspace:packages/utils"
+  dependencies:
+    "@bench/ui": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -324,10 +328,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-assign@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "object-assign@npm:4.1.1"
+  checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
+  languageName: node
+  linkType: hard
+
 "proxy-from-env@npm:^1.1.0":
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+  languageName: node
+  linkType: hard
+
+"react@npm:17.0.2":
+  version: 17.0.2
+  resolution: "react@npm:17.0.2"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+    object-assign: "npm:^4.1.1"
+  checksum: 10c0/07ae8959acf1596f0550685102fd6097d461a54a4fd46a50f88a0cd7daaa97fdd6415de1dcb4bfe0da6aa43221a6746ce380410fa848acc60f8ac41f6649c148
   languageName: node
   linkType: hard
 

--- a/fixtures/bench-pm/configs/yarn-isolated/yarn.lock
+++ b/fixtures/bench-pm/configs/yarn-isolated/yarn.lock
@@ -17,12 +17,16 @@ __metadata:
 "@bench/ui@workspace:*, @bench/ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@bench/ui@workspace:packages/ui"
+  dependencies:
+    react: "npm:17.0.2"
   languageName: unknown
   linkType: soft
 
 "@bench/utils@workspace:*, @bench/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@bench/utils@workspace:packages/utils"
+  dependencies:
+    "@bench/ui": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -324,10 +328,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-assign@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "object-assign@npm:4.1.1"
+  checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
+  languageName: node
+  linkType: hard
+
 "proxy-from-env@npm:^1.1.0":
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+  languageName: node
+  linkType: hard
+
+"react@npm:17.0.2":
+  version: 17.0.2
+  resolution: "react@npm:17.0.2"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+    object-assign: "npm:^4.1.1"
+  checksum: 10c0/07ae8959acf1596f0550685102fd6097d461a54a4fd46a50f88a0cd7daaa97fdd6415de1dcb4bfe0da6aa43221a6746ce380410fa848acc60f8ac41f6649c148
   languageName: node
   linkType: hard
 

--- a/fixtures/bench-pm/configs/yarn-pnp/yarn.lock
+++ b/fixtures/bench-pm/configs/yarn-pnp/yarn.lock
@@ -17,12 +17,16 @@ __metadata:
 "@bench/ui@workspace:*, @bench/ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@bench/ui@workspace:packages/ui"
+  dependencies:
+    react: "npm:17.0.2"
   languageName: unknown
   linkType: soft
 
 "@bench/utils@workspace:*, @bench/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@bench/utils@workspace:packages/utils"
+  dependencies:
+    "@bench/ui": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -324,10 +328,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-assign@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "object-assign@npm:4.1.1"
+  checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
+  languageName: node
+  linkType: hard
+
 "proxy-from-env@npm:^1.1.0":
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+  languageName: node
+  linkType: hard
+
+"react@npm:17.0.2":
+  version: 17.0.2
+  resolution: "react@npm:17.0.2"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+    object-assign: "npm:^4.1.1"
+  checksum: 10c0/07ae8959acf1596f0550685102fd6097d461a54a4fd46a50f88a0cd7daaa97fdd6415de1dcb4bfe0da6aa43221a6746ce380410fa848acc60f8ac41f6649c148
   languageName: node
   linkType: hard
 

--- a/fixtures/bench-pm/template/packages/ui/package.json
+++ b/fixtures/bench-pm/template/packages/ui/package.json
@@ -2,5 +2,8 @@
   "name": "@bench/ui",
   "version": "1.0.0",
   "private": true,
-  "main": "./src/index.js"
+  "main": "./src/index.js",
+  "dependencies": {
+    "react": "17.0.2"
+  }
 }

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -3,7 +3,7 @@ use std::{
     collections::HashSet as StdHashSet,
     hash::{BuildHasherDefault, Hash, Hasher},
     io,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     sync::Arc,
 };
 
@@ -339,6 +339,23 @@ impl<Fs: FileSystem> Cache<Fs> {
         }
     }
 
+    /// Whether every component strictly below `anchor` on the way to `path` is a real, non-symlink
+    /// entry — the precondition for appending the suffix verbatim in the anchor fast path. Walks the
+    /// cached parent chain and reuses the cached `lstat`, so components already stat'd while
+    /// resolving the file add no syscalls. Returns `false` if any component is a symlink, is missing,
+    /// or the chain does not reach `anchor`.
+    fn suffix_below_anchor_is_symlink_free(&self, path: &CachedPath, anchor: &CachedPath) -> bool {
+        let mut current = path.clone();
+        while current.path() != anchor.path() {
+            if current.link_metadata(&self.fs).is_none_or(|m| m.is_symlink) {
+                return false;
+            }
+            let Some(parent) = current.parent(self) else { return false };
+            current = parent;
+        }
+        true
+    }
+
     /// Returns the canonical path, resolving all symbolic links.
     ///
     /// <https://github.com/parcel-bundler/parcel/blob/4d27ec8b8bd1792f536811fef86e74a31fa0e704/crates/parcel-resolver/src/cache.rs#L232>
@@ -375,6 +392,30 @@ impl<Fs: FileSystem> Cache<Fs> {
                 .ok_or_else(|| {
                     io::Error::new(io::ErrorKind::NotFound, "Cached path no longer exists").into()
                 });
+        }
+
+        // Anchor fast path: canonicalize the real `<...>/node_modules/<pkg>` directory (the
+        // "anchor") and append the suffix below it without a per-component `read_link` walk. A
+        // symlinked anchor (a linked workspace package, or the top-level link of an isolated layout)
+        // keeps the normal walk. The suffix is appended verbatim only after confirming every
+        // component strictly below the anchor is a real, non-symlink entry — a package may still
+        // ship an internal symlink (e.g. `lib -> dist`), and appending across it would skip the
+        // link. That check is what makes this correct for any layout, so no `node_modules` trust
+        // gate is needed here. The `lstat` reuses the cache, so components already stat'd while
+        // resolving the file cost nothing.
+        if path.inside_node_modules
+            && let Some(anchor) = self.pkg_anchor(path)
+            && anchor.path() != path.path()
+            && anchor.link_metadata(&self.fs).is_some_and(|m| !m.is_symlink)
+            && let Ok(rest) = path.path().strip_prefix(anchor.path())
+            && !rest.components().any(|c| matches!(c, Component::ParentDir))
+            && self.suffix_below_anchor_is_symlink_free(path, &anchor)
+        {
+            let anchor_canonical = self.canonicalize_with_visited(&anchor, visited)?;
+            let canonical = anchor_canonical.normalize_with(rest, self);
+            let _ =
+                path.canonicalized.set((Arc::downgrade(&canonical.0), canonical.0.path.clone()));
+            return Ok(canonical);
         }
 
         // Check for circular symlink by tracking visited paths in the current canonicalization chain
@@ -423,5 +464,47 @@ impl<Fs: FileSystem> Cache<Fs> {
         // Remove from visited set when unwinding the recursion
         visited.remove(&path.hash);
         Ok(res)
+    }
+
+    /// The deepest `<...>/node_modules/<pkg>` (or `<...>/node_modules/@scope/<pkg>`) ancestor of
+    /// `path`, inclusive of `path` itself.
+    ///
+    /// Returns `None` when `path` is not inside any `node_modules`, for degenerate shapes that have
+    /// no package segment (`<...>/node_modules` itself, or a bare `<...>/node_modules/@scope`), or
+    /// when the segment under `node_modules` is a dot-directory (`.bin`, `.pnpm`, `.store`, `.bun`,
+    /// …). A real package name never starts with `.`, and those special directories hold symlinks
+    /// (e.g. the `.bin` shims) — so they are not anchors and must take the normal canonicalize walk.
+    ///
+    /// Allocation-free and performs no filesystem access: each step is a `Weak::upgrade` via
+    /// [`CachedPath::parent`], and the `node_modules`/scope checks read precomputed bits and path
+    /// bytes. Walking up and stopping at the *first* `node_modules` makes the deepest anchor win, so
+    /// a package's own nested `node_modules/<dep>` (e.g. pnpm dependency links) becomes its own
+    /// anchor rather than being hidden behind an outer one.
+    pub(crate) fn pkg_anchor(&self, path: &CachedPath) -> Option<CachedPath> {
+        if !path.inside_node_modules {
+            return None;
+        }
+        // `child` is the node one level below `cur`; `grandchild` two levels below. When `cur` is
+        // `node_modules`, `child` is the `<pkg>` segment (or the `@scope` dir, in which case the
+        // anchor is the `grandchild` `<pkg>`).
+        let mut grandchild: Option<CachedPath> = None;
+        let mut child: Option<CachedPath> = None;
+        let mut cur = path.clone();
+        loop {
+            if cur.is_node_modules() {
+                let pkg = child?;
+                // First byte of the segment directly under `node_modules`.
+                return match pkg.path().file_name().and_then(|name| name.as_encoded_bytes().first())
+                {
+                    Some(b'@') => grandchild, // scoped package: anchor is `<pkg>` under `@scope`
+                    Some(b'.') => None,       // `.bin`/`.pnpm`/`.store`/`.bun`/… — not a package
+                    _ => Some(pkg),
+                };
+            }
+            let parent = cur.parent(self)?;
+            grandchild = child;
+            child = Some(cur);
+            cur = parent;
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,40 +342,63 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         ctx: &mut Ctx,
     ) -> Result<Option<Arc<PackageJson>>, ResolveError> {
         // Algorithm:
-        // Find `node_modules/package/package.json`
-        // or the first package.json if the path is not inside node_modules.
-        let inside_node_modules = cached_path.inside_node_modules();
-        if inside_node_modules {
-            let mut last = None;
-            // Go up directories when the querying path is not a directory
-            let mut cp = cached_path.clone();
-            if !self.is_dir(&cp, ctx)
-                && let Some(cv) = cp.parent(&self.cache)
-            {
-                cp = cv;
-            }
-            let mut cp = Some(cp);
-            while let Some(p) = cp {
-                if p.is_node_modules() {
-                    break;
-                }
-                // Skip /node_modules/@scope/package.json
-                if let Some(parent) = p.parent(&self.cache)
-                    && parent.is_node_modules()
-                    && let Some(filename) = p.path().file_name()
-                    && filename.as_encoded_bytes().starts_with(b"@")
-                {
-                    break;
-                }
-                if let Some(package_json) = self.cache.get_package_json(&p, &self.options, ctx)? {
-                    last = Some(package_json);
-                }
-                cp = p.parent(&self.cache);
-            }
-            Ok(last)
-        } else {
-            self.cache.find_package_json(cached_path, &self.options, ctx)
+        // Find `node_modules/package/package.json` (the package "anchor"), or the first
+        // package.json if the path is not inside node_modules.
+        if !cached_path.inside_node_modules() {
+            return self.cache.find_package_json(cached_path, &self.options, ctx);
         }
+        // Fast path: jump straight to the `<...>/node_modules/<pkg>` anchor's package.json instead
+        // of probing `package.json` at every intermediate directory. Skipped when dependency
+        // tracking is enabled (`resolve_with_context`) so the directory walk's `missing_dependencies`
+        // stays byte-identical for watch-based consumers; the jump targets the common resolution
+        // path where dependencies are not collected. Falls back to the slow walk when the anchor has
+        // no `package.json` of its own, so a manifest in a nested directory below the anchor is still
+        // found — keeping `resolve()` consistent with the `resolve_with_context()` slow path.
+        if ctx.missing_dependencies.is_none()
+            && let Some(anchor) = self.cache.pkg_anchor(cached_path)
+            && let Some(package_json) = self.cache.get_package_json(&anchor, &self.options, ctx)?
+        {
+            return Ok(Some(package_json));
+        }
+        self.find_package_json_for_a_package_slow(cached_path, ctx)
+    }
+
+    /// Directory-walk fallback for [`Self::find_package_json_for_a_package`]: probe `package.json`
+    /// at each directory from `cached_path` up to the `node_modules` boundary. Used when dependency
+    /// tracking is enabled (to preserve exact `missing_dependencies`) or for degenerate paths with
+    /// no package anchor.
+    fn find_package_json_for_a_package_slow(
+        &self,
+        cached_path: &CachedPath,
+        ctx: &mut Ctx,
+    ) -> Result<Option<Arc<PackageJson>>, ResolveError> {
+        let mut last = None;
+        // Go up directories when the querying path is not a directory
+        let mut cp = cached_path.clone();
+        if !self.is_dir(&cp, ctx)
+            && let Some(cv) = cp.parent(&self.cache)
+        {
+            cp = cv;
+        }
+        let mut cp = Some(cp);
+        while let Some(p) = cp {
+            if p.is_node_modules() {
+                break;
+            }
+            // Skip /node_modules/@scope/package.json
+            if let Some(parent) = p.parent(&self.cache)
+                && parent.is_node_modules()
+                && let Some(filename) = p.path().file_name()
+                && filename.as_encoded_bytes().starts_with(b"@")
+            {
+                break;
+            }
+            if let Some(package_json) = self.cache.get_package_json(&p, &self.options, ctx)? {
+                last = Some(package_json);
+            }
+            cp = p.parent(&self.cache);
+        }
+        Ok(last)
     }
 
     /// [`Cache::is_file`] using this resolver's [`ResolveOptions::symlinks`] policy.


### PR DESCRIPTION
## Summary

Two fast paths for resolving inside `node_modules`, built on one allocation-free helper — `Cache::pkg_anchor`, which walks the cached parent chain (no syscalls) to the deepest `<...>/node_modules/<pkg>` directory (the "anchor").

## 1. Canonicalize the anchor, not every component

`canonicalize_with_visited` canonicalizes the **real** anchor and appends the suffix below it without a per-component `read_link` walk:

- The anchor is canonicalized **properly** (recursively), so a symlinked project root (`/tmp`→`/private/tmp`, a symlinked `$HOME`/checkout, a Windows junction) is still resolved.
- A **symlinked anchor** — a linked workspace package, or the top-level link of an isolated layout — takes the normal walk, which follows it and everything below.
- The suffix is appended only after `suffix_below_anchor_is_symlink_free` confirms every component strictly below the anchor is a real, non-symlink entry. That `lstat` reuses the cache (`CachedMeta`), so components already stat'd while resolving the file cost nothing — and any internal package symlink (`lib -> dist`, a re-export file) or `..` suffix falls back to the normal walk.

This is correct for **any** layout — flat, isolated, PnP, workspace, nested, or a hand-built tree — because it *verifies* the suffix rather than assuming it from a detected layout. No layout detection, no markers, no trust gate.

## 2. Jump to the package's `package.json`

`find_package_json_for_a_package` jumps straight to the anchor's `package.json` instead of probing every intermediate directory, falling back to the directory walk when dependency tracking is enabled (`resolve_with_context`, so `missing_dependencies` stays byte-identical) or when the anchor has no manifest of its own.

## Measured syscall reduction

FileSystem-call counts for the 18-request `package_managers` workload (which includes monorepo cases — a nested `react@17` under a workspace and a workspace-to-workspace dep), this branch vs `main`, measured with one counting-`FileSystem` harness:

| combo | main | now | Δ |
|---|---|---|---|
| npm-flat / yarn-flat / bun-flat | 108 | 86 | **−20%** |
| pnpm-isolated / pnpm-hoisted / bun-isolated | 143 | 120 | **−16%** |
| yarn-isolated | 135 | 112 | **−17%** |
| yarn-pnp | 174 | 134 | **−23%** |

The reduction comes from `read` (skipped intermediate `package.json` ENOENT probes) and the eliminated per-component canonicalize walk; the suffix check adds no syscalls in real installs because the lstats are cache hits.

## Tests

- `node_modules_canonicalize.rs` walks every path (~12.4k) under each installed `fixtures/bench-pm/installs/<combo>/node_modules` tree (all npm/pnpm/yarn/bun × flat/isolated/hoisted/pnp combos) and asserts the resolver's canonicalization equals `std::fs::canonicalize` — Windows-aware — exercising the symlinks into virtual stores, the `.bin` shim directory, and the monorepo layouts (a nested `react@17` under `packages/ui`, a workspace-to-workspace link).
- Committed symlink fixtures cover a **real** anchor with internal dir/file symlinks (`internal-symlink`) and a **symlinked** workspace anchor with a suffix symlink (`symlinked-workspace`); each test fails without the suffix check.
- Full suite green: 271 unit + integration + dependencies + resolve_package + doctest, clippy `--deny warnings`, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
