### PR TITLE
perf(alias): skip UTF-8 validation of resolved path when no alias key matches

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -58,6 +58,30 @@ pub fn compile_alias(aliases: &Alias) -> CompiledAlias {
         .collect()
 }
 
+impl CompiledAliasEntry {
+    /// Whether this entry's key matches `specifier` (raw bytes) — exactly the condition under
+    /// which [`ResolverGeneric::load_alias`] proceeds to try this entry's values. Matching on
+    /// bytes lets a caller gate on a path's `OsStr` without paying UTF-8 validation up front
+    /// (the validated `&str` and its bytes are identical, so the result is the same).
+    pub(crate) fn key_matches(&self, specifier: &[u8]) -> bool {
+        // Fast-reject entries whose required first byte differs (see `match_first_byte`). `None`
+        // matches any specifier (e.g. an empty wildcard prefix), so such entries always proceed.
+        if let Some(required) = self.match_first_byte
+            && Some(required) != specifier.first().copied()
+        {
+            return false;
+        }
+        match &self.match_kind {
+            AliasMatchKind::Exact => self.key.as_bytes() == specifier,
+            // The actual prefix/suffix is validated later in `load_alias_value`.
+            AliasMatchKind::Wildcard { .. } => true,
+            AliasMatchKind::Prefix => specifier
+                .strip_prefix(self.key.as_bytes())
+                .is_some_and(|tail| tail.is_empty() || matches!(tail.first(), Some(b'/' | b'\\'))),
+        }
+    }
+}
+
 impl<Fs: FileSystem> ResolverGeneric<Fs> {
     pub(super) fn load_alias_by_options(
         &self,
@@ -81,30 +105,13 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         ctx: &mut Ctx,
     ) -> Result<Option<CachedPath>, ResolveError> {
         for alias in aliases {
-            // Fast-reject entries whose required first byte doesn't match the specifier.
-            // `match_first_byte == None` means the entry can match any specifier (e.g. an
-            // empty wildcard prefix), so it always proceeds. The first-byte load is inlined
-            // so it is skipped entirely when `aliases` is empty (the default config) or when
-            // every iteration short-circuits on a `None` `match_first_byte`.
-            if let Some(required) = alias.match_first_byte
-                && Some(required) != specifier.as_bytes().first().copied()
-            {
+            // Skip entries whose key doesn't match the specifier. `key_matches` is the single
+            // source of truth for this test (also used to gate the file-path-as-alias lookup in
+            // `load_browser_field_or_alias` before paying for UTF-8 validation).
+            if !alias.key_matches(specifier.as_bytes()) {
                 continue;
             }
             let alias_key = alias.key.as_str();
-            match &alias.match_kind {
-                AliasMatchKind::Exact => {
-                    if alias_key != specifier {
-                        continue;
-                    }
-                }
-                AliasMatchKind::Wildcard { .. } => {}
-                AliasMatchKind::Prefix => {
-                    if Self::strip_package_name(specifier, alias_key).is_none() {
-                        continue;
-                    }
-                }
-            }
             // It should stop resolving when all of the tried alias values
             // failed to resolve.
             // <https://github.com/webpack/enhanced-resolve/blob/570337b969eee46120a18b62b72809a3246147da/lib/AliasPlugin.js#L65>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -902,14 +902,20 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         {
             return Ok(Some(path));
         }
-        // enhanced-resolve: try file as alias
-        // Guard this because this is on a hot path, and `.to_string_lossy()` has a cost.
+        // enhanced-resolve: try the resolved file path itself as an alias key.
+        // `to_string_lossy()` validates UTF-8 over the whole path, which is wasteful on this hot
+        // path when no alias can match (the common case: alias keys are bare specifiers, the path
+        // is absolute). Gate on the raw `OsStr` bytes first — `key_matches` is the same per-entry
+        // test `load_alias` applies — and only materialize the string when some key matches.
         if !self.options.alias.is_empty() {
-            let alias_specifier = cached_path.path().to_string_lossy();
-            if let Some(path) =
-                self.load_alias(cached_path, &alias_specifier, &self.alias, tsconfig, ctx)?
-            {
-                return Ok(Some(path));
+            let path_bytes = cached_path.path().as_os_str().as_encoded_bytes();
+            if self.alias.iter().any(|alias| alias.key_matches(path_bytes)) {
+                let alias_specifier = cached_path.path().to_string_lossy();
+                if let Some(path) =
+                    self.load_alias(cached_path, &alias_specifier, &self.alias, tsconfig, ctx)?
+                {
+                    return Ok(Some(path));
+                }
             }
         }
         Ok(None)


### PR DESCRIPTION
## Problem

`load_browser_field_or_alias` runs `cached_path.path().to_string_lossy()` on **every probed file candidate**, to try the user `alias` list against the resolved path (enhanced-resolve applies aliases to resolved paths too). On a valid-UTF-8 path the returned `Cow` is borrowed (no allocation), but it still **validates UTF-8 over the whole path** each time — wasted work on a hot path, since alias keys are bare specifiers that essentially never match an absolute file path.

A warm `sample` profile of `resolver_memory/single-thread` attributed ~11% of self-time to `Utf8Chunks::next` / `from_utf8_lossy` driven by this single line.

## Change

- Add `CompiledAliasEntry::key_matches(&[u8])` — the exact per-entry test `load_alias` uses to decide whether to try an alias, evaluated on raw bytes.
- `load_alias` now uses it (single source of truth; removes the duplicated inline match block).
- Gate the `to_string_lossy()` behind `self.alias.iter().any(|a| a.key_matches(path_bytes))` over `as_os_str().as_encoded_bytes()`. When no key matches the path bytes (the common case) the validation is skipped; when one does, behavior is identical.

Behavior-preserving: `key_matches` mirrors `load_alias`'s own condition, so the gate only skips work where `load_alias` would have returned `None`. Byte-only and `as_encoded_bytes()` is already used elsewhere in the crate, so it stays cross-platform.

## Result

`resolver_memory/single-thread`: **28.76 → 27.04 µs (−6.2%, p=0.00)**, stable on a warm-to-warm re-run. Re-profiling confirms `Utf8Chunks` / `from_utf8_lossy` drop out of the profile and `load_alias` self-time falls 1804 → 381 samples.