### PR TITLE
refactor(package-json): dedupe simd/serde backends behind JSON traits

### DIFF
--- a/src/package_json/mod.rs
+++ b/src/package_json/mod.rs
@@ -276,7 +276,9 @@ impl<S: PackageJsonBackend> PackageJsonGeneric<S> {
     /// TypeScript version ranges to path redirect maps.
     ///
     /// <https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions>
-    pub(crate) fn types_versions(&self) -> Option<ImportsExportsMapGeneric<'_, <S::Value<'_> as JsonValue>::Object>> {
+    pub(crate) fn types_versions(
+        &self,
+    ) -> Option<ImportsExportsMapGeneric<'_, <S::Value<'_> as JsonValue>::Object>> {
         Some(ImportsExportsMapGeneric(self.field("typesVersions")?.as_object()?))
     }
 
@@ -324,7 +326,8 @@ impl<S: PackageJsonBackend> PackageJsonGeneric<S> {
     pub(crate) fn imports_fields<'a>(
         &'a self,
         imports_fields: &'a [Vec<String>],
-    ) -> impl Iterator<Item = ImportsExportsMapGeneric<'a, <S::Value<'a> as JsonValue>::Object>> + 'a {
+    ) -> impl Iterator<Item = ImportsExportsMapGeneric<'a, <S::Value<'a> as JsonValue>::Object>> + 'a
+    {
         let object = self.store.root().as_object();
         imports_fields
             .iter()
@@ -454,7 +457,9 @@ impl<'a, O: JsonObject> ImportsExportsMapGeneric<'a, O> {
         self.0.iter().map(|(key, _)| key)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&'a str, ImportsExportsEntryGeneric<'a, O::Value>)> {
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<Item = (&'a str, ImportsExportsEntryGeneric<'a, O::Value>)> {
         self.0.iter().map(|(key, value)| (key, ImportsExportsEntryGeneric(value)))
     }
 }

--- a/src/package_json/mod.rs
+++ b/src/package_json/mod.rs
@@ -1,8 +1,9 @@
 //! package.json definitions
 //!
-//! This module provides platform-specific implementations for parsing package.json files.
-//! On little-endian systems, it uses simd-json for high performance.
-//! On big-endian systems, it falls back to serde_json.
+//! The bulk of the `package.json` accessor logic lives here, written once against the
+//! [`JsonValue`]/[`JsonObject`] backend traits. Each platform provides a thin backend:
+//! on little-endian systems [`simd`] parses with simd-json (zero-copy `BorrowedValue`),
+//! on big-endian systems [`serde`] falls back to `serde_json::Value`.
 
 #[cfg(target_endian = "big")]
 mod serde;
@@ -14,9 +15,12 @@ pub use serde::*;
 #[cfg(target_endian = "little")]
 pub use simd::*;
 
-use std::{fmt, path::Path};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
 
-use crate::JSONError;
+use crate::{JSONError, ResolveError, path::PathUtil};
 
 /// Check if JSON content is empty or contains only whitespace
 fn check_if_empty(json_bytes: &[u8], path: &Path) -> Result<(), JSONError> {
@@ -70,4 +74,387 @@ pub enum SideEffects<'a> {
     Bool(bool),
     String(&'a str),
     Array(Vec<&'a str>),
+}
+
+// ---------------------------------------------------------------------------
+// JSON backend abstraction
+// ---------------------------------------------------------------------------
+
+/// A JSON value, abstracting over `simd_json::BorrowedValue` and `serde_json::Value`.
+///
+/// Only the operations the resolver needs are exposed; the variant differences between the
+/// two backends (e.g. `BorrowedValue::Static(Bool)` vs `Value::Bool`) are hidden behind
+/// [`Self::as_bool`]/[`Self::entry_kind`] so the accessor logic can be written once.
+pub trait JsonValue: Sized {
+    type Object: JsonObject<Value = Self>;
+
+    fn as_str(&self) -> Option<&str>;
+    fn as_bool(&self) -> Option<bool>;
+    fn as_slice(&self) -> Option<&[Self]>;
+    fn as_object(&self) -> Option<&Self::Object>;
+    fn entry_kind(&self) -> ImportsExportsKind;
+}
+
+/// A JSON object (string-keyed map), abstracting over the two backends' object types.
+pub trait JsonObject {
+    type Value: JsonValue<Object = Self>;
+
+    fn get(&self, key: &str) -> Option<&Self::Value>;
+    fn iter(&self) -> impl Iterator<Item = (&str, &Self::Value)>;
+}
+
+/// Storage holding the parsed root value. The simd backend stores a self-referential cell
+/// (the `BorrowedValue` borrows the file bytes); the serde backend stores an owned `Value`.
+pub trait PackageJsonBackend {
+    type Value<'a>: JsonValue
+    where
+        Self: 'a;
+
+    fn root(&self) -> &Self::Value<'_>;
+}
+
+/// Navigate `fields` along `path` (e.g. `["exports"]` or `["a", "b"]`), returning the value.
+fn get_value_by_path<'a, O: JsonObject>(fields: &'a O, path: &[String]) -> Option<&'a O::Value> {
+    let mut value = fields.get(path.first()?.as_str())?;
+    for key in &path[1..] {
+        value = value.as_object()?.get(key.as_str())?;
+    }
+    Some(value)
+}
+
+/// Interpret a `"browser"`/alias-field value: a string is the replacement, `false` means the
+/// request is ignored, anything else is "no mapping".
+fn alias_value<'a, V: JsonValue>(
+    key: &Path,
+    value: &'a V,
+) -> Result<Option<&'a str>, ResolveError> {
+    if let Some(s) = value.as_str() {
+        return Ok(Some(s));
+    }
+    if value.as_bool() == Some(false) {
+        return Err(ResolveError::Ignored(key.to_path_buf()));
+    }
+    Ok(None)
+}
+
+// ---------------------------------------------------------------------------
+// PackageJson (generic over the backend)
+// ---------------------------------------------------------------------------
+
+/// Generic `package.json`. The public, per-target `PackageJson` is a type alias over this
+/// (see the backend modules), so the rest of the crate is unaware of the generic parameter.
+pub struct PackageJsonGeneric<S> {
+    /// Path to `package.json`. Contains the `package.json` filename.
+    pub path: PathBuf,
+
+    /// Realpath to `package.json`. Contains the `package.json` filename.
+    pub realpath: PathBuf,
+
+    pub(crate) store: S,
+}
+
+impl<S: PackageJsonBackend> fmt::Debug for PackageJsonGeneric<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PackageJson")
+            .field("path", &self.path)
+            .field("realpath", &self.realpath)
+            .field("name", &self.name())
+            .field("type", &self.r#type())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S: PackageJsonBackend> PackageJsonGeneric<S> {
+    /// Returns the path where the `package.json` was found.
+    ///
+    /// Contains the `package.json` filename.
+    ///
+    /// This does not need to be the path where the file is stored on disk.
+    /// See [Self::realpath()].
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the path where the `package.json` file was stored on disk.
+    ///
+    /// Contains the `package.json` filename.
+    ///
+    /// This is the canonicalized version of [Self::path()], where all symbolic
+    /// links are resolved.
+    #[must_use]
+    pub fn realpath(&self) -> &Path {
+        &self.realpath
+    }
+
+    /// Directory to `package.json`.
+    ///
+    /// # Panics
+    ///
+    /// * When the `package.json` path is misconfigured.
+    #[must_use]
+    pub fn directory(&self) -> &Path {
+        debug_assert!(self.realpath.file_name().is_some_and(|x| x == "package.json"));
+        self.realpath.parent().unwrap()
+    }
+
+    fn field(&self, key: &str) -> Option<&S::Value<'_>> {
+        self.store.root().as_object()?.get(key)
+    }
+
+    /// Name of the package.
+    ///
+    /// The "name" field can be used together with the "exports" field to
+    /// self-reference a package using its name.
+    ///
+    /// <https://nodejs.org/api/packages.html#name>
+    #[must_use]
+    pub fn name(&self) -> Option<&str> {
+        self.field("name")?.as_str()
+    }
+
+    /// Version of the package.
+    ///
+    /// <https://nodejs.org/api/packages.html#name>
+    #[must_use]
+    pub fn version(&self) -> Option<&str> {
+        self.field("version")?.as_str()
+    }
+
+    /// Returns the package type, if one is configured in the `package.json`.
+    ///
+    /// <https://nodejs.org/api/packages.html#type>
+    #[must_use]
+    pub fn r#type(&self) -> Option<PackageType> {
+        PackageType::from_str(self.field("type")?.as_str()?)
+    }
+
+    /// The "sideEffects" field.
+    ///
+    /// <https://webpack.js.org/guides/tree-shaking>
+    #[must_use]
+    pub fn side_effects(&self) -> Option<SideEffects<'_>> {
+        let value = self.field("sideEffects")?;
+        if let Some(b) = value.as_bool() {
+            return Some(SideEffects::Bool(b));
+        }
+        if let Some(s) = value.as_str() {
+            return Some(SideEffects::String(s));
+        }
+        value
+            .as_slice()
+            .map(|arr| SideEffects::Array(arr.iter().filter_map(JsonValue::as_str).collect()))
+    }
+
+    /// The "exports" field allows defining the entry points of a package.
+    ///
+    /// <https://nodejs.org/api/packages.html#exports>
+    #[must_use]
+    pub fn exports(&self) -> Option<ImportsExportsEntryGeneric<'_, S::Value<'_>>> {
+        Some(ImportsExportsEntryGeneric(self.field("exports")?))
+    }
+
+    /// The "types" field in package.json.
+    ///
+    /// Used by TypeScript to find type declarations for a package.
+    #[must_use]
+    pub fn types(&self) -> Option<&str> {
+        self.field("types")?.as_str()
+    }
+
+    /// The "typings" field in package.json (legacy equivalent of "types").
+    ///
+    /// Used by TypeScript to find type declarations for a package.
+    #[must_use]
+    pub fn typings(&self) -> Option<&str> {
+        self.field("typings")?.as_str()
+    }
+
+    /// The "typesVersions" field in package.json.
+    ///
+    /// Returns the raw JSON value for the "typesVersions" field, which maps
+    /// TypeScript version ranges to path redirect maps.
+    ///
+    /// <https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions>
+    pub(crate) fn types_versions(&self) -> Option<ImportsExportsMapGeneric<'_, <S::Value<'_> as JsonValue>::Object>> {
+        Some(ImportsExportsMapGeneric(self.field("typesVersions")?.as_object()?))
+    }
+
+    /// The "main" field defines the entry point of a package when imported by
+    /// name via a node_modules lookup. Its value should be a path.
+    ///
+    /// When a package has an "exports" field, this will take precedence over
+    /// the "main" field when importing the package by name.
+    ///
+    /// Values are dynamically retrieved from [crate::ResolveOptions::main_fields].
+    ///
+    /// <https://nodejs.org/api/packages.html#main>
+    pub(crate) fn main_fields<'a>(
+        &'a self,
+        main_fields: &'a [String],
+    ) -> impl Iterator<Item = &'a str> + 'a {
+        let object = self.store.root().as_object();
+        main_fields
+            .iter()
+            .filter_map(move |main_field| object?.get(main_field.as_str()))
+            .filter_map(JsonValue::as_str)
+    }
+
+    /// The "exports" field allows defining the entry points of a package when
+    /// imported by name loaded either via a node_modules lookup or a
+    /// self-reference to its own name.
+    ///
+    /// <https://nodejs.org/api/packages.html#exports>
+    pub(crate) fn exports_fields<'a>(
+        &'a self,
+        exports_fields: &'a [Vec<String>],
+    ) -> impl Iterator<Item = ImportsExportsEntryGeneric<'a, S::Value<'a>>> + 'a {
+        let object = self.store.root().as_object();
+        exports_fields
+            .iter()
+            .filter_map(move |object_path| get_value_by_path(object?, object_path))
+            .map(ImportsExportsEntryGeneric)
+    }
+
+    /// In addition to the "exports" field, there is a package "imports" field
+    /// to create private mappings that only apply to import specifiers from
+    /// within the package itself.
+    ///
+    /// <https://nodejs.org/api/packages.html#subpath-imports>
+    pub(crate) fn imports_fields<'a>(
+        &'a self,
+        imports_fields: &'a [Vec<String>],
+    ) -> impl Iterator<Item = ImportsExportsMapGeneric<'a, <S::Value<'a> as JsonValue>::Object>> + 'a {
+        let object = self.store.root().as_object();
+        imports_fields
+            .iter()
+            .filter_map(move |object_path| get_value_by_path(object?, object_path))
+            .filter_map(JsonValue::as_object)
+            .map(ImportsExportsMapGeneric)
+    }
+
+    fn browser_fields<'a>(
+        &'a self,
+        alias_fields: &'a [Vec<String>],
+    ) -> impl Iterator<Item = &'a <S::Value<'a> as JsonValue>::Object> + 'a {
+        let object = self.store.root().as_object();
+        alias_fields
+            .iter()
+            .filter_map(move |object_path| get_value_by_path(object?, object_path))
+            // Only object is valid, all other types are invalid
+            // https://github.com/webpack/enhanced-resolve/blob/3a28f47788de794d9da4d1702a3a583d8422cd48/lib/AliasFieldPlugin.js#L44-L52
+            .filter_map(JsonValue::as_object)
+    }
+
+    /// Apply this `package.json`'s `"browser"` field (and any other [`crate::ResolveOptions`]
+    /// `alias_fields`) to a request or a resolved path.
+    ///
+    /// * **Forward** (`request` is `Some`): look the request up as a key, remapping it before
+    ///   it is resolved on disk (e.g. `module-a` -> `./browser/module-a.js`).
+    /// * **Reverse** (`request` is `None`): find the key whose package-relative path equals
+    ///   the already-resolved `path`, remapping a file after it is found.
+    ///
+    /// # Errors
+    ///
+    /// * [`ResolveError::Ignored`] when the matched value is `false` (request excluded).
+    ///
+    /// <https://github.com/defunctzombie/package-browser-field-spec>
+    pub(crate) fn resolve_browser_field<'a>(
+        &'a self,
+        path: &Path,
+        request: Option<&str>,
+        alias_fields: &'a [Vec<String>],
+    ) -> Result<Option<&'a str>, ResolveError> {
+        for object in self.browser_fields(alias_fields) {
+            if let Some(request) = request {
+                // Find matching key in object
+                if let Some(value) = object.get(request) {
+                    return alias_value(path, value);
+                }
+            } else {
+                let dir = self.path.parent().unwrap();
+                let path_file_name = path.file_name();
+                for (key, value) in object.iter() {
+                    // Fast path: `normalize_with` keeps `key`'s last component, so a key whose
+                    // file name differs from the candidate's can't match — skip without
+                    // allocating. `.`/`..` keys have no `file_name` and fall through.
+                    if let Some(key_file_name) = Path::new(key).file_name()
+                        && Some(key_file_name) != path_file_name
+                    {
+                        continue;
+                    }
+                    let joined = dir.normalize_with(key);
+                    if joined == path {
+                        return alias_value(path, value);
+                    }
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// imports/exports field views (generic over the backend)
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct ImportsExportsEntryGeneric<'a, V>(pub(crate) &'a V);
+
+impl<'a, V: JsonValue> ImportsExportsEntryGeneric<'a, V> {
+    #[must_use]
+    pub fn kind(&self) -> ImportsExportsKind {
+        self.0.entry_kind()
+    }
+
+    #[must_use]
+    pub fn as_string(&self) -> Option<&'a str> {
+        self.0.as_str()
+    }
+
+    #[must_use]
+    pub fn as_array(&self) -> Option<ImportsExportsArrayGeneric<'a, V>> {
+        self.0.as_slice().map(ImportsExportsArrayGeneric)
+    }
+
+    #[must_use]
+    pub fn as_map(&self) -> Option<ImportsExportsMapGeneric<'a, V::Object>> {
+        self.0.as_object().map(ImportsExportsMapGeneric)
+    }
+}
+
+#[derive(Clone)]
+pub struct ImportsExportsArrayGeneric<'a, V>(&'a [V]);
+
+impl<'a, V: JsonValue> ImportsExportsArrayGeneric<'a, V> {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = ImportsExportsEntryGeneric<'a, V>> {
+        self.0.iter().map(ImportsExportsEntryGeneric)
+    }
+}
+
+#[derive(Clone)]
+pub struct ImportsExportsMapGeneric<'a, O>(pub(crate) &'a O);
+
+impl<'a, O: JsonObject> ImportsExportsMapGeneric<'a, O> {
+    pub fn get(&self, key: &str) -> Option<ImportsExportsEntryGeneric<'a, O::Value>> {
+        self.0.get(key).map(ImportsExportsEntryGeneric)
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &'a str> {
+        self.0.iter().map(|(key, _)| key)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&'a str, ImportsExportsEntryGeneric<'a, O::Value>)> {
+        self.0.iter().map(|(key, value)| (key, ImportsExportsEntryGeneric(value)))
+    }
 }

--- a/src/package_json/serde.rs
+++ b/src/package_json/serde.rs
@@ -1,271 +1,90 @@
-//! package.json definitions (serde implementation for big-endian systems)
+//! package.json backend for big-endian systems (serde_json, owned `Value`).
 //!
-//! Code related to export field are copied from [Parcel's resolver](https://github.com/parcel-bundler/parcel/blob/v2/packages/utils/node-resolver-rs/src/package_json.rs)
+//! The accessor logic lives in [`super`]; this module only provides the storage
+//! (an owned [`Value`]), the [`JsonValue`]/[`JsonObject`] implementations, and `parse`.
 
-use std::{
-    fmt,
-    path::{Path, PathBuf},
+use std::path::PathBuf;
+
+use serde_json::{Map, Value};
+
+use super::{
+    ImportsExportsArrayGeneric, ImportsExportsEntryGeneric, ImportsExportsKind,
+    ImportsExportsMapGeneric, JsonObject, JsonValue, PackageJsonBackend, PackageJsonGeneric,
 };
+use crate::{FileSystem, JSONError, replace_bom_with_whitespace};
 
-use serde_json::Value;
+/// `package.json` parsed with serde_json (an owned `Value`).
+pub type PackageJson = PackageJsonGeneric<Value>;
+pub type ImportsExportsEntry<'a> = ImportsExportsEntryGeneric<'a, Value>;
+pub type ImportsExportsArray<'a> = ImportsExportsArrayGeneric<'a, Value>;
+pub type ImportsExportsMap<'a> = ImportsExportsMapGeneric<'a, Map<String, Value>>;
 
-use crate::{FileSystem, JSONError, ResolveError, path::PathUtil, replace_bom_with_whitespace};
+impl JsonValue for Value {
+    type Object = Map<String, Value>;
 
-use super::{ImportsExportsKind, PackageType, SideEffects};
+    fn as_str(&self) -> Option<&str> {
+        match self {
+            Value::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
 
-/// Serde implementation for the deserialized `package.json`.
-///
-/// This implementation is used on big-endian systems where simd-json is not available.
-pub struct PackageJson {
-    /// Path to `package.json`. Contains the `package.json` filename.
-    pub path: PathBuf,
+    fn as_bool(&self) -> Option<bool> {
+        match self {
+            Value::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
 
-    /// Realpath to `package.json`. Contains the `package.json` filename.
-    pub realpath: PathBuf,
+    fn as_slice(&self) -> Option<&[Self]> {
+        match self {
+            Value::Array(arr) => Some(arr.as_slice()),
+            _ => None,
+        }
+    }
 
-    /// Parsed JSON value
-    value: Value,
+    // `Self::Object` would be ambiguous with the `Value::Object` variant, so name the concrete
+    // object type.
+    fn as_object(&self) -> Option<&Map<String, Value>> {
+        match self {
+            Value::Object(obj) => Some(obj),
+            _ => None,
+        }
+    }
+
+    fn entry_kind(&self) -> ImportsExportsKind {
+        match self {
+            Value::String(_) => ImportsExportsKind::String,
+            Value::Array(_) => ImportsExportsKind::Array,
+            Value::Object(_) => ImportsExportsKind::Map,
+            _ => ImportsExportsKind::Invalid,
+        }
+    }
 }
 
-impl fmt::Debug for PackageJson {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PackageJson")
-            .field("path", &self.path)
-            .field("realpath", &self.realpath)
-            .field("name", &self.name())
-            .field("type", &self.r#type())
-            .finish_non_exhaustive()
+impl JsonObject for Map<String, Value> {
+    type Value = Value;
+
+    fn get(&self, key: &str) -> Option<&Self::Value> {
+        // Inherent `Map::get` (takes priority over the trait method being defined).
+        self.get(key)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&str, &Self::Value)> {
+        // Inherent `Map::iter` (takes priority over the trait method being defined).
+        self.iter().map(|(key, value)| (key.as_str(), value))
+    }
+}
+
+impl PackageJsonBackend for Value {
+    type Value<'a> = Value;
+
+    fn root(&self) -> &Self::Value<'_> {
+        self
     }
 }
 
 impl PackageJson {
-    /// Returns the path where the `package.json` was found.
-    ///
-    /// Contains the `package.json` filename.
-    ///
-    /// This does not need to be the path where the file is stored on disk.
-    /// See [Self::realpath()].
-    #[must_use]
-    pub fn path(&self) -> &Path {
-        &self.path
-    }
-
-    /// Returns the path where the `package.json` file was stored on disk.
-    ///
-    /// Contains the `package.json` filename.
-    ///
-    /// This is the canonicalized version of [Self::path()], where all symbolic
-    /// links are resolved.
-    #[must_use]
-    pub fn realpath(&self) -> &Path {
-        &self.realpath
-    }
-
-    /// Directory to `package.json`.
-    ///
-    /// # Panics
-    ///
-    /// * When the `package.json` path is misconfigured.
-    #[must_use]
-    pub fn directory(&self) -> &Path {
-        debug_assert!(self.realpath.file_name().is_some_and(|x| x == "package.json"));
-        self.realpath.parent().unwrap()
-    }
-
-    /// Name of the package.
-    ///
-    /// The "name" field can be used together with the "exports" field to
-    /// self-reference a package using its name.
-    ///
-    /// <https://nodejs.org/api/packages.html#name>
-    #[must_use]
-    pub fn name(&self) -> Option<&str> {
-        self.value.as_object().and_then(|obj| obj.get("name")).and_then(|v| v.as_str())
-    }
-
-    /// Version of the package.
-    ///
-    /// <https://nodejs.org/api/packages.html#name>
-    #[must_use]
-    pub fn version(&self) -> Option<&str> {
-        self.value.as_object().and_then(|obj| obj.get("version")).and_then(|v| v.as_str())
-    }
-
-    /// Returns the package type, if one is configured in the `package.json`.
-    ///
-    /// <https://nodejs.org/api/packages.html#type>
-    #[must_use]
-    pub fn r#type(&self) -> Option<PackageType> {
-        self.value
-            .as_object()
-            .and_then(|obj| obj.get("type"))
-            .and_then(|v| v.as_str())
-            .and_then(PackageType::from_str)
-    }
-
-    /// The "sideEffects" field.
-    ///
-    /// <https://webpack.js.org/guides/tree-shaking>
-    #[must_use]
-    pub fn side_effects(&self) -> Option<SideEffects<'_>> {
-        self.value.as_object().and_then(|obj| obj.get("sideEffects")).and_then(
-            |value| match value {
-                Value::Bool(b) => Some(SideEffects::Bool(*b)),
-                Value::String(s) => Some(SideEffects::String(s.as_str())),
-                Value::Array(arr) => {
-                    let strings: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
-                    Some(SideEffects::Array(strings))
-                }
-                _ => None,
-            },
-        )
-    }
-
-    /// The "exports" field allows defining the entry points of a package.
-    ///
-    /// <https://nodejs.org/api/packages.html#exports>
-    #[must_use]
-    pub fn exports(&self) -> Option<ImportsExportsEntry<'_>> {
-        self.value.as_object().and_then(|obj| obj.get("exports")).map(ImportsExportsEntry)
-    }
-
-    /// The "types" field in package.json.
-    ///
-    /// Used by TypeScript to find type declarations for a package.
-    #[must_use]
-    pub fn types(&self) -> Option<&str> {
-        self.value.as_object().and_then(|obj| obj.get("types")).and_then(|v| v.as_str())
-    }
-
-    /// The "typings" field in package.json (legacy equivalent of "types").
-    ///
-    /// Used by TypeScript to find type declarations for a package.
-    #[must_use]
-    pub fn typings(&self) -> Option<&str> {
-        self.value.as_object().and_then(|obj| obj.get("typings")).and_then(|v| v.as_str())
-    }
-
-    /// The "typesVersions" field in package.json.
-    ///
-    /// Returns the raw JSON value for the "typesVersions" field, which maps
-    /// TypeScript version ranges to path redirect maps.
-    ///
-    /// <https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions>
-    pub(crate) fn types_versions(&self) -> Option<ImportsExportsMap<'_>> {
-        self.value
-            .as_object()
-            .and_then(|obj| obj.get("typesVersions"))
-            .and_then(|v| v.as_object())
-            .map(ImportsExportsMap)
-    }
-
-    /// The "main" field defines the entry point of a package when imported by
-    /// name via a node_modules lookup. Its value should be a path.
-    ///
-    /// When a package has an "exports" field, this will take precedence over
-    /// the "main" field when importing the package by name.
-    ///
-    /// Values are dynamically retrieved from [crate::ResolveOptions::main_fields].
-    ///
-    /// <https://nodejs.org/api/packages.html#main>
-    pub(crate) fn main_fields<'a>(
-        &'a self,
-        main_fields: &'a [String],
-    ) -> impl Iterator<Item = &'a str> + 'a {
-        let json_object = self.value.as_object();
-
-        main_fields
-            .iter()
-            .filter_map(move |main_field| json_object.and_then(|obj| obj.get(main_field.as_str())))
-            .filter_map(|v| v.as_str())
-    }
-
-    /// The "exports" field allows defining the entry points of a package when
-    /// imported by name loaded either via a node_modules lookup or a
-    /// self-reference to its own name.
-    ///
-    /// <https://nodejs.org/api/packages.html#exports>
-    pub(crate) fn exports_fields<'a>(
-        &'a self,
-        exports_fields: &'a [Vec<String>],
-    ) -> impl Iterator<Item = ImportsExportsEntry<'a>> + 'a {
-        exports_fields
-            .iter()
-            .filter_map(move |object_path| {
-                self.value
-                    .as_object()
-                    .and_then(|json_object| Self::get_value_by_path(json_object, object_path))
-            })
-            .map(ImportsExportsEntry)
-    }
-
-    /// In addition to the "exports" field, there is a package "imports" field
-    /// to create private mappings that only apply to import specifiers from
-    /// within the package itself.
-    ///
-    /// <https://nodejs.org/api/packages.html#subpath-imports>
-    pub(crate) fn imports_fields<'a>(
-        &'a self,
-        imports_fields: &'a [Vec<String>],
-    ) -> impl Iterator<Item = ImportsExportsMap<'a>> + 'a {
-        imports_fields
-            .iter()
-            .filter_map(move |object_path| {
-                self.value
-                    .as_object()
-                    .and_then(|json_object| Self::get_value_by_path(json_object, object_path))
-                    .and_then(|v| v.as_object())
-            })
-            .map(ImportsExportsMap)
-    }
-
-    /// Apply this `package.json`'s `"browser"` field (and any other [`crate::ResolveOptions`]
-    /// `alias_fields`) to a request or a resolved path.
-    ///
-    /// * **Forward** (`request` is `Some`): look the request up as a key, remapping it before
-    ///   it is resolved on disk (e.g. `module-a` -> `./browser/module-a.js`).
-    /// * **Reverse** (`request` is `None`): find the key whose package-relative path equals
-    ///   the already-resolved `path`, remapping a file after it is found.
-    ///
-    /// # Errors
-    ///
-    /// * [`ResolveError::Ignored`] when the matched value is `false` (request excluded).
-    ///
-    /// <https://github.com/defunctzombie/package-browser-field-spec>
-    pub(crate) fn resolve_browser_field<'a>(
-        &'a self,
-        path: &Path,
-        request: Option<&str>,
-        alias_fields: &'a [Vec<String>],
-    ) -> Result<Option<&'a str>, ResolveError> {
-        for object in self.browser_fields(alias_fields) {
-            if let Some(request) = request {
-                // Find matching key in object
-                if let Some(value) = object.get(request) {
-                    return Self::alias_value(path, value);
-                }
-            } else {
-                let dir = self.path.parent().unwrap();
-                let path_file_name = path.file_name();
-                for (key, value) in object {
-                    // Fast path: `normalize_with` keeps `key`'s last component, so a key whose
-                    // file name differs from the candidate's can't match — skip without
-                    // allocating. `.`/`..` keys have no `file_name` and fall through.
-                    if let Some(key_file_name) = Path::new(key.as_str()).file_name()
-                        && Some(key_file_name) != path_file_name
-                    {
-                        continue;
-                    }
-                    let joined = dir.normalize_with(key.as_str());
-                    if joined == path {
-                        return Self::alias_value(path, value);
-                    }
-                }
-            }
-        }
-        Ok(None)
-    }
-
     /// Parse a package.json file from JSON bytes
     ///
     /// # Errors
@@ -284,145 +103,6 @@ impl PackageJson {
             line: error.line(),
             column: error.column(),
         })?;
-        Ok(Self { path, realpath, value })
-    }
-
-    fn get_value_by_path<'a>(
-        fields: &'a serde_json::Map<String, Value>,
-        path: &[String],
-    ) -> Option<&'a Value> {
-        if path.is_empty() {
-            return None;
-        }
-        let mut value = fields.get(path[0].as_str())?;
-
-        for key in path.iter().skip(1) {
-            if let Some(obj) = value.as_object() {
-                value = obj.get(key.as_str())?;
-            } else {
-                return None;
-            }
-        }
-        Some(value)
-    }
-
-    /// The "browser" field is provided by a module author as a hint to javascript bundlers or component tools when packaging modules for client side use.
-    /// Multiple values are configured by [crate::ResolveOptions::alias_fields].
-    ///
-    /// <https://github.com/defunctzombie/package-browser-field-spec>
-    pub(crate) fn browser_fields<'a>(
-        &'a self,
-        alias_fields: &'a [Vec<String>],
-    ) -> impl Iterator<Item = &'a serde_json::Map<String, Value>> + 'a {
-        alias_fields.iter().filter_map(move |object_path| {
-            self.value
-                .as_object()
-                .and_then(|json_object| Self::get_value_by_path(json_object, object_path))
-                // Only object is valid, all other types are invalid
-                // https://github.com/webpack/enhanced-resolve/blob/3a28f47788de794d9da4d1702a3a583d8422cd48/lib/AliasFieldPlugin.js#L44-L52
-                .and_then(|value| value.as_object())
-        })
-    }
-
-    pub(crate) fn alias_value<'a>(
-        key: &Path,
-        value: &'a Value,
-    ) -> Result<Option<&'a str>, ResolveError> {
-        match value {
-            Value::String(s) => Ok(Some(s.as_str())),
-            Value::Bool(false) => Err(ResolveError::Ignored(key.to_path_buf())),
-            _ => Ok(None),
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct ImportsExportsEntry<'a>(pub(crate) &'a Value);
-
-impl<'a> ImportsExportsEntry<'a> {
-    #[must_use]
-    pub fn kind(&self) -> ImportsExportsKind {
-        match self.0 {
-            Value::String(_) => ImportsExportsKind::String,
-            Value::Array(_) => ImportsExportsKind::Array,
-            Value::Object(_) => ImportsExportsKind::Map,
-            _ => ImportsExportsKind::Invalid,
-        }
-    }
-
-    #[must_use]
-    pub fn as_string(&self) -> Option<&'a str> {
-        match self.0 {
-            Value::String(s) => Some(s.as_str()),
-            _ => None,
-        }
-    }
-
-    #[must_use]
-    pub fn as_array(&self) -> Option<ImportsExportsArray<'a>> {
-        match self.0 {
-            Value::Array(arr) => Some(ImportsExportsArray(arr)),
-            _ => None,
-        }
-    }
-
-    #[must_use]
-    pub fn as_map(&self) -> Option<ImportsExportsMap<'a>> {
-        match self.0 {
-            Value::Object(obj) => Some(ImportsExportsMap(obj)),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct ImportsExportsArray<'a>(&'a [Value]);
-
-impl<'a> ImportsExportsArray<'a> {
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = ImportsExportsEntry<'a>> {
-        ImportsExportsArrayIter { slice: self.0, index: 0 }
-    }
-}
-
-struct ImportsExportsArrayIter<'a> {
-    slice: &'a [Value],
-    index: usize,
-}
-
-impl<'a> Iterator for ImportsExportsArrayIter<'a> {
-    type Item = ImportsExportsEntry<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.slice.get(self.index).map(|value| {
-            self.index += 1;
-            ImportsExportsEntry(value)
-        })
-    }
-}
-
-#[derive(Clone)]
-pub struct ImportsExportsMap<'a>(pub(crate) &'a serde_json::Map<String, Value>);
-
-impl<'a> ImportsExportsMap<'a> {
-    pub fn get(&self, key: &str) -> Option<ImportsExportsEntry<'a>> {
-        self.0.get(key).map(ImportsExportsEntry)
-    }
-
-    pub fn keys(&self) -> impl Iterator<Item = &'a str> {
-        self.0.keys().map(String::as_str)
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&'a str, ImportsExportsEntry<'a>)> {
-        self.0.iter().map(|(k, v)| (k.as_str(), ImportsExportsEntry(v)))
+        Ok(Self { path, realpath, store: value })
     }
 }

--- a/src/package_json/simd.rs
+++ b/src/package_json/simd.rs
@@ -1,23 +1,30 @@
-//! package.json definitions (SIMD implementation for little-endian systems)
+//! package.json backend for little-endian systems (simd-json, zero-copy `BorrowedValue`).
 //!
-//! Code related to export field are copied from [Parcel's resolver](https://github.com/parcel-bundler/parcel/blob/v2/packages/utils/node-resolver-rs/src/package_json.rs)
+//! The accessor logic lives in [`super`]; this module only provides the storage
+//! ([`PackageJsonCell`]), the [`JsonValue`]/[`JsonObject`] implementations, and `parse`.
 
-use std::{
-    fmt,
-    path::{Path, PathBuf},
-};
+// `self_cell!` generates `pub` constructors with `impl FnOnce` parameters.
+#![allow(clippy::impl_trait_in_params)]
+
+use std::path::PathBuf;
 
 use self_cell::MutBorrow;
-use simd_json::{BorrowedValue, prelude::*};
+use simd_json::BorrowedValue;
 
-use super::{ImportsExportsKind, PackageType, SideEffects};
-use crate::{FileSystem, JSONError, ResolveError, path::PathUtil, replace_bom_with_whitespace};
+use super::{
+    ImportsExportsArrayGeneric, ImportsExportsEntryGeneric, ImportsExportsKind,
+    ImportsExportsMapGeneric, JsonObject, JsonValue, PackageJsonBackend, PackageJsonGeneric,
+};
+use crate::{FileSystem, JSONError, replace_bom_with_whitespace};
 
 // Use simd_json's Object type which handles the hasher correctly based on features
 type BorrowedObject<'a> = simd_json::value::borrowed::Object<'a>;
 
+// `pub` because it appears as the type parameter of the public `PackageJson` alias. The
+// `self_cell!`-generated `pub` constructors take `impl FnOnce`; the module-level
+// `allow(clippy::impl_trait_in_params)` above silences clippy for those generated items.
 self_cell::self_cell! {
-    struct PackageJsonCell {
+    pub struct PackageJsonCell {
         owner: MutBorrow<Vec<u8>>,
 
         #[covariant]
@@ -25,288 +32,78 @@ self_cell::self_cell! {
     }
 }
 
-/// Serde implementation for the deserialized `package.json`.
-///
-/// This implementation is used by the [crate::Cache] and enabled through the
-/// `fs_cache` feature.
-pub struct PackageJson {
-    /// Path to `package.json`. Contains the `package.json` filename.
-    pub path: PathBuf,
+/// `package.json` parsed with simd-json (the parsed `BorrowedValue` borrows the file bytes).
+pub type PackageJson = PackageJsonGeneric<PackageJsonCell>;
+pub type ImportsExportsEntry<'a> = ImportsExportsEntryGeneric<'a, BorrowedValue<'a>>;
+pub type ImportsExportsArray<'a> = ImportsExportsArrayGeneric<'a, BorrowedValue<'a>>;
+pub type ImportsExportsMap<'a> = ImportsExportsMapGeneric<'a, BorrowedObject<'a>>;
 
-    /// Realpath to `package.json`. Contains the `package.json` filename.
-    pub realpath: PathBuf,
+impl<'a> JsonValue for BorrowedValue<'a> {
+    type Object = BorrowedObject<'a>;
 
-    cell: PackageJsonCell,
+    fn as_str(&self) -> Option<&str> {
+        match self {
+            BorrowedValue::String(s) => Some(s.as_ref()),
+            _ => None,
+        }
+    }
+
+    fn as_bool(&self) -> Option<bool> {
+        match self {
+            BorrowedValue::Static(simd_json::StaticNode::Bool(b)) => Some(*b),
+            _ => None,
+        }
+    }
+
+    fn as_slice(&self) -> Option<&[Self]> {
+        match self {
+            BorrowedValue::Array(arr) => Some(arr.as_slice()),
+            _ => None,
+        }
+    }
+
+    // `Self::Object` would be ambiguous with the `BorrowedValue::Object` variant, so name the
+    // concrete object type.
+    fn as_object(&self) -> Option<&BorrowedObject<'a>> {
+        match self {
+            BorrowedValue::Object(obj) => Some(obj),
+            _ => None,
+        }
+    }
+
+    fn entry_kind(&self) -> ImportsExportsKind {
+        match self {
+            BorrowedValue::String(_) => ImportsExportsKind::String,
+            BorrowedValue::Array(_) => ImportsExportsKind::Array,
+            BorrowedValue::Object(_) => ImportsExportsKind::Map,
+            BorrowedValue::Static(_) => ImportsExportsKind::Invalid,
+        }
+    }
 }
 
-impl fmt::Debug for PackageJson {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PackageJson")
-            .field("path", &self.path)
-            .field("realpath", &self.realpath)
-            .field("name", &self.name())
-            .field("type", &self.r#type())
-            .finish_non_exhaustive()
+impl<'a> JsonObject for BorrowedObject<'a> {
+    type Value = BorrowedValue<'a>;
+
+    fn get(&self, key: &str) -> Option<&Self::Value> {
+        // Inherent `HashMap::get` (takes priority over the trait method being defined).
+        self.get(key)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&str, &Self::Value)> {
+        // Inherent `HashMap::iter` (takes priority over the trait method being defined).
+        self.iter().map(|(k, v)| (k.as_ref(), v))
+    }
+}
+
+impl PackageJsonBackend for PackageJsonCell {
+    type Value<'a> = BorrowedValue<'a>;
+
+    fn root(&self) -> &Self::Value<'_> {
+        self.borrow_dependent()
     }
 }
 
 impl PackageJson {
-    /// Returns the path where the `package.json` was found.
-    ///
-    /// Contains the `package.json` filename.
-    ///
-    /// This does not need to be the path where the file is stored on disk.
-    /// See [Self::realpath()].
-    #[must_use]
-    pub fn path(&self) -> &Path {
-        &self.path
-    }
-
-    /// Returns the path where the `package.json` file was stored on disk.
-    ///
-    /// Contains the `package.json` filename.
-    ///
-    /// This is the canonicalized version of [Self::path()], where all symbolic
-    /// links are resolved.
-    #[must_use]
-    pub fn realpath(&self) -> &Path {
-        &self.realpath
-    }
-
-    /// Directory to `package.json`.
-    ///
-    /// # Panics
-    ///
-    /// * When the `package.json` path is misconfigured.
-    #[must_use]
-    pub fn directory(&self) -> &Path {
-        debug_assert!(self.realpath.file_name().is_some_and(|x| x == "package.json"));
-        self.realpath.parent().unwrap()
-    }
-
-    /// Name of the package.
-    ///
-    /// The "name" field can be used together with the "exports" field to
-    /// self-reference a package using its name.
-    ///
-    /// <https://nodejs.org/api/packages.html#name>
-    #[must_use]
-    pub fn name(&self) -> Option<&str> {
-        self.cell
-            .borrow_dependent()
-            .as_object()
-            .and_then(|obj| obj.get("name"))
-            .and_then(|v| v.as_str())
-    }
-
-    /// Version of the package.
-    ///
-    /// <https://nodejs.org/api/packages.html#name>
-    #[must_use]
-    pub fn version(&self) -> Option<&str> {
-        self.cell
-            .borrow_dependent()
-            .as_object()
-            .and_then(|obj| obj.get("version"))
-            .and_then(|v| v.as_str())
-    }
-
-    /// Returns the package type, if one is configured in the `package.json`.
-    ///
-    /// <https://nodejs.org/api/packages.html#type>
-    #[must_use]
-    pub fn r#type(&self) -> Option<PackageType> {
-        self.cell
-            .borrow_dependent()
-            .as_object()
-            .and_then(|obj| obj.get("type"))
-            .and_then(|v| v.as_str())
-            .and_then(PackageType::from_str)
-    }
-
-    /// The "sideEffects" field.
-    ///
-    /// <https://webpack.js.org/guides/tree-shaking>
-    #[must_use]
-    pub fn side_effects(&self) -> Option<SideEffects<'_>> {
-        self.cell.borrow_dependent().as_object().and_then(|obj| obj.get("sideEffects")).and_then(
-            |value| match value {
-                BorrowedValue::Static(simd_json::StaticNode::Bool(b)) => {
-                    Some(SideEffects::Bool(*b))
-                }
-                BorrowedValue::String(s) => Some(SideEffects::String(s.as_ref())),
-                BorrowedValue::Array(arr) => {
-                    let strings: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
-                    Some(SideEffects::Array(strings))
-                }
-                _ => None,
-            },
-        )
-    }
-
-    /// The "exports" field allows defining the entry points of a package.
-    ///
-    /// <https://nodejs.org/api/packages.html#exports>
-    #[must_use]
-    pub fn exports(&self) -> Option<ImportsExportsEntry<'_>> {
-        self.cell
-            .borrow_dependent()
-            .as_object()
-            .and_then(|obj| obj.get("exports"))
-            .map(ImportsExportsEntry)
-    }
-
-    /// The "types" field in package.json.
-    ///
-    /// Used by TypeScript to find type declarations for a package.
-    #[must_use]
-    pub fn types(&self) -> Option<&str> {
-        self.cell
-            .borrow_dependent()
-            .as_object()
-            .and_then(|obj| obj.get("types"))
-            .and_then(|v| v.as_str())
-    }
-
-    /// The "typings" field in package.json (legacy equivalent of "types").
-    ///
-    /// Used by TypeScript to find type declarations for a package.
-    #[must_use]
-    pub fn typings(&self) -> Option<&str> {
-        self.cell
-            .borrow_dependent()
-            .as_object()
-            .and_then(|obj| obj.get("typings"))
-            .and_then(|v| v.as_str())
-    }
-
-    /// The "typesVersions" field in package.json.
-    ///
-    /// Returns the raw JSON value for the "typesVersions" field, which maps
-    /// TypeScript version ranges to path redirect maps.
-    ///
-    /// <https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions>
-    pub(crate) fn types_versions(&self) -> Option<ImportsExportsMap<'_>> {
-        self.cell
-            .borrow_dependent()
-            .as_object()
-            .and_then(|obj| obj.get("typesVersions"))
-            .and_then(|v| v.as_object())
-            .map(ImportsExportsMap)
-    }
-
-    /// The "main" field defines the entry point of a package when imported by
-    /// name via a node_modules lookup. Its value should be a path.
-    ///
-    /// When a package has an "exports" field, this will take precedence over
-    /// the "main" field when importing the package by name.
-    ///
-    /// Values are dynamically retrieved from [crate::ResolveOptions::main_fields].
-    ///
-    /// <https://nodejs.org/api/packages.html#main>
-    pub(crate) fn main_fields<'a>(
-        &'a self,
-        main_fields: &'a [String],
-    ) -> impl Iterator<Item = &'a str> + 'a {
-        let json_value = self.cell.borrow_dependent();
-        let json_object = json_value.as_object();
-
-        main_fields
-            .iter()
-            .filter_map(move |main_field| json_object.and_then(|obj| obj.get(main_field.as_str())))
-            .filter_map(|v| v.as_str())
-    }
-
-    /// The "exports" field allows defining the entry points of a package when
-    /// imported by name loaded either via a node_modules lookup or a
-    /// self-reference to its own name.
-    ///
-    /// <https://nodejs.org/api/packages.html#exports>
-    pub(crate) fn exports_fields<'a>(
-        &'a self,
-        exports_fields: &'a [Vec<String>],
-    ) -> impl Iterator<Item = ImportsExportsEntry<'a>> + 'a {
-        let json_value = self.cell.borrow_dependent();
-
-        exports_fields
-            .iter()
-            .filter_map(move |object_path| {
-                json_value
-                    .as_object()
-                    .and_then(|json_object| Self::get_value_by_path(json_object, object_path))
-            })
-            .map(ImportsExportsEntry)
-    }
-
-    /// In addition to the "exports" field, there is a package "imports" field
-    /// to create private mappings that only apply to import specifiers from
-    /// within the package itself.
-    ///
-    /// <https://nodejs.org/api/packages.html#subpath-imports>
-    pub(crate) fn imports_fields<'a>(
-        &'a self,
-        imports_fields: &'a [Vec<String>],
-    ) -> impl Iterator<Item = ImportsExportsMap<'a>> + 'a {
-        let json_value = self.cell.borrow_dependent();
-
-        imports_fields
-            .iter()
-            .filter_map(move |object_path| {
-                json_value
-                    .as_object()
-                    .and_then(|json_object| Self::get_value_by_path(json_object, object_path))
-                    .and_then(|v| v.as_object())
-            })
-            .map(ImportsExportsMap)
-    }
-
-    /// Apply this `package.json`'s `"browser"` field (and any other [`crate::ResolveOptions`]
-    /// `alias_fields`) to a request or a resolved path.
-    ///
-    /// * **Forward** (`request` is `Some`): look the request up as a key, remapping it before
-    ///   it is resolved on disk (e.g. `module-a` -> `./browser/module-a.js`).
-    /// * **Reverse** (`request` is `None`): find the key whose package-relative path equals
-    ///   the already-resolved `path`, remapping a file after it is found.
-    ///
-    /// # Errors
-    ///
-    /// * [`ResolveError::Ignored`] when the matched value is `false` (request excluded).
-    ///
-    /// <https://github.com/defunctzombie/package-browser-field-spec>
-    pub(crate) fn resolve_browser_field<'a>(
-        &'a self,
-        path: &Path,
-        request: Option<&str>,
-        alias_fields: &'a [Vec<String>],
-    ) -> Result<Option<&'a str>, ResolveError> {
-        for object in self.browser_fields(alias_fields) {
-            if let Some(request) = request {
-                // Find matching key in object
-                if let Some(value) = object.get(request) {
-                    return Self::alias_value(path, value);
-                }
-            } else {
-                let dir = self.path.parent().unwrap();
-                let path_file_name = path.file_name();
-                for (key, value) in object {
-                    // Fast path: `normalize_with` keeps `key`'s last component, so a key whose
-                    // file name differs from the candidate's can't match — skip without
-                    // allocating. `.`/`..` keys have no `file_name` and fall through.
-                    if let Some(key_file_name) = Path::new(key.as_ref()).file_name()
-                        && Some(key_file_name) != path_file_name
-                    {
-                        continue;
-                    }
-                    let joined = dir.normalize_with(key.as_ref());
-                    if joined == path {
-                        return Self::alias_value(path, value);
-                    }
-                }
-            }
-        }
-        Ok(None)
-    }
-
     /// Parse a package.json file from JSON bytes
     ///
     /// # Panics
@@ -366,149 +163,6 @@ impl PackageJson {
             }
         })?;
 
-        Ok(Self { path, realpath, cell })
-    }
-
-    fn get_value_by_path<'a>(
-        fields: &'a BorrowedObject<'a>,
-        path: &[String],
-    ) -> Option<&'a BorrowedValue<'a>> {
-        if path.is_empty() {
-            return None;
-        }
-        let mut value = fields.get(path[0].as_str())?;
-
-        for key in path.iter().skip(1) {
-            if let Some(obj) = value.as_object() {
-                value = obj.get(key.as_str())?;
-            } else {
-                return None;
-            }
-        }
-        Some(value)
-    }
-
-    /// The "browser" field is provided by a module author as a hint to javascript bundlers or component tools when packaging modules for client side use.
-    /// Multiple values are configured by [crate::ResolveOptions::alias_fields].
-    ///
-    /// <https://github.com/defunctzombie/package-browser-field-spec>
-    pub(crate) fn browser_fields<'a>(
-        &'a self,
-        alias_fields: &'a [Vec<String>],
-    ) -> impl Iterator<Item = &'a BorrowedObject<'a>> + 'a {
-        let json_value = self.cell.borrow_dependent();
-
-        alias_fields.iter().filter_map(move |object_path| {
-            json_value
-                .as_object()
-                .and_then(|json_object| Self::get_value_by_path(json_object, object_path))
-                // Only object is valid, all other types are invalid
-                // https://github.com/webpack/enhanced-resolve/blob/3a28f47788de794d9da4d1702a3a583d8422cd48/lib/AliasFieldPlugin.js#L44-L52
-                .and_then(|value| value.as_object())
-        })
-    }
-
-    pub(crate) fn alias_value<'a>(
-        key: &Path,
-        value: &'a BorrowedValue<'a>,
-    ) -> Result<Option<&'a str>, ResolveError> {
-        match value {
-            BorrowedValue::String(s) => Ok(Some(s.as_ref())),
-            BorrowedValue::Static(simd_json::StaticNode::Bool(false)) => {
-                Err(ResolveError::Ignored(key.to_path_buf()))
-            }
-            _ => Ok(None),
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct ImportsExportsEntry<'a>(pub(crate) &'a BorrowedValue<'a>);
-
-impl<'a> ImportsExportsEntry<'a> {
-    #[must_use]
-    pub fn kind(&self) -> ImportsExportsKind {
-        match self.0 {
-            BorrowedValue::String(_) => ImportsExportsKind::String,
-            BorrowedValue::Array(_) => ImportsExportsKind::Array,
-            BorrowedValue::Object(_) => ImportsExportsKind::Map,
-            BorrowedValue::Static(_) => ImportsExportsKind::Invalid,
-        }
-    }
-
-    #[must_use]
-    pub fn as_string(&self) -> Option<&'a str> {
-        match self.0 {
-            BorrowedValue::String(s) => Some(s.as_ref()),
-            _ => None,
-        }
-    }
-
-    #[must_use]
-    pub fn as_array(&self) -> Option<ImportsExportsArray<'a>> {
-        match self.0 {
-            BorrowedValue::Array(arr) => Some(ImportsExportsArray(arr)),
-            _ => None,
-        }
-    }
-
-    #[must_use]
-    pub fn as_map(&self) -> Option<ImportsExportsMap<'a>> {
-        match self.0 {
-            BorrowedValue::Object(obj) => Some(ImportsExportsMap(obj)),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct ImportsExportsArray<'a>(&'a [BorrowedValue<'a>]);
-
-impl<'a> ImportsExportsArray<'a> {
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = ImportsExportsEntry<'a>> {
-        ImportsExportsArrayIter { slice: self.0, index: 0 }
-    }
-}
-
-struct ImportsExportsArrayIter<'a> {
-    slice: &'a [BorrowedValue<'a>],
-    index: usize,
-}
-
-impl<'a> Iterator for ImportsExportsArrayIter<'a> {
-    type Item = ImportsExportsEntry<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.slice.get(self.index).map(|value| {
-            self.index += 1;
-            ImportsExportsEntry(value)
-        })
-    }
-}
-
-#[derive(Clone)]
-pub struct ImportsExportsMap<'a>(pub(crate) &'a BorrowedObject<'a>);
-
-impl<'a> ImportsExportsMap<'a> {
-    pub fn get(&self, key: &str) -> Option<ImportsExportsEntry<'a>> {
-        self.0.get(key).map(ImportsExportsEntry)
-    }
-
-    pub fn keys(&self) -> impl Iterator<Item = &'a str> {
-        self.0.keys().map(std::convert::AsRef::as_ref)
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&'a str, ImportsExportsEntry<'a>)> {
-        self.0.iter().map(|(k, v)| (k.as_ref(), ImportsExportsEntry(v)))
+        Ok(Self { path, realpath, store: cell })
     }
 }

--- a/src/tests/exports_field.rs
+++ b/src/tests/exports_field.rs
@@ -7,7 +7,8 @@ use std::path::Path;
 use serde_json::json;
 
 use crate::{
-    Ctx, PathUtil, ResolveError, ResolveOptions, Resolver, package_json::ImportsExportsEntry,
+    Ctx, PathUtil, ResolveError, ResolveOptions, Resolver,
+    package_json::{ImportsExportsEntry, ImportsExportsEntryGeneric},
 };
 
 #[test]
@@ -326,14 +327,14 @@ fn exports_field(value: &serde_json::Value) -> ImportsExportsEntry<'static> {
     let bytes = Box::leak::<'static>(Box::new(json_str.into_bytes()));
     let borrowed = simd_json::to_borrowed_value(bytes).unwrap();
     let value = Box::leak::<'static>(Box::new(borrowed));
-    ImportsExportsEntry(value)
+    ImportsExportsEntryGeneric(value)
 }
 
 #[cfg(target_endian = "big")]
 fn exports_field(value: &serde_json::Value) -> ImportsExportsEntry<'static> {
     // Clone and leak the value to get a 'static reference for big-endian
     let value = Box::leak::<'static>(Box::new(value.clone()));
-    ImportsExportsEntry(value)
+    ImportsExportsEntryGeneric(value)
 }
 
 #[test]

--- a/src/tests/imports_field.rs
+++ b/src/tests/imports_field.rs
@@ -6,7 +6,10 @@ use std::path::Path;
 
 use serde_json::json;
 
-use crate::{Ctx, ImportsExportsMap, PathUtil, ResolveError, ResolveOptions, Resolver};
+use crate::{
+    Ctx, ImportsExportsMap, PathUtil, ResolveError, ResolveOptions, Resolver,
+    package_json::ImportsExportsMapGeneric,
+};
 
 #[test]
 fn test_simple() {
@@ -116,7 +119,7 @@ fn imports_field(value: &serde_json::Value) -> ImportsExportsMap<'static> {
         panic!("Expected an object");
     };
     let map = Box::leak::<'static>(Box::new(map));
-    ImportsExportsMap(map)
+    ImportsExportsMapGeneric(map)
 }
 
 #[cfg(target_endian = "big")]
@@ -126,7 +129,7 @@ fn imports_field(value: &serde_json::Value) -> ImportsExportsMap<'static> {
     let serde_json::Value::Object(map) = value else {
         panic!("Expected an object");
     };
-    ImportsExportsMap(map)
+    ImportsExportsMapGeneric(map)
 }
 
 #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
## What

The little-endian (simd-json, zero-copy `BorrowedValue`) and big-endian (serde_json, owned `Value`) implementations of `PackageJson` were ~95% duplicated — the same ~20 accessor methods, the `resolve_browser_field`/`get_value_by_path` logic, and the `ImportsExports{Entry,Array,Map}` wrapper types, differing only in the JSON value type, storage, and a few variant matches.

## Change

Extract the accessor logic into `package_json/mod.rs`, written **once** against three small backend traits:

- `JsonValue` / `JsonObject` — abstract over `BorrowedValue` vs `serde_json::Value` (variant differences like `Static(Bool)` vs `Bool` hidden behind `as_bool`/`entry_kind`).
- `PackageJsonBackend` — a GAT-based storage trait (`type Value<'a>`), letting the simd self-cell (which borrows the file bytes) and the serde owned value share one `PackageJsonGeneric<S>`.

The public `PackageJson` and `ImportsExports*` types are per-target **type aliases** over the generics, so the rest of the crate (and downstream API) is unchanged.

Each backend module shrinks to its trait impls + `parse`:

| file | before | after |
|---|---|---|
| `simd.rs` | 514 | 168 |
| `serde.rs` | 428 | 108 |
| `mod.rs` | 73 | 460 |
| **total** | **1015** | **736** |

## Verification

- All tests pass (`cargo test`, 263 lib + integration; the exports/imports field suites exercise the shared logic).
- `cargo clippy --all-features --all-targets -- --deny warnings`: clean.
- `cargo check --target s390x-unknown-linux-gnu` (compiles the serde backend): clean. Because the logic is now shared, the little-endian test suite also covers the serde path's behavior (only its ~60-line backend + `parse` differ).
- **Perf-neutral** (monomorphized): controlled A/B on `resolver_memory/single-thread` — pre-refactor 27.98 µs vs this branch 27.92 µs, change +0.0% (p=0.99), "No change in performance detected".

Maintainability only — only one backend compiles per target, so this is not a binary-size change.