### PR TITLE
perf(path): drop Chain<Once, Components> in normalize_with

### DIFF
--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -201,26 +201,13 @@ impl CachedPath {
         SCRATCH_PATH.with_borrow_mut(|path| {
             path.clear();
             path.push(&self.path);
-            for component in std::iter::once(head).chain(components) {
-                match component {
-                    Component::CurDir => {}
-                    Component::ParentDir => {
-                        path.pop();
-                    }
-                    Component::Normal(c) => {
-                        cfg_if! {
-                            if #[cfg(target_family = "wasm")] {
-                                // Need to trim the extra \0 introduces by https://github.com/nodejs/uvwasi/issues/262
-                                path.push(c.to_string_lossy().trim_end_matches('\0'));
-                            } else {
-                                path.push(c);
-                            }
-                        }
-                    }
-                    Component::Prefix(..) | Component::RootDir => {
-                        unreachable!("Path {:?} Subpath {:?}", self.path, subpath)
-                    }
-                }
+            // Process `head` before the rest rather than `std::iter::once(head).chain(components)`:
+            // the `Chain<Once<_>, Components>` adapter is a large value that LLVM copies around a
+            // big stack frame on every call. Folding `head` in by hand keeps the loop over a bare
+            // `Components` iterator.
+            push_normalized_component(path, head);
+            for component in components {
+                push_normalized_component(path, component);
             }
 
             cache.value(path)
@@ -244,6 +231,31 @@ impl CachedPath {
     #[cfg(not(windows))]
     pub(crate) fn normalize_root<Fs: FileSystem>(&self, _cache: &Cache<Fs>) -> Self {
         self.clone()
+    }
+}
+
+/// Apply a single path component to `path` for normalization (drop `.`, pop on `..`, push names).
+///
+/// `Prefix`/`RootDir` only ever appear as the first component of a `Components` iterator, and the
+/// caller handles that head component before reaching here, so those arms are unreachable.
+#[inline]
+fn push_normalized_component(path: &mut PathBuf, component: Component<'_>) {
+    match component {
+        Component::CurDir => {}
+        Component::ParentDir => {
+            path.pop();
+        }
+        Component::Normal(c) => {
+            cfg_if! {
+                if #[cfg(target_family = "wasm")] {
+                    // Need to trim the extra \0 introduces by https://github.com/nodejs/uvwasi/issues/262
+                    path.push(c.to_string_lossy().trim_end_matches('\0'));
+                } else {
+                    path.push(c);
+                }
+            }
+        }
+        Component::Prefix(..) | Component::RootDir => unreachable!(),
     }
 }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -108,22 +108,34 @@ fn normalize_with_impl(base: &Path, subpath: &Path) -> PathBuf {
     }
 
     let mut ret = base.to_path_buf();
-    for component in std::iter::once(head).chain(components) {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                ret.pop();
-            }
-            Component::Normal(c) => {
-                ret.push(c);
-            }
-            Component::Prefix(..) | Component::RootDir => {
-                unreachable!("Path {:?} Subpath {:?}", base, subpath)
-            }
-        }
+    // `head` is processed before the rest instead of `std::iter::once(head).chain(components)`:
+    // the `Chain<Once<_>, Components>` adapter is a large value that LLVM copies around a big
+    // stack frame on every call. Folding `head` in by hand keeps the loop over a bare
+    // `Components` iterator.
+    push_normalized_component(&mut ret, head);
+    for component in components {
+        push_normalized_component(&mut ret, component);
     }
 
     ret
+}
+
+/// Apply a single path component to `ret` for normalization (drop `.`, pop on `..`, push names).
+///
+/// `Prefix`/`RootDir` only ever appear as the first component of a `Components` iterator, and the
+/// callers handle that head component before reaching here, so those arms are unreachable.
+#[inline]
+fn push_normalized_component(ret: &mut PathBuf, component: Component<'_>) {
+    match component {
+        Component::CurDir => {}
+        Component::ParentDir => {
+            ret.pop();
+        }
+        Component::Normal(c) => {
+            ret.push(c);
+        }
+        Component::Prefix(..) | Component::RootDir => unreachable!(),
+    }
 }
 
 // https://github.com/webpack/enhanced-resolve/blob/main/test/path.test.js


### PR DESCRIPTION
## What

Found via `cargo asm`: `normalize_with_impl` carried a **512-byte stack frame** dominated by SIMD register shuffling, traced to one line:

```rust
for component in std::iter::once(head).chain(components) { ... }
```

`Chain<Once<Component>, Components>` is a large value — `Component` is a fat enum embedding `&OsStr`, and the adapter also holds the whole `Components` iterator state plus an `Option` — so LLVM copies it around the frame on every call. The pattern lived in **both** hot path-join routines (`src/path.rs` and `src/cache/cached_path.rs`), exercised on every relative import and every symlink-canonicalization step.

## How

`head` is already proven to be neither `Prefix` nor `RootDir`, so process it directly and then loop the bare `Components` — no adapter. The per-component logic moves into a shared `push_normalized_component` helper (verified fully inlined, so there's no call-per-component cost).

## Results

`path::normalize_with_impl`:

|              | before | after        |
| ------------ | ------ | ------------ |
| stack frame  | 512 B  | 304 B (−40%) |
| instructions | 126    | 91 (−28%)    |

Also drops the `unreachable!("{:?} {:?}", …)` Debug-format machinery (the arms are genuinely unreachable — `Components` only yields `Prefix`/`RootDir` as its first item, which the caller already consumed).

End-to-end `resolver_memory/single-thread` is within noise (−0.4%, p=0.25, measured warm-to-warm) — `normalize_with` is a small slice of that workload. The benefit is leaner codegen and reduced stack pressure in the recursive `canonicalize_with_visited`.

All 315 tests pass (`--all-features`); clippy clean.
