### PR TITLE
perf(tsconfig): reuse cached lstat to avoid redundant stat in get_tsconfig

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -255,8 +255,16 @@ impl<Fs: FileSystem> Cache<Fs> {
             return Ok(Arc::clone(tsconfig.value()));
         }
 
-        // Not in any cache, parse from file
-        let meta = self.fs.metadata(path).ok();
+        // Not in any cache, parse from file.
+        // Classify file/dir via the cached `lstat` (which the canonicalization below reuses)
+        // instead of a standalone `stat`. For a regular file/dir the two agree; only follow the
+        // link with a `stat` when `path` is actually a symlink, preserving the symlink-following
+        // classification while saving one metadata syscall per tsconfig in the common case.
+        let cached_path = self.value(path);
+        let meta = match cached_path.link_metadata(&self.fs) {
+            Some(m) if m.is_symlink() => self.fs.metadata(path).ok(),
+            other => other,
+        };
         let tsconfig_path = if meta.is_some_and(|m| m.is_file) {
             Cow::Borrowed(path)
         } else if meta.is_some_and(|m| m.is_dir) {


### PR DESCRIPTION
## Problem

While tracing every `FileSystem` syscall during resolve, module resolution turned out to be redundancy-free (cold + warm), but **tsconfig loading double-stats every config file**.

`Cache::get_tsconfig` classifies the config path with `fs.metadata` (a `stat`) to decide file-vs-dir, then canonicalizes the same path — which issues an `lstat`. Those populate different cache slots (`followed` vs `link`), so neither reuses the other. Every tsconfig in an `extends`/`references` graph was therefore both `stat`'d **and** `lstat`'d.

## Fix

Classify via the cached `link_metadata` (`lstat`, the same slot canonicalization needs) and only fall back to `stat` when the path is actually a symlink:

```rust
let cached_path = self.value(path);
let meta = match cached_path.link_metadata(&self.fs) {
    Some(m) if m.is_symlink() => self.fs.metadata(path).ok(),
    other => other,
};
```

The later `canonicalize(&self.value(&tsconfig_path))` now reuses that cached `lstat` (same path → same `Arc<CachedPathImpl>` via the path cache), removing one metadata syscall per config file on cold load. Symlink-following classification is preserved for all four cases (regular file/dir, symlink→file, symlink→dir, missing).

This is a cold-only win (a tsconfig loads once per resolver), in the same spirit as the earlier lstat/stat-unification work.

## Measurements

Traced over the tsconfig fixtures (cold load):

| scenario | before | after | Δ |
| --- | --- | --- | --- |
| `extends-chain` (3 configs) | 21 syscalls | 18 | −14% |
| `project-references` (6 configs) | 39 syscalls | 33 | −15% |

The `stat` op is eliminated from tsconfig loading entirely.

## Verification

- `cargo test --all-features` — 315 tests pass (77 tsconfig)
- `cargo clippy --all-features` — clean
- `cargo check --all-features --all-targets` — clean