### PR TITLE
perf(resolve): compute parent once in package.json scope walk

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,8 +359,9 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 if p.is_node_modules() {
                     break;
                 }
+                let parent = p.parent(&self.cache);
                 // Skip /node_modules/@scope/package.json
-                if let Some(parent) = p.parent(&self.cache)
+                if let Some(parent) = &parent
                     && parent.is_node_modules()
                     && let Some(filename) = p.path().file_name()
                     && filename.as_encoded_bytes().starts_with(b"@")
@@ -370,7 +371,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 if let Some(package_json) = self.cache.get_package_json(&p, &self.options, ctx)? {
                     last = Some(package_json);
                 }
-                cp = p.parent(&self.cache);
+                cp = parent;
             }
             Ok(last)
         } else {


### PR DESCRIPTION
## What

`find_package_json_for_a_package` runs on **every bare-specifier resolve** (`import 'react'` etc.). Its `inside_node_modules` walk called `p.parent(&self.cache)` **twice per loop iteration**:

```rust
// @scope skip check
if let Some(parent) = p.parent(&self.cache) && parent.is_node_modules() && … { break; }
…
cp = p.parent(&self.cache);   // walk up — same parent, recomputed
```

`CachedPath::parent()` does a `Weak::upgrade` + `Arc` clone — atomic refcount operations the compiler **can't** common-subexpression-eliminate (the atomics are observable side effects). So each node_modules level walked paid for two upgrades instead of one. Compute it once and reuse.

## Notes

Within noise on the macro benchmarks (`resolver_memory` single- and multi-thread) — the walk is a small slice of resolve time and the `Weak` upgrades are L1-cached hits — so I'm not claiming a benchmark number. The justification is that it removes genuinely duplicated atomic work (strictly fewer ops, never more, and fewer refcount touches matter more under multi-thread contention) and reads cleaner.

All 275 tests pass (`--all-features`); clippy clean. Behaviour is identical.
