### PR TITLE
chore(bench): pin rayon thread count so parallel benches are deterministic

### DIFF
--- a/benches/package_managers.rs
+++ b/benches/package_managers.rs
@@ -55,6 +55,10 @@ fn run_combo(c: &mut Criterion, combo: Combo) {
 }
 
 fn bench_package_managers(c: &mut Criterion) {
+    // Pin rayon's pool to a fixed thread count so the parallel fan-out is deterministic across
+    // machines / CI runners; otherwise the pool sizes to the host core count, which varies and
+    // makes CodSpeed's instrumented instruction count flaky.
+    let _ = rayon::ThreadPoolBuilder::new().num_threads(4).build_global();
     for &combo in Combo::ALL {
         #[cfg(not(feature = "yarn_pnp"))]
         if matches!(combo, Combo::YarnPnp) {

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -157,7 +157,16 @@ fn oxc_resolver_real() -> oxc_resolver::Resolver {
     Resolver::new(resolve_options())
 }
 
+/// Pin rayon's global pool to a fixed thread count so the `multi-thread` benches are deterministic.
+/// Rayon otherwise sizes the pool to the host core count, which varies across CI runners and makes
+/// CodSpeed's instrumented instruction count flaky. Idempotent: the first call wins, the rest are
+/// no-ops, so it's safe to call from every parallel bench regardless of run order or filtering.
+fn pin_rayon_threads() {
+    let _ = rayon::ThreadPoolBuilder::new().num_threads(4).build_global();
+}
+
 fn bench_resolver_memory(c: &mut Criterion) {
+    pin_rayon_threads();
     let data = data();
     let cwd = env::current_dir().unwrap();
     let symlink_test_dir = cwd.join("fixtures/enhanced-resolve/test/temp_symlinks");
@@ -240,6 +249,7 @@ fn bench_resolver_memory(c: &mut Criterion) {
 }
 
 fn bench_resolver_real(c: &mut Criterion) {
+    pin_rayon_threads();
     let data = data();
     let symlink_test_dir = create_symlinks().expect("Create symlink fixtures failed");
 


### PR DESCRIPTION
## Problem

The CodSpeed reports are flaky. The same benchmarks swing wildly on PRs that can't possibly affect them:

| PR | Changed | Bogus CodSpeed swings |
| --- | --- | --- |
| #1232 | tsconfig glob only | `pm/npm-flat` **−7.3%**, `resolver_real[multi-thread]` −5.9%, `pm/yarn-isolated` **+12%** |
| #1235 | 1-line `parent()` dedup | `pm/bun-flat` **+10%**, `pm/yarn-flat` +5.5%, `resolver_memory[multi-thread]` −5.4% |

CodSpeed itself flags **"⚠️ Different runtime environments detected"** on these.

## Root cause

The `pm/*` and `resolver_*[multi-thread]` benches fan resolution out across **`rayon` worker threads**, and nothing pins the thread count — so rayon uses each runner's detected core count, which **varies across GitHub `ubuntu-latest` runners**. Under CodSpeed's instrumentation (Valgrind serializes threads onto one core and counts instructions), a different pool size between the BASE and HEAD runs produces wildly different instruction totals.

## Fix

Pin rayon's global pool to a **fixed 4 threads** at the start of each parallel bench (idempotent `build_global`). The thread count is now identical across machines and runs, so under Valgrind's deterministic scheduling the instrumented instruction count is deterministic — while the benches stay multi-threaded under local `cargo bench`.

No `cfg`/feature split: the benches behave the same locally and under CodSpeed. Verified both `cargo bench --no-run` and `cargo bench --no-run --features codspeed` compile with no warnings.
