### PR TITLE
refactor: outline normalize_with to reduce binary size

### DIFF
--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -181,12 +181,18 @@ impl CachedPath {
     }
 
     /// Returns a new path by resolving the given subpath (including "." and ".." components) with this path.
+    #[inline]
     pub(crate) fn normalize_with<Fs: FileSystem, P: AsRef<Path>>(
         &self,
         subpath: P,
         cache: &Cache<Fs>,
     ) -> Self {
-        let subpath = subpath.as_ref();
+        // Forward to a single instantiation (per `Fs`) so the many `AsRef<Path>` call
+        // sites don't each monomorphize the full body (binary-size win).
+        self.normalize_with_impl(subpath.as_ref(), cache)
+    }
+
+    fn normalize_with_impl<Fs: FileSystem>(&self, subpath: &Path, cache: &Cache<Fs>) -> Self {
         let mut components = subpath.components();
         let Some(head) = components.next() else { return cache.value(subpath) };
         if matches!(head, Component::Prefix(..) | Component::RootDir) {

--- a/src/path.rs
+++ b/src/path.rs
@@ -79,34 +79,11 @@ impl PathUtil for Path {
     }
 
     // https://github.com/parcel-bundler/parcel/blob/e0b99c2a42e9109a9ecbd6f537844a1b33e7faf5/packages/utils/node-resolver-rs/src/path.rs#L37
+    #[inline]
     fn normalize_with<B: AsRef<Self>>(&self, subpath: B) -> PathBuf {
-        let subpath = subpath.as_ref();
-
-        let mut components = subpath.components();
-
-        let Some(head) = components.next() else { return subpath.to_path_buf() };
-
-        if matches!(head, Component::Prefix(..) | Component::RootDir) {
-            return subpath.to_path_buf();
-        }
-
-        let mut ret = self.to_path_buf();
-        for component in std::iter::once(head).chain(components) {
-            match component {
-                Component::CurDir => {}
-                Component::ParentDir => {
-                    ret.pop();
-                }
-                Component::Normal(c) => {
-                    ret.push(c);
-                }
-                Component::Prefix(..) | Component::RootDir => {
-                    unreachable!("Path {:?} Subpath {:?}", self, subpath)
-                }
-            }
-        }
-
-        ret
+        // Forward to a single non-generic instantiation so the many `AsRef<Path>`
+        // call sites don't each monomorphize the full body (binary-size win).
+        normalize_with_impl(self, subpath.as_ref())
     }
 
     fn is_invalid_exports_target(&self) -> bool {
@@ -117,6 +94,36 @@ impl PathUtil for Path {
             _ => false,
         })
     }
+}
+
+// Non-generic body of [`PathUtil::normalize_with`]. Kept out of the generic method so it is
+// compiled once instead of once per `AsRef<Path>` argument type at the call sites.
+fn normalize_with_impl(base: &Path, subpath: &Path) -> PathBuf {
+    let mut components = subpath.components();
+
+    let Some(head) = components.next() else { return subpath.to_path_buf() };
+
+    if matches!(head, Component::Prefix(..) | Component::RootDir) {
+        return subpath.to_path_buf();
+    }
+
+    let mut ret = base.to_path_buf();
+    for component in std::iter::once(head).chain(components) {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+            Component::Prefix(..) | Component::RootDir => {
+                unreachable!("Path {:?} Subpath {:?}", base, subpath)
+            }
+        }
+    }
+
+    ret
 }
 
 // https://github.com/webpack/enhanced-resolve/blob/main/test/path.test.js


### PR DESCRIPTION
## What

`PathUtil::normalize_with` and `CachedPath::normalize_with` are generic over `AsRef<Path>`, so the compiler emitted a full copy of each body for every distinct argument type across their ~30 call sites (`&str`, `&Path`, `&PathBuf`, `&String`, …).

This keeps the public / `pub(crate)` generic signature as a thin `#[inline]` wrapper and moves the body into a single non-generic instantiation (`normalize_with_impl`). The wrapper only does `.as_ref()` and tail-calls the shared impl, so behaviour is unchanged.

## Binary size

Measured on the real napi cdylib (`liboxc_resolver_napi.dylib`, default features), clean stash-based A/B:

| Metric | Before | After | Δ |
|---|--:|--:|--:|
| `.text` section | 1,031,968 | 1,027,028 | **−4,940 B (−4.94 KiB)** |

The file size moves only −16 B because Mach-O segments are quantized to 16 KB pages — the `.text` number is the real machine code removed, and it carries directly to the wasm build (byte-granular code section).

Found with `cargo llvm-lines`: both functions showed up as multi-copy monomorphizations whose per-copy bodies are identical apart from the inlined `as_ref()`, so fat-LTO's function-merging could not fold them.

## Notes

Perf-neutral: `normalize_with` is hot, but the `#[inline]` wrapper folds away, leaving callers with a direct call to the single shared impl — same call structure as before.