### PR TITLE
fix(tsconfig): walk up for non-TS and `allowJs`-off `.js` importers

### DIFF
--- a/fixtures/tsconfig/cases/referenced-allow-js-off/src/consumer.js
+++ b/fixtures/tsconfig/cases/referenced-allow-js-off/src/consumer.js
@@ -1,0 +1,4 @@
+// `.js` importer: even though `include` names `src/**/*.js`, the referenced
+// project has `allowJs` off, so it does not own this file and `@lib/*` must
+// not apply.
+export {};

--- a/fixtures/tsconfig/cases/referenced-allow-js-off/src/consumer.ts
+++ b/fixtures/tsconfig/cases/referenced-allow-js-off/src/consumer.ts
@@ -1,0 +1,3 @@
+// `.ts` importer: the referenced project includes `src/**/*.ts`, so it owns
+// this file and its `@lib/*` alias applies.
+export {};

--- a/fixtures/tsconfig/cases/referenced-allow-js-off/src/foo.ts
+++ b/fixtures/tsconfig/cases/referenced-allow-js-off/src/foo.ts
@@ -1,0 +1,2 @@
+// Resolution target reached through the referenced project's `@lib/*` alias.
+export {};

--- a/fixtures/tsconfig/cases/referenced-allow-js-off/tsconfig.json
+++ b/fixtures/tsconfig/cases/referenced-allow-js-off/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/fixtures/tsconfig/cases/referenced-allow-js-off/tsconfig.lib.json
+++ b/fixtures/tsconfig/cases/referenced-allow-js-off/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@lib/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.js"]
+}

--- a/fixtures/tsconfig/cases/solution-style-non-ts/src/feature/App.vue
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/src/feature/App.vue
@@ -1,0 +1,3 @@
+<script setup lang="ts">
+import HelloWorld from "@/components/HelloWorld.vue";
+</script>

--- a/fixtures/tsconfig/cases/solution-style-non-ts/src/feature/legacy.js
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/src/feature/legacy.js
@@ -1,0 +1,4 @@
+// A `.js` file the child does not `include` and does not compile (`allowJs` is
+// off). It is still a source file, so auto-discovery keeps it on the nearest
+// tsconfig (the child) rather than walking up like a `.vue` resource would.
+export {};

--- a/fixtures/tsconfig/cases/solution-style-non-ts/src/feature/local.ts
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/src/feature/local.ts
@@ -1,0 +1,3 @@
+// A `.ts` file the nearer child `tsconfig.json` *does* include, so the child
+// keeps owning it (auto-discovery does not walk up for this importer).
+export {};

--- a/fixtures/tsconfig/cases/solution-style-non-ts/src/feature/tsconfig.json
+++ b/fixtures/tsconfig/cases/solution-style-non-ts/src/feature/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -226,6 +226,34 @@ fn referenced_config_allow_js_uses_own_setting() {
     assert_eq!(resolved_path, Ok(f.join("src/foo.js")));
 }
 
+/// Counterpart to `referenced_config_allow_js_uses_own_setting` for `allowJs`
+/// *off*. The referenced project lists `src/**/*.js` in `include`, but with
+/// `allowJs` off a `.js` file is not part of its program (TypeScript drops the
+/// extension before the globs are consulted), so it must not claim a `.js`
+/// importer through the solution. A `.ts` importer the same `include` genuinely
+/// covers still routes through it.
+#[test]
+fn referenced_config_drops_js_when_allow_js_off() {
+    let f = super::fixture_root().join("tsconfig/cases/referenced-allow-js-off");
+
+    let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".ts".into(), ".js".into()],
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
+
+    // `.ts` importer: covered by `src/**/*.ts`, so `@lib/*` resolves.
+    let covered =
+        resolver.resolve_file(f.join("src/consumer.ts"), "@lib/foo.ts").map(|f| f.full_path());
+    assert_eq!(covered, Ok(f.join("src/foo.ts")));
+
+    // `.js` importer: dropped because `allowJs` is off, so `@lib/*` does not
+    // apply and the alias is left unresolved.
+    let dropped =
+        resolver.resolve_file(f.join("src/consumer.js"), "@lib/foo.ts").map(|f| f.full_path());
+    assert_eq!(dropped, Err(ResolveError::NotFound("@lib/foo.ts".into())));
+}
+
 #[test]
 fn root_paths_apply_to_default_include_files() {
     let f = super::fixture_root().join("tsconfig/cases/project-references-default-include");
@@ -289,7 +317,65 @@ fn solution_style_non_ts_extensions() {
     }
 
     // ...while a file whose extension is not matched by any `include` glob
-    // (here `.css`) is left to the solution root, which owns no `paths`.
+    // (here `.css`) is owned by no project. It is never routed to the
+    // referenced project, so the `@/*` alias does not leak into it: auto-
+    // discovery walks past the solution root (which lists no `files`) up to the
+    // outermost ancestor tsconfig.
     let tsconfig = resolver.find_tsconfig(f.join("src/styles.css")).unwrap().unwrap();
-    assert_eq!(tsconfig.path, f.join("tsconfig.json"));
+    assert_eq!(tsconfig.path, super::fixture_root().join("tsconfig/tsconfig.json"));
+
+    // And so the `@/*` alias (declared only by the referenced project) does not
+    // apply to the `.css` file.
+    let leaked = resolver
+        .resolve_file(f.join("src/styles.css"), "@/components/HelloWorld.vue")
+        .map(|f| f.full_path());
+    assert_eq!(leaked, Err(ResolveError::NotFound("@/components/HelloWorld.vue".into())));
+}
+
+/// A nearer child `tsconfig.json` whose `include` does not cover a non-TS
+/// importer must not intercept it; auto-discovery walks past it to an ancestor
+/// solution project that genuinely includes the file.
+///
+/// `src/feature/tsconfig.json` only includes `**/*.ts`, so it does not own
+/// `src/feature/App.vue`. The solution root references a project that includes
+/// `src/**/*.vue` and owns the `@/*` alias, so the `.vue` importer must resolve
+/// through it.
+///
+/// Previously `claims_ownership_of` returned `true` for *every* non-TS importer
+/// (a blanket "use the nearest tsconfig" shortcut). The child therefore claimed
+/// `App.vue` and the walk stopped there, so `@/*` — which the child does not
+/// declare — never resolved.
+#[test]
+fn solution_style_nested_non_ts_walks_up() {
+    let f = super::fixture_root().join("tsconfig/cases/solution-style-non-ts");
+
+    let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".ts".into(), ".vue".into()],
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        ..ResolveOptions::default()
+    });
+
+    let importer = f.join("src/feature/App.vue");
+
+    // The `.vue` importer resolves the solution project's `@/*` alias.
+    let resolved_path =
+        resolver.resolve_file(&importer, "@/components/HelloWorld.vue").map(|f| f.full_path());
+    assert_eq!(resolved_path, Ok(f.join("src/components/HelloWorld.vue")));
+
+    // Auto-discovery routes the importer to the referenced project that owns
+    // `@/*`, not the nearer child `tsconfig.json` (which does not cover it).
+    let tsconfig = resolver.find_tsconfig(&importer).unwrap().unwrap();
+    assert_eq!(tsconfig.path, f.join("tsconfig.app.json"));
+
+    // A `.ts` file the child *does* include stays owned by the child — the walk
+    // only continues for files the nearer config does not cover.
+    let local = resolver.find_tsconfig(f.join("src/feature/local.ts")).unwrap().unwrap();
+    assert_eq!(local.path, f.join("src/feature/tsconfig.json"));
+
+    // A `.js` file with `allowJs` off is not part of the child's program, so
+    // the child does not own it and — like the `.vue` above — the walk
+    // continues up. No ancestor compiles a bare `.js` here, so it ends on the
+    // outermost tsconfig (auto-discovery's fallback).
+    let legacy = resolver.find_tsconfig(f.join("src/feature/legacy.js")).unwrap().unwrap();
+    assert_eq!(legacy.path, super::fixture_root().join("tsconfig/tsconfig.json"));
 }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -583,9 +583,12 @@ impl TsConfig {
     /// doesn't actually cover the file via its `files` / `include` / `exclude`
     /// or via a matching reference.
     pub(crate) fn claims_ownership_of(&self, path: &Path) -> bool {
-        // Non-TS files aren't considered for project ownership; preserve the
-        // legacy behavior of using the nearest tsconfig for them.
-        if !self.is_file_extension_allowed_in_tsconfig(path) {
+        // A directory (extensionless importer) isn't a file, so `files` /
+        // `include` ownership doesn't apply — the nearest enclosing tsconfig
+        // governs it (its `paths` / `baseUrl` / `extends`). A genuine file is
+        // claimed only when owned (below), so an `allowJs`-off `.js` this
+        // config won't compile instead walks up.
+        if path.extension().is_none() {
             return true;
         }
         // Any matching reference claims ownership (consistent with
@@ -613,7 +616,12 @@ impl TsConfig {
         {
             return true;
         }
-        // 2. Check include patterns
+        // 2. Reject non-program inputs: a `.js`-family file with `allowJs` off
+        //    (even if a glob names `.js`), or an extensionless path
+        if self.is_extensionless_or_uncompiled_js(path) {
+            return false;
+        }
+        // 3. Check include patterns
         let is_included = self.include.as_ref().map_or_else(
             || {
                 if self.files.is_some() {
@@ -624,7 +632,7 @@ impl TsConfig {
             },
             |include_patterns| self.is_glob_matches(path, GlobPattern::Pattern(include_patterns)),
         );
-        // 3. Check exclude patterns
+        // 4. Check exclude patterns
         if is_included {
             return self.exclude.as_ref().is_none_or(|exclude_patterns| {
                 !self.is_glob_matches(path, GlobPattern::Pattern(exclude_patterns))
@@ -688,6 +696,17 @@ impl TsConfig {
             TS_EXTENSIONS.contains(&ext)
                 || if allow_js { JS_EXTENSIONS.contains(&ext) } else { false }
         })
+    }
+
+    /// Whether `path` has no extension (typically a directory) or a `.js`-family
+    /// extension this tsconfig does not compile (`allowJs` off). Unlike
+    /// `is_file_extension_allowed_in_tsconfig`, it excludes genuine non-TS files
+    /// (e.g. `.vue`), which must instead be claimed through `include`.
+    fn is_extensionless_or_uncompiled_js(&self, path: &Path) -> bool {
+        let allow_js = self.compiler_options.allow_js.is_some_and(|b| b);
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .is_none_or(|ext| !allow_js && matches!(ext, "js" | "jsx" | "mjs" | "cjs"))
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1213. When auto-discovering a `tsconfig.json` for an importer, `claims_ownership_of` treated *any* file the tsconfig doesn't compile as "owned by the nearest tsconfig" and stopped the upward walk. That blanket shortcut intercepted files that an ancestor project genuinely owns.

## The problem

The guard was:

```rust
if !self.is_file_extension_allowed_in_tsconfig(path) {
    return true; // claimed by the nearest tsconfig
}
```

`is_file_extension_allowed_in_tsconfig` is true only for TS extensions (and JS when `allowJs` is on), so the negation claimed **non-TS files** (`.vue`, `.css`), **extensionless paths**, and **`allowJs`-off `.js`** alike. Two concrete failures:

1. **Non-TS files don't reach their solution project.** A child `tsconfig.json` including only `**/*.ts` would claim a sibling `App.vue`. Auto-discovery stopped at the child, so a solution root that references a config with `include: ["src/**/*.vue"]` and a `@/*` alias never owned the file and the alias didn't resolve.
2. **`allowJs`-off `.js` leaks a referenced project's `paths`.** A referenced project with `allowJs` off but `include: ["src/**/*.js"]` would still route a `.js` importer through itself, applying its `@lib/*` paths to a file TypeScript excludes from the program.

## The fix

- **`claims_ownership_of`** — narrow the early `return true` to `path.extension().is_none()`. A directory (extensionless importer) isn't a file, so `files`/`include` ownership doesn't apply and the nearest enclosing tsconfig governs it (many discovery cases rely on its `paths`/`baseUrl`/`extends`). A genuine file — including an `allowJs`-off `.js` this config won't compile — is claimed only when actually owned, otherwise the walk continues up.
- **`is_file_included_in_tsconfig`** — reject non-program inputs (an `allowJs`-off `.js`, even when a glob names `.js`; or an extensionless path) before consulting `include`, so `resolve_tsconfig_solution` won't route such files to a referenced project.
- Extracted `is_extensionless_or_uncompiled_js` to share that predicate.

Directory importers are unchanged: they still resolve against their nearest tsconfig (verified by the existing `tsconfig_discovery` cases).

## Tests

- `solution_style_nested_non_ts_walks_up` (new) — a child config including only `**/*.ts` no longer intercepts `App.vue`; the walk reaches the solution project that owns `@/*`. A `.ts` the child includes stays on the child; an `allowJs`-off `legacy.js` walks up like the `.vue`.
- `referenced_config_drops_js_when_allow_js_off` (new) — a `.ts` importer resolves `@lib/*`; a `.js` importer does not (dropped because `allowJs` is off).
- `solution_style_non_ts_extensions` (updated) — a `.css` matched by no `include` walks past the solution root to the outermost ancestor, and the `@/*` alias does not leak into it.

New fixtures under `fixtures/tsconfig/cases/referenced-allow-js-off/` and `fixtures/tsconfig/cases/solution-style-non-ts/src/feature/`.