### PR TITLE
perf(tsconfig): cut allocations in glob ownership matching

### DIFF
--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -562,6 +562,11 @@ enum GlobPattern<'a> {
     All,
 }
 
+/// Normalize Windows `\` to `/` for glob matching, without allocating when there's nothing to replace.
+fn to_forward_slashes(s: Cow<'_, str>) -> Cow<'_, str> {
+    if s.contains('\\') { Cow::Owned(s.replace('\\', "/")) } else { s }
+}
+
 /// Tsconfig resolver
 impl TsConfig {
     pub(crate) fn resolve_tsconfig_solution(tsconfig: Arc<Self>, path: &Path) -> Arc<Self> {
@@ -634,7 +639,6 @@ impl TsConfig {
     }
 
     fn is_glob_matches(&self, path: &Path, pattern: GlobPattern) -> bool {
-        let path_str = path.to_string_lossy().replace('\\', "/");
         match pattern {
             // The default `**/*` is scoped to the tsconfig directory; as a
             // wildcard pattern it is restricted to the configured TS/JS
@@ -643,10 +647,13 @@ impl TsConfig {
                 path.starts_with(self.directory())
                     && self.is_file_extension_allowed_in_tsconfig(path)
             }
-            GlobPattern::Pattern(patterns) => patterns.iter().any(|pattern| {
-                let pattern = pattern.to_string_lossy().replace('\\', "/");
-                self.is_glob_match(pattern.as_ref(), path, &path_str)
-            }),
+            GlobPattern::Pattern(patterns) => {
+                let path_str = to_forward_slashes(path.to_string_lossy());
+                patterns.iter().any(|pattern| {
+                    let pattern = to_forward_slashes(pattern.to_string_lossy());
+                    self.is_glob_match(pattern.as_ref(), path, path_str.as_ref())
+                })
+            }
         }
     }
 


### PR DESCRIPTION
## What

`TsConfig::is_glob_matches` runs per reference inside `claims_ownership_of` / `resolve_tsconfig_solution` on every resolve in a TS project. `cargo asm` showed it carrying a 272-byte frame and unconditional `String` allocations. Two needless allocations:

1. **Eager `path_str`** — `path.to_string_lossy().replace('\\', "/")` was computed at the top, but the `GlobPattern::All` arm (the default `**/*` include) never uses it. Moving it into the `Pattern` arm lets the common default-`include` ownership check skip the allocation entirely. **Frame 272 B → 192 B.**

2. **Unconditional `.replace`** — `str::replace` always allocates a fresh `String`, even when there's nothing to replace, which is *always* the case for Unix paths (no `\`). Since `to_string_lossy()` already hands back a borrowed `Cow` for ASCII paths, the only allocation was this `replace`. A new `to_forward_slashes` helper guards it behind `contains('\\')`, so the common Unix case stays alloc-free — for both the path and each pattern.

## Notes

End-to-end this is within noise on the tsconfig benches (`resolver_memory/find tsconfig`, `tsconfig_paths_aliases_memory`) — glob matching is a small slice of resolve time. The benefit is fewer allocations and a smaller stack frame; behaviour is unchanged (the `All` arm is strictly less work, the `Pattern` arm trades an unconditional alloc for a cheaper `contains` scan).

All 315 tests pass (`--all-features`); clippy clean.
