### PR TITLE
fix(tsconfig): support node subpath imports in extends field

### DIFF
--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -406,6 +406,22 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             None => Err(ResolveError::Specifier(SpecifierError::Empty(specifier.to_string()))),
             Some(b'/') => Ok(PathBuf::from(specifier)),
             Some(b'.') => Ok(tsconfig.directory().normalize_with(specifier)),
+            Some(b'#') => {
+                let mut ctx = Ctx::default();
+                if let Some(package_json) =
+                    self.find_package_json_for_a_package(directory, &mut ctx)?
+                {
+                    if let Some(cached_path) = self.package_imports_resolve(
+                        specifier,
+                        &package_json,
+                        Some(tsconfig),
+                        &mut ctx,
+                    )? {
+                        return Ok(cached_path.path().to_path_buf());
+                    }
+                }
+                Err(ResolveError::TsconfigNotFound(PathBuf::from(specifier)))
+            }
             _ => self
                 .clone_with_options(ResolveOptions {
                     tsconfig: None,


### PR DESCRIPTION
### Description
This PR fixes an issue where the \`tsconfig\` resolver fails to resolve Node subpath imports (specifiers starting with \`#\`) when used in the \`extends\` field.

Currently, \`get_extended_tsconfig_path\` falls back to \`load_package_self_or_node_modules\` for any specifier that does not start with \`.\` or \`/\`. This treats the \`#\` prefix as a literal directory name, leading to an unhandled \`TsconfigNotFound\` error.

### Changes
- Added a new match arm for \`Some(b'#')\` in \`get_extended_tsconfig_path\`.
- Reused the existing \`find_package_json_for_a_package\` and \`package_imports_resolve\` methods to properly look up the closest \`package.json\` and resolve the subpath alias according to the Node specification.

### Related Issues
Ref: rolldown/rolldown#9611