### PR TITLE
refactor: replace fancy-regex with regress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,21 +46,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -366,17 +342,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]
@@ -836,7 +801,6 @@ dependencies = [
  "dashmap",
  "dirs",
  "document-features",
- "fancy-regex",
  "fast-glob",
  "indexmap",
  "json-strip-comments",
@@ -846,6 +810,7 @@ dependencies = [
  "pico-args",
  "pnp",
  "rayon",
+ "regress",
  "rustc-hash",
  "rustix",
  "self_cell",
@@ -865,12 +830,12 @@ dependencies = [
 name = "oxc_resolver_napi"
 version = "11.21.1"
 dependencies = [
- "fancy-regex",
  "mimalloc-safe",
  "napi",
  "napi-build",
  "napi-derive",
  "oxc_resolver",
+ "regress",
  "tracing-subscriber",
 ]
 
@@ -1024,23 +989,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "regress"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,9 +117,9 @@ self_cell = "1" # Used by simd implementation for self-referential struct
 [dev-dependencies]
 criterion2 = { version = "3.0.3", default-features = false }
 dirs = { version = "6.0.0" }
-fancy-regex = { version = "^0.18.0", default-features = false, features = ["std"] }
 pico-args = "0.5.0"
 rayon = { version = "1.12.0" }
+regress = { version = "0.11" } # ECMAScript regex engine for testing `Restriction::Fn`
 vfs = "0.13.0" # for testing with in memory file system
 walkdir = "2" # for loading benchmark fixtures
 
@@ -162,9 +162,3 @@ codegen-units = 1
 strip = "symbols" # set to `false` for debug information
 debug = false # set to `true` for debug information
 panic = "abort" # Let it crash and force ourselves to write safe Rust.
-
-[profile.release.package.regex-automata]
-opt-level = "z" # Optimize for size.
-
-[profile.release.package.regex-syntax]
-opt-level = "z" # Optimize for size.

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -22,9 +22,9 @@ doctest = false
 [dependencies]
 oxc_resolver = { workspace = true }
 
-fancy-regex = { version = "^0.18.0", default-features = false, features = ["std"] }
 napi = { version = "3.8", default-features = false, features = ["napi3", "serde-json"] }
 napi-derive = { version = "3" }
+regress = { version = "0.11" } # ECMAScript regex engine for `Restriction` regex
 tracing-subscriber = { version = "0.3.23", optional = true, default-features = false, features = [
   "std",
   "fmt",

--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
-use regress::Regex;
 use napi::Either;
 use napi_derive::napi;
+use regress::Regex;
 
 /// Module Resolution Options
 ///

--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
-use fancy_regex::Regex;
+use regress::Regex;
 use napi::Either;
 use napi_derive::napi;
 
@@ -232,7 +232,7 @@ impl TryFrom<Restriction> for oxc_resolver::Restriction {
                 let re = Regex::new(&regex)
                     .map_err(|e| napi::Error::from_reason(format!("Invalid regex: {e}")))?;
                 Ok(oxc_resolver::Restriction::Fn(Arc::new(move |path| {
-                    re.is_match(path.to_str().unwrap_or_default()).unwrap_or(false)
+                    re.find(path.to_str().unwrap_or_default()).is_some()
                 })))
             }
             (Some(path), None) => Ok(oxc_resolver::Restriction::Path(PathBuf::from(path))),

--- a/src/tests/restrictions.rs
+++ b/src/tests/restrictions.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use fancy_regex::Regex;
+use regress::Regex;
 
 use crate::{ResolveError, ResolveOptions, Resolver, Restriction};
 
@@ -14,7 +14,7 @@ fn should_respect_regexp_restriction() {
     let resolver1 = Resolver::new(ResolveOptions {
         extensions: vec![".js".into()],
         restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-            path.as_os_str().to_str().is_some_and(|s| re.is_match(s).unwrap_or(false))
+            path.as_os_str().to_str().is_some_and(|s| re.find(s).is_some())
         }))],
         ..ResolveOptions::default()
     });
@@ -32,7 +32,7 @@ fn should_try_to_find_alternative_1() {
         extensions: vec![".js".into(), ".css".into()],
         main_files: vec!["index".into()],
         restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-            path.as_os_str().to_str().is_some_and(|s| re.is_match(s).unwrap_or(false))
+            path.as_os_str().to_str().is_some_and(|s| re.find(s).is_some())
         }))],
         ..ResolveOptions::default()
     });
@@ -65,7 +65,7 @@ fn should_try_to_find_alternative_2() {
         extensions: vec![".js".into(), ".css".into()],
         main_fields: vec!["main".into(), "style".into()],
         restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-            path.as_os_str().to_str().is_some_and(|s| re.is_match(s).unwrap_or(false))
+            path.as_os_str().to_str().is_some_and(|s| re.find(s).is_some())
         }))],
         ..ResolveOptions::default()
     });
@@ -83,7 +83,7 @@ fn should_try_to_find_alternative_3() {
         extensions: vec![".js".into()],
         main_fields: vec!["main".into(), "module".into(), "style".into()],
         restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-            path.as_os_str().to_str().is_some_and(|s| re.is_match(s).unwrap_or(false))
+            path.as_os_str().to_str().is_some_and(|s| re.find(s).is_some())
         }))],
         ..ResolveOptions::default()
     });
@@ -103,7 +103,7 @@ fn should_check_restrictions_in_load_index_with_enforce_extension_disabled() {
         main_files: vec!["index".into()],
         enforce_extension: crate::EnforceExtension::Disabled,
         restrictions: vec![Restriction::Fn(Arc::new(move |path| {
-            path.as_os_str().to_str().is_some_and(|s| re.is_match(s).unwrap_or(false))
+            path.as_os_str().to_str().is_some_and(|s| re.find(s).is_some())
         }))],
         ..ResolveOptions::default()
     });
@@ -206,11 +206,11 @@ fn should_apply_multiple_restrictions() {
         main_files: vec!["index".into()],
         restrictions: vec![
             Restriction::Fn(Arc::new(move |path| {
-                path.as_os_str().to_str().is_some_and(|s| re_css.is_match(s).unwrap_or(false))
+                path.as_os_str().to_str().is_some_and(|s| re_css.find(s).is_some())
             })),
             Restriction::Fn(Arc::new(move |path| {
                 // Reject .js files
-                path.as_os_str().to_str().is_some_and(|s| !re_no_js.is_match(s).unwrap_or(false))
+                path.as_os_str().to_str().is_some_and(|s| re_no_js.find(s).is_none())
             })),
         ],
         ..ResolveOptions::default()
@@ -235,11 +235,11 @@ fn should_fail_if_any_restriction_fails() {
         restrictions: vec![
             Restriction::Fn(Arc::new(move |path| {
                 // First restriction: must be CSS
-                path.as_os_str().to_str().is_some_and(|s| re_css.is_match(s).unwrap_or(false))
+                path.as_os_str().to_str().is_some_and(|s| re_css.find(s).is_some())
             })),
             Restriction::Fn(Arc::new(move |path| {
                 // Second restriction: must NOT be CSS (contradicts first)
-                path.as_os_str().to_str().is_some_and(|s| !re_no_css.is_match(s).unwrap_or(false))
+                path.as_os_str().to_str().is_some_and(|s| re_no_css.find(s).is_none())
             })),
         ],
         ..ResolveOptions::default()


### PR DESCRIPTION
Replaces `fancy-regex` with `regress` for the regex in the `Restriction` API (regex matching against resolved paths).

### Why

After bumping `pnp` to `0.12.10` (#1217), `pnp` no longer pulls in `fancy-regex` — it switched to `regress` (an ECMAScript-grammar regex engine). The only remaining users of `fancy-regex` were oxc-resolver itself:

- `napi/src/options.rs` — runtime: compiles the user-supplied `restrictions` regex string (shipped in the native addon).
- `src/tests/restrictions.rs` — dev-only: builds `Restriction::Fn` closures in tests.

Switching these to `regress` lets the entire `regex` stack drop out of the dependency tree. `regress` is also the more faithful choice for the napi path, since those patterns originate from JavaScript.

### Result

`fancy-regex`, `regex-automata`, `regex-syntax`, `aho-corasick`, `bit-set`, and `bit-vec` are all removed from `Cargo.lock`. `regress` only reuses `hashbrown`/`memchr` (already in the tree) and is now shared with `pnp` (single compile).

The `[profile.release.package.regex-automata]` / `regex-syntax` size overrides are removed as well — those packages no longer exist in the graph (they had started emitting "did not match any packages" warnings).

### Notes

- API mapping: `regress` has no `is_match`; `Regex::new(...)` still returns `Result`, and a match test becomes `re.find(s).is_some()`.
- The regex-stack removal only fully holds on `pnp 0.12.10` (now on `main` via #1217), since `pnp` ≤ 0.12.9 still depended on `fancy-regex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
