### PR TITLE
perf(resolve): skip redundant is_dir when reading a directory's package.json

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -155,13 +155,39 @@ impl<Fs: FileSystem> Cache<Fs> {
         options: &ResolveOptions,
         ctx: &mut Ctx,
     ) -> Result<Option<Arc<PackageJson>>, ResolveError> {
-        self.find_package_json(path, options, ctx).map(|option_package_json| {
-            option_package_json.filter(|package_json| {
-                package_json
-                    .path()
-                    .parent()
-                    .is_some_and(|p| p.as_os_str() == path.path().as_os_str())
-            })
+        Ok(Self::filter_own_package_json(path, self.find_package_json(path, options, ctx)?))
+    }
+
+    /// [`Cache::get_package_json`] for a `path` the caller already knows is a directory.
+    ///
+    /// Skips [`Cache::find_package_json`]'s leading `while !is_dir(path)` walk, which is a
+    /// dependency-neutral no-op once `path` is a directory (a single `is_dir` returning `true`),
+    /// and calls [`Cache::find_package_json_impl`] directly.
+    ///
+    /// # Errors
+    ///
+    /// * [ResolveError::Json]
+    pub(crate) fn get_package_json_of_dir(
+        &self,
+        path: &CachedPath,
+        options: &ResolveOptions,
+        ctx: &mut Ctx,
+    ) -> Result<Option<Arc<PackageJson>>, ResolveError> {
+        debug_assert!(
+            self.followed_metadata(path, options.symlinks).is_some_and(FileMetadata::is_dir),
+            "get_package_json_of_dir requires a directory: {}",
+            path.path().display()
+        );
+        Ok(Self::filter_own_package_json(path, self.find_package_json_impl(path, options, ctx)?))
+    }
+
+    /// Keep `package_json` only when it lives directly in `path` (i.e. `path` is its own scope).
+    fn filter_own_package_json(
+        path: &CachedPath,
+        package_json: Option<Arc<PackageJson>>,
+    ) -> Option<Arc<PackageJson>> {
+        package_json.filter(|package_json| {
+            package_json.path().parent().is_some_and(|p| p.as_os_str() == path.path().as_os_str())
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,7 +368,11 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 {
                     break;
                 }
-                if let Some(package_json) = self.cache.get_package_json(&p, &self.options, ctx)? {
+                // `p` is always a directory here (it starts at a directory and only walks
+                // parents), so skip `get_package_json`'s redundant leading `is_dir`.
+                if let Some(package_json) =
+                    self.cache.get_package_json_of_dir(&p, &self.options, ctx)?
+                {
                     last = Some(package_json);
                 }
                 cp = parent;
@@ -1147,7 +1151,9 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     ) -> ResolveResult {
         // 2. If X does not match this pattern or DIR/NAME/package.json is not a file,
         //    return.
-        let Some(package_json) = self.cache.get_package_json(cached_path, &self.options, ctx)?
+        // The sole caller gates this behind `is_dir(cached_path)`, so skip the redundant `is_dir`.
+        let Some(package_json) =
+            self.cache.get_package_json_of_dir(cached_path, &self.options, ctx)?
         else {
             return Ok(None);
         };
@@ -1404,8 +1410,10 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 //   1. Continue the next loop iteration.
                 if self.is_dir(&cached_path, ctx) {
                     // 4. Let pjson be the result of READ_PACKAGE_JSON(packageURL).
+                    // `cached_path` was just confirmed to be a directory above, so skip
+                    // `get_package_json`'s redundant leading `is_dir`.
                     if let Some(package_json) =
-                        self.cache.get_package_json(&cached_path, &self.options, ctx)?
+                        self.cache.get_package_json_of_dir(&cached_path, &self.options, ctx)?
                     {
                         // 5. If pjson is not null and pjson.exports is not null or undefined, then
                         // 1. Return the result of PACKAGE_EXPORTS_RESOLVE(packageURL, packageSubpath, pjson.exports, defaultConditions).


### PR DESCRIPTION
## What

While tracing redundant work during resolve, the resolved package's directory is `is_dir`-checked multiple times within a single warm resolve. Several of those come from reading a directory's `package.json`: `get_package_json` routes through `find_package_json`, whose leading `while !is_dir(path)` walk only matters when `path` is **not** a directory.

## Change

Add `Cache::get_package_json_of_dir`, which calls `find_package_json_impl` directly (skipping the `while !is_dir` walk) and shares the "package.json lives directly in this dir" filter with `get_package_json` via a small `filter_own_package_json` helper. A `debug_assert!` (over the ctx-free `followed_metadata`) enforces the directory precondition.

Used at the three call sites that provably hold a directory:
- the `find_package_json_for_a_package` walk loop (`p` starts at a directory and only walks parents),
- `load_node_modules` (right after its own `is_dir` check), and
- `load_package_exports` (its sole caller gates on `is_dir`).

`get_package_json` itself is left **unchanged**, because `load_as_directory` has an ungated caller that can pass a non-directory.

## Why it's safe

For a directory, `find_package_json`'s walk is a single `is_dir` that returns `true` and records **no** dependency, so calling `find_package_json_impl` directly yields an identical result **and** an identical recorded dependency set. The exact-vector `dependencies.rs` contract test passes unchanged, as do all 315 lib + integration tests; the `debug_assert!` (active in test builds) never fires, confirming every converted site truly passes a directory. `clippy --all-features` is clean.

## Performance

Honest disclosure: this removes genuinely redundant work but the saving is **within benchmark noise** — `is_dir` resolves to a single cached `AtomicU8` load. Warm-to-warm `resolver_memory/single-thread` across four runs: −0.72% / +0.07% / +0.46% / +0.07% (p mostly > 0.05). In the spirit of #1235 (dedup duplicated atomic work): strictly less work, provably cannot regress — but not a measurable speedup.