### PR TITLE
feat(tsconfig): support package.json imports field in extends

### DIFF
--- a/fixtures/tsconfig/cases/extends-imports/default.tsconfig.json
+++ b/fixtures/tsconfig/cases/extends-imports/default.tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "ES2022"
+  }
+}

--- a/fixtures/tsconfig/cases/extends-imports/node.tsconfig.json
+++ b/fixtures/tsconfig/cases/extends-imports/node.tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "ES2015"
+  }
+}

--- a/fixtures/tsconfig/cases/extends-imports/package.json
+++ b/fixtures/tsconfig/cases/extends-imports/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "extends-imports",
+  "imports": {
+    "#string": "./string.tsconfig.json",
+    "#conditional": {
+      "node": "./node.tsconfig.json",
+      "default": "./default.tsconfig.json"
+    }
+  }
+}

--- a/fixtures/tsconfig/cases/extends-imports/string.tsconfig.json
+++ b/fixtures/tsconfig/cases/extends-imports/string.tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "ES2020"
+  }
+}

--- a/fixtures/tsconfig/cases/extends-imports/tsconfig-missing.json
+++ b/fixtures/tsconfig/cases/extends-imports/tsconfig-missing.json
@@ -1,0 +1,3 @@
+{
+  "extends": "#missing"
+}

--- a/fixtures/tsconfig/cases/extends-imports/tsconfig-string.json
+++ b/fixtures/tsconfig/cases/extends-imports/tsconfig-string.json
@@ -1,0 +1,3 @@
+{
+  "extends": "#string"
+}

--- a/fixtures/tsconfig/cases/extends-imports/tsconfig.json
+++ b/fixtures/tsconfig/cases/extends-imports/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "#conditional"
+}

--- a/src/tests/tsconfig_extends.rs
+++ b/src/tests/tsconfig_extends.rs
@@ -367,6 +367,31 @@ fn test_extend_package() {
     }
 }
 
+#[test]
+fn test_extend_imports() {
+    let f = super::fixture_root().join("tsconfig/cases/extends-imports");
+
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: f.join("tsconfig.json"),
+            references: TsconfigReferences::Auto,
+        })),
+        ..ResolveOptions::default()
+    });
+
+    let resolution = resolver.resolve_tsconfig(f.join("tsconfig-string.json")).expect("resolved");
+    assert_eq!(resolution.compiler_options.target, Some("ES2020".to_string()));
+
+    let resolution = resolver.resolve_tsconfig(&f).expect("resolved");
+    assert_eq!(resolution.compiler_options.target, Some("ES2015".to_string()));
+
+    let result = resolver.resolve_tsconfig(f.join("tsconfig-missing.json"));
+    assert!(
+        matches!(&result, Err(crate::ResolveError::TsconfigNotFound(_))),
+        "expected TsconfigNotFound for an undefined `#` import, got {result:?}",
+    );
+}
+
 fn assert_extends_symlink_resolves_to_canonical(config_file: &Path) {
     let f = super::fixture_root().join("tsconfig/cases/extends-symlink");
     let resolver = Resolver::new(ResolveOptions {

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -396,6 +396,25 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         Ok(None)
     }
 
+    /// Lookup configuration shared by tsconfig `extends` targets that resolve
+    /// through `node_modules`: bare package specifiers (via the package
+    /// `exports` field) and `#`-prefixed subpath imports (via the package
+    /// `imports` field). Both use the same conditions so that, for example,
+    /// `extends: "pkg"` and `extends: "#pkg"` agree on which condition wins.
+    fn tsconfig_extends_resolver(&self) -> Self {
+        self.clone_with_options(ResolveOptions {
+            tsconfig: None,
+            condition_names: vec!["node".into(), "import".into()],
+            extensions: vec![".json".into()],
+            main_files: vec!["tsconfig".into()],
+            #[cfg(feature = "yarn_pnp")]
+            yarn_pnp: self.options.yarn_pnp,
+            #[cfg(feature = "yarn_pnp")]
+            cwd: self.options.cwd.clone(),
+            ..ResolveOptions::default()
+        })
+    }
+
     fn get_extended_tsconfig_path(
         &self,
         directory: &CachedPath,
@@ -406,18 +425,25 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             None => Err(ResolveError::Specifier(SpecifierError::Empty(specifier.to_string()))),
             Some(b'/') => Ok(PathBuf::from(specifier)),
             Some(b'.') => Ok(tsconfig.directory().normalize_with(specifier)),
-            _ => self
-                .clone_with_options(ResolveOptions {
-                    tsconfig: None,
-                    condition_names: vec!["node".into(), "import".into()],
-                    extensions: vec![".json".into()],
-                    main_files: vec!["tsconfig".into()],
-                    #[cfg(feature = "yarn_pnp")]
-                    yarn_pnp: self.options.yarn_pnp,
-                    #[cfg(feature = "yarn_pnp")]
-                    cwd: self.options.cwd.clone(),
-                    ..ResolveOptions::default()
+            // Node.js subpath imports, e.g. `extends: "#config"`, resolved
+            // through the nearest `package.json` `imports` field — the same
+            // path the resolver takes for `require("#config")`.
+            Some(b'#') => self
+                .tsconfig_extends_resolver()
+                .load_package_imports(directory, specifier, Some(tsconfig), &mut Ctx::default())
+                .map_err(|err| match err {
+                    ResolveError::PackageImportNotDefined(..) | ResolveError::NotFound(..) => {
+                        ResolveError::TsconfigNotFound(PathBuf::from(specifier))
+                    }
+                    _ => err,
                 })
+                .and_then(|resolved| {
+                    resolved
+                        .map(|p| p.path().to_path_buf())
+                        .ok_or_else(|| ResolveError::TsconfigNotFound(PathBuf::from(specifier)))
+                }),
+            _ => self
+                .tsconfig_extends_resolver()
                 .load_package_self_or_node_modules(directory, specifier, None, &mut Ctx::default())
                 .map(|p| p.to_path_buf())
                 .map_err(|err| match err {


### PR DESCRIPTION
## What

Resolve `#`-prefixed Node.js subpath imports in tsconfig `extends` through the nearest `package.json` `imports` field:

```jsonc
// package.json
{ "imports": { "#base": "./common.tsconfig.json" } }
// tsconfig.json
{ "extends": "#base" }
```

Previously this failed with `TsconfigNotFound`: `get_extended_tsconfig_path` only handled `/`, `.`/`..`, and bare package specifiers (the last via `exports`/`node_modules`, which never consults `imports`).

## Why

TypeScript supports this — it's used in monorepos to avoid brittle `../../../tsconfig.json` paths. Verified against `typescript-go`: `tsgo --showConfig` resolves the fixture to the same targets this PR asserts (`#string` → es2020, `#conditional` node-branch → es6).

Reported in rolldown/rolldown#9611 (labeled `bug: upstream`).

## How

- New `Some(b'#')` arm in `get_extended_tsconfig_path` that routes through `load_package_imports` — the same wrapper the resolver uses for `require("#x")`, so it gets the correct package-scope lookup (`LOOKUP_PACKAGE_SCOPE`) and result verification (`resolve_esm_match`).
- Extracted `tsconfig_extends_resolver` so the `#` (imports) and bare-package (`exports`/`node_modules`) arms share one lookup config (conditions `["node", "import"]`) — `extends: "pkg"` and `extends: "#pkg"` now agree on which condition wins.
- An undefined `#import` (or a missing target) is reported as `TsconfigNotFound`, consistent with how a missing bare-package or relative `extends` target is reported — and with `tsgo`, which emits `File '#missing' not found`.

## Tests

One fixture (`fixtures/tsconfig/cases/extends-imports/`) and one test (`test_extend_imports`) covering, via its `package.json` `imports` map:

- `#string` → string target → `target: ES2020`
- `#conditional` → `{ node, default }` object → `node` wins over `default` → `target: ES2015`
- `extends: "#missing"` (not in `imports`) → `TsconfigNotFound`

All cross-checked against `tsgo` (es2020 / es6 / `File '#missing' not found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
