### PR TITLE
chore(deps): update pnp to v0.12.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,18 +919,18 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pnp"
-version = "0.12.9"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d021b5b4a2ea34bf137831fbbc5856e9c7ca70861f95a0f8dc51323b6e821faa"
+checksum = "a068874344fa15263114022fc7bc257990fec3f679a9ce1aa235c18008456c32"
 dependencies = [
  "byteorder",
  "concurrent_lru",
- "fancy-regex",
  "flate2",
  "indexmap",
  "nodejs-built-in-modules",
  "pathdiff",
  "radix_trie",
+ "regress",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -1041,6 +1041,16 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "regress"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ thiserror = "2"
 tracing = "0.1"
 
 percent-encoding = "2"
-pnp = { version = "0.12.8", optional = true }
+pnp = { version = "0.12.10", optional = true }
 
 document-features = { version = "0.2.12", optional = true }
 


### PR DESCRIPTION
Bumps the `pnp` crate (Yarn Plug'n'Play resolution, behind the `yarn_pnp` feature) from `0.12.8` to `0.12.10`.

Notable transitive change: `pnp` swapped its regex engine from `fancy-regex` to `regress` (adds `regress v0.11.1`). This only affects builds with the `yarn_pnp` feature enabled.

Verified `cargo check`/`clippy`/`doc` with `--all-features` and the `tests::pnp` suite under `--features yarn_pnp` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)