### PR TITLE
feat(file_system): make FileSystemOs cheaply cloneable and Debug

### DIFF
--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -5,6 +5,8 @@ use std::{
 
 use cfg_if::cfg_if;
 #[cfg(feature = "yarn_pnp")]
+use std::sync::Arc;
+#[cfg(feature = "yarn_pnp")]
 use pnp::fs::{LruZipCache, VPath, VPathInfo, ZipCache};
 
 use crate::ResolveError;
@@ -124,12 +126,21 @@ impl From<fs::Metadata> for FileMetadata {
 }
 
 #[cfg(not(feature = "yarn_pnp"))]
+#[derive(Clone)]
 pub struct FileSystemOs;
 
 #[cfg(feature = "yarn_pnp")]
+#[derive(Clone)]
 pub struct FileSystemOs {
-    pnp_lru: LruZipCache<Vec<u8>>,
+    // `Arc` so `FileSystemOs` is cheaply `Clone`: clones share the same pnp zip cache.
+    pnp_lru: Arc<LruZipCache<Vec<u8>>>,
     yarn_pnp: bool,
+}
+
+impl std::fmt::Debug for FileSystemOs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileSystemOs").finish()
+    }
 }
 
 impl FileSystemOs {
@@ -244,7 +255,7 @@ impl FileSystemOs {
 impl FileSystem for FileSystemOs {
     #[cfg(feature = "yarn_pnp")]
     fn new(yarn_pnp: bool) -> Self {
-        Self { pnp_lru: LruZipCache::new(50, pnp::fs::open_zip_via_read_p), yarn_pnp }
+        Self { pnp_lru: Arc::new(LruZipCache::new(50, pnp::fs::open_zip_via_read_p)), yarn_pnp }
     }
 
     #[cfg(not(feature = "yarn_pnp"))]

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -5,9 +5,9 @@ use std::{
 
 use cfg_if::cfg_if;
 #[cfg(feature = "yarn_pnp")]
-use std::sync::Arc;
-#[cfg(feature = "yarn_pnp")]
 use pnp::fs::{LruZipCache, VPath, VPathInfo, ZipCache};
+#[cfg(feature = "yarn_pnp")]
+use std::sync::Arc;
 
 use crate::ResolveError;
 


### PR DESCRIPTION
## What

Make `FileSystemOs` cheaply `Clone` (and add a `Debug` impl) so a `FileSystemOs`-backed resolver can be cloned without rebuilding the Yarn PnP zip cache.

- Wrap the pnp `LruZipCache` in an `Arc` — clones share the same cache.
- `#[derive(Clone)]` on both the default (unit struct) and `yarn_pnp` variants.
- Add a `Debug` impl (the cache isn't `Debug`, so it's a minimal hand-written one).

## Verification

- `cargo check` (default) and `cargo check --features yarn_pnp` both clean.
- `cargo clippy --all-features --all-targets -- --deny warnings` clean.
- `cargo test` (263 lib tests) pass.