### PR TITLE
fix(tsconfig): honor explicit non-TS extensions in `include`

### DIFF
--- a/fixtures/tsconfig/cases/solution-style-non-ts/src/App.vue
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/src/App.vue
@@ -1,0 +1,1 @@
+<!-- Importer fixture (`.vue`). The resolver only needs this file to exist. -->

--- a/fixtures/tsconfig/cases/solution-style-non-ts/src/Widget.svelte
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/src/Widget.svelte
@@ -1,0 +1,1 @@
+<!-- Importer fixture (`.svelte`). Proves the fix is not `.vue`-specific. -->

--- a/fixtures/tsconfig/cases/solution-style-non-ts/src/components/HelloWorld.vue
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/src/components/HelloWorld.vue
@@ -1,0 +1,1 @@
+<!-- Resolution target (`.vue`) reached via the `@/*` alias. -->

--- a/fixtures/tsconfig/cases/solution-style-non-ts/src/main.ts
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/src/main.ts
@@ -1,0 +1,2 @@
+// Importer fixture (`.ts`). The resolver only needs this file to exist.
+export {}

--- a/fixtures/tsconfig/cases/solution-style-non-ts/src/styles.css
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/src/styles.css
@@ -1,0 +1,1 @@
+/* Importer fixture (`.css`): an extension NOT listed in any `include` glob. */

--- a/fixtures/tsconfig/cases/solution-style-non-ts/src/util.ts
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/src/util.ts
@@ -1,0 +1,2 @@
+// Resolution target reached via the `@/*` alias.
+export const util = true

--- a/fixtures/tsconfig/cases/solution-style-non-ts/tsconfig.app.json
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue", "src/**/*.svelte"]
+}

--- a/fixtures/tsconfig/cases/solution-style-non-ts/tsconfig.json
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }]
+}

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -240,3 +240,56 @@ fn root_paths_apply_to_default_include_files() {
         resolver.resolve_file(f.join("index.ts"), "@app/util").map(|f| f.full_path());
     assert_eq!(resolved_path, Ok(f.join("src/util.ts")));
 }
+
+/// Regression test for <https://github.com/vitejs/vite/issues/22047>.
+///
+/// A solution-style root `tsconfig.json` (`"files": []` + `references`) whose
+/// referenced project declares `paths` and explicitly includes non-TS
+/// extensions (`src/**/*.vue`, `src/**/*.svelte`), as scaffolded by Vite. An
+/// import originating from such a non-TS file must resolve through the
+/// referenced project's `paths`, exactly like an import from a `.ts` file.
+///
+/// Previously the importer's extension was rejected before the `include` globs
+/// were consulted, so a `.vue` / `.svelte` importer never matched the
+/// referenced project and the empty solution root (which owns no `paths`) was
+/// selected, leaving the `@/*` alias unresolved.
+#[test]
+fn solution_style_non_ts_extensions() {
+    let f = super::fixture_root().join("tsconfig/cases/solution-style-non-ts");
+
+    let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".ts".into(), ".tsx".into(), ".vue".into(), ".svelte".into()],
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
+
+    let hello = f.join("src/components/HelloWorld.vue");
+
+    #[rustfmt::skip]
+    let pass = [
+        // `.vue` importer (the original bug) resolves the alias.
+        (f.join("src/App.vue"),       "@/components/HelloWorld.vue", hello.clone()),
+        // Any explicitly-included extension works, not just `.vue`.
+        (f.join("src/Widget.svelte"), "@/components/HelloWorld.vue", hello.clone()),
+        // `.ts` importers keep working (no regression).
+        (f.join("src/main.ts"),       "@/components/HelloWorld.vue", hello.clone()),
+        (f.join("src/main.ts"),       "@/util.ts",                   f.join("src/util.ts")),
+    ];
+
+    for (path, request, expected) in pass {
+        let resolved = resolver.resolve_file(&path, request).map(|f| f.full_path());
+        assert_eq!(resolved, Ok(expected), "{request} from {path:?}");
+    }
+
+    // The referenced project owns the `.vue` / `.svelte` / `.ts` files through
+    // its `include` globs, so auto-discovery selects it for those importers...
+    for importer in ["src/App.vue", "src/Widget.svelte", "src/main.ts"] {
+        let tsconfig = resolver.find_tsconfig(f.join(importer)).unwrap().unwrap();
+        assert_eq!(tsconfig.path, f.join("tsconfig.app.json"), "find_tsconfig for {importer}");
+    }
+
+    // ...while a file whose extension is not matched by any `include` glob
+    // (here `.css`) is left to the solution root, which owns no `paths`.
+    let tsconfig = resolver.find_tsconfig(f.join("src/styles.css")).unwrap().unwrap();
+    assert_eq!(tsconfig.path, f.join("tsconfig.json"));
+}

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -272,13 +272,13 @@ fn solution_style_non_ts_extensions() {
         // Any explicitly-included extension works, not just `.vue`.
         (f.join("src/Widget.svelte"), "@/components/HelloWorld.vue", hello.clone()),
         // `.ts` importers keep working (no regression).
-        (f.join("src/main.ts"),       "@/components/HelloWorld.vue", hello.clone()),
+        (f.join("src/main.ts"),       "@/components/HelloWorld.vue", hello),
         (f.join("src/main.ts"),       "@/util.ts",                   f.join("src/util.ts")),
     ];
 
     for (path, request, expected) in pass {
-        let resolved = resolver.resolve_file(&path, request).map(|f| f.full_path());
-        assert_eq!(resolved, Ok(expected), "{request} from {path:?}");
+        let resolved_path = resolver.resolve_file(&path, request).map(|f| f.full_path());
+        assert_eq!(resolved_path, Ok(expected), "{request} from {path:?}");
     }
 
     // The referenced project owns the `.vue` / `.svelte` / `.ts` files through

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -608,10 +608,6 @@ impl TsConfig {
     }
 
     fn is_file_included_in_tsconfig(&self, path: &Path) -> bool {
-        // 0. Check extension first - each tsconfig uses its own allowJs setting
-        if !self.is_file_extension_allowed_in_tsconfig(path) {
-            return false;
-        }
         // 1. Check files array (highest priority - overrides exclude)
         if self.files.as_ref().is_some_and(|files| files.iter().any(|file| Path::new(file) == path))
         {
@@ -640,8 +636,13 @@ impl TsConfig {
     fn is_glob_matches(&self, path: &Path, pattern: GlobPattern) -> bool {
         let path_str = path.to_string_lossy().replace('\\', "/");
         match pattern {
-            // The default include `**/*` is scoped to the tsconfig directory.
-            GlobPattern::All => path.starts_with(self.directory()),
+            // The default `**/*` is scoped to the tsconfig directory; as a
+            // wildcard pattern it is restricted to the configured TS/JS
+            // extensions, same as the gate in `is_glob_match`.
+            GlobPattern::All => {
+                path.starts_with(self.directory())
+                    && self.is_file_extension_allowed_in_tsconfig(path)
+            }
             GlobPattern::Pattern(patterns) => patterns.iter().any(|pattern| {
                 let pattern = pattern.to_string_lossy().replace('\\', "/");
                 self.is_glob_match(pattern.as_ref(), path, &path_str)
@@ -665,7 +666,14 @@ impl TsConfig {
         } else {
             Cow::Borrowed(pattern)
         };
-        // Fast check: if pattern ends with *, filename must have valid extension
+        // Extension gate, applied only to wildcard-terminated patterns: a pattern
+        // ending in `*` (e.g. the default `**/*`, or a bare directory like `src`
+        // that expands to `src/**/*`) matches "any file", so — mirroring
+        // TypeScript — it is restricted to the configured TS/JS extensions.
+        // A pattern naming an explicit extension (e.g. `src/**/*.vue`) does not
+        // end in `*` and is matched verbatim below; this is what lets
+        // solution-style tsconfigs claim explicitly-included non-TS files such
+        // as `.vue` / `.svelte` (e.g. the Vite Vue scaffold).
         if pattern.ends_with('*') && !self.is_file_extension_allowed_in_tsconfig(path) {
             return false;
         }


### PR DESCRIPTION
Related to #1212

## Summary

`is_file_included_in_tsconfig` checked a file's extension *before* evaluating the `include` globs, rejecting any non-TS/JS extension up front — so a file with a non-TS extension that is **explicitly** listed in `include` (e.g. `src/**/*.vue`) was never matched.

In a solution-style layout (a root `tsconfig.json` with `"files": []` + `references`, and `paths` declared in a referenced `tsconfig.app.json` whose `include` lists `src/**/*.vue`), a `.vue` / `.svelte` importer therefore could not select the project that owns it. The empty solution root (no `paths`) was chosen instead, so `@/*`-style aliases never resolved.

## Why

This is the default `create-vite` **Vue + TS** layout, and it blocks migrating from the [`vite-tsconfig-paths`] plugin to Vite's built-in `resolve.tsconfigPaths` (Vite 8 / rolldown-vite, which resolves through oxc-resolver): `import Foo from '@/components/Foo.vue'` inside a `.vue` file fails in both dev and build. Downstream report: vitejs/vite#22047.

Closes #<issue>.

## Change

- Drop the blanket extension pre-gate in `is_file_included_in_tsconfig`.
- Apply the TS/JS restriction in the default `**/*` (`GlobPattern::All`) branch instead, so a bare/omitted `include` still matches only TS/JS while an explicitly-named extension matches verbatim.

Extension filtering is now consistently per-pattern: the gate in `is_glob_match` already restricts only wildcard-terminated (`*`) patterns, so `src/**/*.vue` matches `.vue` once it is actually reached. This mirrors TypeScript (`getSubPatternFromSpec` / `isImplicitGlob`) and tsconfck's `isGlobMatch` — no hardcoded per-framework list, and no dependency on `allowJs`.

## Tests

Adds `solution_style_non_ts_extensions` with a fixture mirroring the create-vite Vue scaffold: `.vue` / `.svelte` importers resolve a referenced project's `paths`, `.ts` importers keep working, and an extension not listed in any `include` (here `.css`) is still left to the solution root. The test fails on `main` and passes with this change.

## Out of scope

`claims_ownership_of` still routes a non-TS importer to the *nearest* tsconfig. In nested layouts (a child tsconfig that doesn't `include` the file, with an ancestor solution project that does) the child still intercepts it. That needs a separate change to the discovery walk and is left as a follow-up.

[`vite-tsconfig-paths`]: https://github.com/aleclarson/vite-tsconfig-paths
