### PR TITLE
perf(cache): byte-level fast path for normalize_with

### DIFF
--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -193,6 +193,16 @@ impl CachedPath {
     }
 
     fn normalize_with_impl<Fs: FileSystem>(&self, subpath: &Path, cache: &Cache<Fs>) -> Self {
+        // Fast path: the overwhelmingly common subpath is a simple relative path with no `.`/`..`
+        // segments (e.g. an `exports` target like `./dist/index.js`), so the join is a plain byte
+        // append — no `std::path::Components` parsing or per-component `PathBuf::push`, which a Time
+        // Profiler shows is the single biggest chunk of resolve CPU. Gated off Windows (needs `/` ->
+        // `\` separator normalization) and wasm (strips interior NULs); both keep the slow path.
+        #[cfg(not(any(target_os = "windows", target_family = "wasm")))]
+        if let Some(result) = self.normalize_with_fast(subpath, cache) {
+            return result;
+        }
+
         let mut components = subpath.components();
         let Some(head) = components.next() else { return cache.value(subpath) };
         if matches!(head, Component::Prefix(..) | Component::RootDir) {
@@ -210,6 +220,48 @@ impl CachedPath {
 
             cache.value(path)
         })
+    }
+
+    /// Byte-level join for the common case where `subpath` is a simple relative path: returns
+    /// `None` (caller falls back to the `Components` path) for anything that needs real
+    /// normalization — absolute subpaths, or any `.`/`..`/empty (`//`) segment.
+    #[cfg(not(any(target_os = "windows", target_family = "wasm")))]
+    fn normalize_with_fast<Fs: FileSystem>(
+        &self,
+        subpath: &Path,
+        cache: &Cache<Fs>,
+    ) -> Option<Self> {
+        let mut sub = subpath.as_os_str().as_encoded_bytes();
+        // Drop a single leading `./`; anything else starting with `.` is a real segment name.
+        if let Some(rest) = sub.strip_prefix(b"./") {
+            sub = rest;
+        }
+        // Bail on absolute or empty subpaths, and on any segment that needs normalization.
+        if sub.is_empty() || sub[0] == b'/' {
+            return None;
+        }
+        for segment in sub.split(|&b| b == b'/') {
+            if segment.is_empty() || segment == b"." || segment == b".." {
+                return None;
+            }
+        }
+        let base = self.path.as_os_str().as_encoded_bytes();
+        if base.is_empty() {
+            return None;
+        }
+        Some(SCRATCH_PATH.with_borrow_mut(|path| {
+            path.clear();
+            let buf = path.as_mut_os_string();
+            // SAFETY: `base` is a whole `OsStr` encoding, so it ends on a valid `OsStr` boundary.
+            buf.push(unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(base) });
+            if base.last() != Some(&b'/') {
+                buf.push(std::path::MAIN_SEPARATOR_STR);
+            }
+            // SAFETY: `sub` is the `subpath` `OsStr` encoding with a leading ASCII `./` stripped,
+            // so it also ends on a valid `OsStr` boundary.
+            buf.push(unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(sub) });
+            cache.value(path)
+        }))
     }
 
     #[inline]


### PR DESCRIPTION
## What

A **Time Profiler** run (xctrace) on a warm resolve loop showed that `std::path::Components` parsing is the single largest chunk of resolve CPU — ~30% across `Components::next` / `parse_next_component_back` / `PathBuf::push` — and the biggest owner is `CachedPath::normalize_with_impl` (~13%), driven by `exports`-field targets like `./dist/index.js` that route through `package_target_resolve → normalize_with` on nearly every resolve.

`std::path::Components` is general-purpose (Windows prefixes, redundant separators, back-and-forth parsing) — generality we don't need when joining an already-clean relative subpath onto a normalized base.

## How

A byte-level fast path: when `subpath` is a simple relative path with no `.`/`..`/empty segments, join `base + subpath` by appending bytes (one whole-subpath `push` instead of per-component pushes), skipping `Components` entirely. Anything needing real normalization — absolute subpaths, `..`, `.` or `//` segments — returns `None` and falls back to the existing `Components` path.

Gated off **Windows** (needs `/`→`\` separator normalization) and **wasm** (strips interior NULs); both keep the proven slow path. The fast path produces byte-identical output to the slow path, so cache identity/hashing is unaffected.

## Results

`resolver_memory/single-thread`, warm A/B (3 runs): **−4.0% / −4.9% / −5.0%**, all `p = 0.00`.

Re-profiling confirms the mechanism:
- `PathBuf::push` self-time **4.1% → 0%** (per-component push eliminated)
- `Components` self-time **23% → 17%** (remainder is other call sites — `path::normalize_with` in canonicalize, `is_invalid_exports_target`, specifier classification — future follow-ups)

All 315 tests pass (`--all-features`), clippy clean. This is the same `normalize_with` already covered by the extensive `exports`/`imports`/relative-path fixtures.
