### PR TITLE
fix(tsconfig): apply each referenced project's own `allowJs`

### DIFF
--- a/fixtures/tsconfig/cases/project-references-ref-allow-js/src/foo.js
+++ b/fixtures/tsconfig/cases/project-references-ref-allow-js/src/foo.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/fixtures/tsconfig/cases/project-references-ref-allow-js/src/index.js
+++ b/fixtures/tsconfig/cases/project-references-ref-allow-js/src/index.js
@@ -1,0 +1,3 @@
+import foo from "@alias/foo.js";
+
+export default foo;

--- a/fixtures/tsconfig/cases/project-references-ref-allow-js/tsconfig.app.json
+++ b/fixtures/tsconfig/cases/project-references-ref-allow-js/tsconfig.app.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "allowJs": true,
+    "paths": {
+      "@alias/*": [
+        "./src/*"
+      ]
+    }
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/fixtures/tsconfig/cases/project-references-ref-allow-js/tsconfig.json
+++ b/fixtures/tsconfig/cases/project-references-ref-allow-js/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -206,6 +206,27 @@ fn walk_up_when_ref_excludes_file() {
 }
 
 #[test]
+fn referenced_config_allow_js_uses_own_setting() {
+    // A Vite-style solution `tsconfig.json` (empty `include`, only `references`)
+    // does not set `allowJs`, but the referenced `tsconfig.app.json` does. When
+    // resolving from a `.js` file, the solution must defer to the referenced
+    // project — whose own `allowJs` lets it claim the file — so its `paths`
+    // alias applies. Previously the solution checked the *parent's* `allowJs`,
+    // which dropped the `.js` file before any reference was consulted.
+    let f = super::fixture_root().join("tsconfig/cases/project-references-ref-allow-js");
+
+    let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".js".into(), ".ts".into()],
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
+
+    let resolved_path =
+        resolver.resolve_file(f.join("src/index.js"), "@alias/foo.js").map(|f| f.full_path());
+    assert_eq!(resolved_path, Ok(f.join("src/foo.js")));
+}
+
+#[test]
 fn root_paths_apply_to_default_include_files() {
     let f = super::fixture_root().join("tsconfig/cases/project-references-default-include");
 

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -566,7 +566,6 @@ enum GlobPattern<'a> {
 impl TsConfig {
     pub(crate) fn resolve_tsconfig_solution(tsconfig: Arc<Self>, path: &Path) -> Arc<Self> {
         if !tsconfig.references_resolved.is_empty()
-            && tsconfig.is_file_extension_allowed_in_tsconfig(path)
             && let Some(solution_tsconfig) = tsconfig
                 .references_resolved
                 .iter()
@@ -609,6 +608,10 @@ impl TsConfig {
     }
 
     fn is_file_included_in_tsconfig(&self, path: &Path) -> bool {
+        // 0. Check extension first - each tsconfig uses its own allowJs setting
+        if !self.is_file_extension_allowed_in_tsconfig(path) {
+            return false;
+        }
         // 1. Check files array (highest priority - overrides exclude)
         if self.files.as_ref().is_some_and(|files| files.iter().any(|file| Path::new(file) == path))
         {


### PR DESCRIPTION
## What

Fixes solution-style `tsconfig.json` resolution so that each **referenced project's own `allowJs`** decides whether it claims a `.js`/`.jsx`/`.mjs`/`.cjs` file, instead of inheriting the answer from the parent solution config.

## Why

A common Vite project layout uses a solution `tsconfig.json` that contains nothing but references:

```jsonc
// tsconfig.json
{ "include": [], "references": [{ "path": "./tsconfig.app.json" }] }
```

```jsonc
// tsconfig.app.json
{
  "compilerOptions": {
    "composite": true,
    "allowJs": true,
    "paths": { "@alias/*": ["./src/*"] }
  },
  "include": ["src/**/*"]
}
```

The root config does **not** set `allowJs`, but the referenced `tsconfig.app.json` does.

`resolve_tsconfig_solution` used to short-circuit on `tsconfig.is_file_extension_allowed_in_tsconfig(path)` — i.e. the **parent's** `allowJs` — *before* iterating the references. For a `.js` file this returned `false`, so no reference was ever consulted, the referenced project's `paths` alias never applied, and resolving `@alias/foo.js` from `src/index.js` failed with `NotFound`.

## How

- Remove the parent-level extension check from `resolve_tsconfig_solution`.
- Add the extension check as step `0` inside `is_file_included_in_tsconfig`, where it is evaluated against `self` — i.e. each referenced project's own `allowJs`.

This keeps the existing `is_glob_match` fast-path behavior intact and makes ownership consistent with `claims_ownership_of`, which already evaluates references via `is_file_included_in_tsconfig`.

## Tests

Added `referenced_config_allow_js_uses_own_setting` in `src/tests/tsconfig_project_references.rs` with a new fixture under `fixtures/tsconfig/cases/project-references-ref-allow-js/` (root solution without `allowJs`, referenced app config with `allowJs: true` and a `paths` alias).

Resolving `@alias/foo.js` from `src/index.js`:

- **Before the fix:** `Err(NotFound("@alias/foo.js"))`
- **After the fix:** `Ok(.../src/foo.js)`