### PR TITLE
perf(browser-field): fast-reject non-matching keys before normalize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1233,7 +1233,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         Err(ResolveError::NotFound(specifier.to_string()))
     }
 
-    /// enhanced-resolve: AliasFieldPlugin for [ResolveOptions::alias_fields]
+    /// enhanced-resolve: AliasFieldPlugin for [crate::ResolveOptions::alias_fields]
     fn load_browser_field(
         &self,
         cached_path: &CachedPath,

--- a/src/package_json/serde.rs
+++ b/src/package_json/serde.rs
@@ -219,8 +219,17 @@ impl PackageJson {
             .map(ImportsExportsMap)
     }
 
-    /// Resolves the request string for this `package.json` by looking at the
-    /// "browser" field.
+    /// Apply this `package.json`'s `"browser"` field (and any other [`crate::ResolveOptions`]
+    /// `alias_fields`) to a request or a resolved path.
+    ///
+    /// * **Forward** (`request` is `Some`): look the request up as a key, remapping it before
+    ///   it is resolved on disk (e.g. `module-a` -> `./browser/module-a.js`).
+    /// * **Reverse** (`request` is `None`): find the key whose package-relative path equals
+    ///   the already-resolved `path`, remapping a file after it is found.
+    ///
+    /// # Errors
+    ///
+    /// * [`ResolveError::Ignored`] when the matched value is `false` (request excluded).
     ///
     /// <https://github.com/defunctzombie/package-browser-field-spec>
     pub(crate) fn resolve_browser_field<'a>(
@@ -237,7 +246,16 @@ impl PackageJson {
                 }
             } else {
                 let dir = self.path.parent().unwrap();
+                let path_file_name = path.file_name();
                 for (key, value) in object {
+                    // Fast path: `normalize_with` keeps `key`'s last component, so a key whose
+                    // file name differs from the candidate's can't match — skip without
+                    // allocating. `.`/`..` keys have no `file_name` and fall through.
+                    if let Some(key_file_name) = Path::new(key.as_str()).file_name()
+                        && Some(key_file_name) != path_file_name
+                    {
+                        continue;
+                    }
                     let joined = dir.normalize_with(key.as_str());
                     if joined == path {
                         return Self::alias_value(path, value);
@@ -289,7 +307,7 @@ impl PackageJson {
     }
 
     /// The "browser" field is provided by a module author as a hint to javascript bundlers or component tools when packaging modules for client side use.
-    /// Multiple values are configured by [ResolveOptions::alias_fields].
+    /// Multiple values are configured by [crate::ResolveOptions::alias_fields].
     ///
     /// <https://github.com/defunctzombie/package-browser-field-spec>
     pub(crate) fn browser_fields<'a>(

--- a/src/package_json/simd.rs
+++ b/src/package_json/simd.rs
@@ -260,8 +260,17 @@ impl PackageJson {
             .map(ImportsExportsMap)
     }
 
-    /// Resolves the request string for this `package.json` by looking at the
-    /// "browser" field.
+    /// Apply this `package.json`'s `"browser"` field (and any other [`crate::ResolveOptions`]
+    /// `alias_fields`) to a request or a resolved path.
+    ///
+    /// * **Forward** (`request` is `Some`): look the request up as a key, remapping it before
+    ///   it is resolved on disk (e.g. `module-a` -> `./browser/module-a.js`).
+    /// * **Reverse** (`request` is `None`): find the key whose package-relative path equals
+    ///   the already-resolved `path`, remapping a file after it is found.
+    ///
+    /// # Errors
+    ///
+    /// * [`ResolveError::Ignored`] when the matched value is `false` (request excluded).
     ///
     /// <https://github.com/defunctzombie/package-browser-field-spec>
     pub(crate) fn resolve_browser_field<'a>(
@@ -278,7 +287,16 @@ impl PackageJson {
                 }
             } else {
                 let dir = self.path.parent().unwrap();
+                let path_file_name = path.file_name();
                 for (key, value) in object {
+                    // Fast path: `normalize_with` keeps `key`'s last component, so a key whose
+                    // file name differs from the candidate's can't match — skip without
+                    // allocating. `.`/`..` keys have no `file_name` and fall through.
+                    if let Some(key_file_name) = Path::new(key.as_ref()).file_name()
+                        && Some(key_file_name) != path_file_name
+                    {
+                        continue;
+                    }
                     let joined = dir.normalize_with(key.as_ref());
                     if joined == path {
                         return Self::alias_value(path, value);
@@ -371,7 +389,7 @@ impl PackageJson {
     }
 
     /// The "browser" field is provided by a module author as a hint to javascript bundlers or component tools when packaging modules for client side use.
-    /// Multiple values are configured by [ResolveOptions::alias_fields].
+    /// Multiple values are configured by [crate::ResolveOptions::alias_fields].
     ///
     /// <https://github.com/defunctzombie/package-browser-field-spec>
     pub(crate) fn browser_fields<'a>(


### PR DESCRIPTION
## What

`PackageJson::resolve_browser_field`'s reverse lookup (`request = None`) runs on **every candidate path** when `alias_fields` is configured (via `load_browser_field_or_alias` → `load_alias_or_file` → `load_as_file`). For each candidate it looped over **all** browser-field keys, doing:

- `dir.normalize_with(key)` — a `PathBuf` allocation + `std::path::Components` parse, and
- `joined == path` — a component-wise path comparison.

Profiling the warm resolve hot path (macOS `sample`) showed `std::path::Components` iteration at **~40% of self-time**, driven mostly by this loop (the `browser-module` fixture has 15 browser keys, and the lookup recurses through `require`).

## Change

`normalize_with` preserves a key's last `Normal` path component, so if that component differs from the candidate path's file name, the join cannot equal the path. Compare file names first (a cheap byte comparison) and skip the allocation + component-wise comparison for the common non-matching keys.

Keys whose last component is not a normal name (`.`, `..`) have no `file_name` and fall through to the full comparison unchanged, so behavior is preserved. Applied to both the `simd` (little-endian) and `serde` (big-endian) implementations.

## Result

`resolver_memory/single-thread`: **41.4µs → 28.4µs (−31%)** (criterion, same machine).

Allocation pressure on the hot path drops sharply (sampled `malloc`/`free`/`memmove` roughly halve or better).

All existing tests pass (`cargo test`, incl. the browser-field suite); `cargo clippy --all-features --all-targets -- --deny warnings` is clean; `cargo check --target s390x-unknown-linux-gnu` (exercises the `serde` path) is clean.