### PR TITLE
perf: avoid UTF-8 validation on alias and .d.ts resolve hot paths

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -59,13 +59,10 @@ pub fn compile_alias(aliases: &Alias) -> CompiledAlias {
 }
 
 impl CompiledAliasEntry {
-    /// Whether this entry's key matches `specifier` (raw bytes) — exactly the condition under
-    /// which [`ResolverGeneric::load_alias`] proceeds to try this entry's values. Matching on
-    /// bytes lets a caller gate on a path's `OsStr` without paying UTF-8 validation up front
-    /// (the validated `&str` and its bytes are identical, so the result is the same).
+    /// Whether this entry's key matches `specifier` (raw bytes). Matching on bytes lets a caller
+    /// gate on a path's `OsStr` without paying for UTF-8 validation up front.
     pub(crate) fn key_matches(&self, specifier: &[u8]) -> bool {
-        // Fast-reject entries whose required first byte differs (see `match_first_byte`). `None`
-        // matches any specifier (e.g. an empty wildcard prefix), so such entries always proceed.
+        // Fast-reject on the required first byte; `None` matches any specifier.
         if let Some(required) = self.match_first_byte
             && Some(required) != specifier.first().copied()
         {
@@ -73,7 +70,7 @@ impl CompiledAliasEntry {
         }
         match &self.match_kind {
             AliasMatchKind::Exact => self.key.as_bytes() == specifier,
-            // The actual prefix/suffix is validated later in `load_alias_value`.
+            // Prefix/suffix is validated later in `load_alias_value`.
             AliasMatchKind::Wildcard { .. } => true,
             AliasMatchKind::Prefix => specifier
                 .strip_prefix(self.key.as_bytes())
@@ -105,9 +102,6 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         ctx: &mut Ctx,
     ) -> Result<Option<CachedPath>, ResolveError> {
         for alias in aliases {
-            // Skip entries whose key doesn't match the specifier. `key_matches` is the single
-            // source of truth for this test (also used to gate the file-path-as-alias lookup in
-            // `load_browser_field_or_alias` before paying for UTF-8 validation).
             if !alias.key_matches(specifier.as_bytes()) {
                 continue;
             }

--- a/src/dts_resolver.rs
+++ b/src/dts_resolver.rs
@@ -182,12 +182,14 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     }
 
     fn dts_module_type(cached_path: &CachedPath) -> Option<ModuleType> {
-        let path_str = cached_path.path().to_string_lossy();
-        if path_str.ends_with(".d.mts") || path_str.ends_with(".mts") {
+        // Suffixes are ASCII, so matching on the raw `OsStr` bytes is equivalent to matching the
+        // UTF-8 string and avoids the validation scan.
+        let bytes = cached_path.path().as_os_str().as_encoded_bytes();
+        if bytes.ends_with(b".d.mts") || bytes.ends_with(b".mts") {
             Some(ModuleType::Module)
-        } else if path_str.ends_with(".d.cts") || path_str.ends_with(".cts") {
+        } else if bytes.ends_with(b".d.cts") || bytes.ends_with(b".cts") {
             Some(ModuleType::CommonJs)
-        } else if path_str.ends_with(".json") {
+        } else if bytes.ends_with(b".json") {
             Some(ModuleType::Json)
         } else {
             None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -902,20 +902,17 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         {
             return Ok(Some(path));
         }
-        // enhanced-resolve: try the resolved file path itself as an alias key.
-        // `to_string_lossy()` validates UTF-8 over the whole path, which is wasteful on this hot
-        // path when no alias can match (the common case: alias keys are bare specifiers, the path
-        // is absolute). Gate on the raw `OsStr` bytes first — `key_matches` is the same per-entry
-        // test `load_alias` applies — and only materialize the string when some key matches.
+        // enhanced-resolve: try file as alias.
+        // Gate on the raw `OsStr` bytes first so `to_str`'s UTF-8 validation is skipped on this
+        // hot path when no alias key matches; a non-UTF-8 path can't match a string alias anyway.
         if !self.options.alias.is_empty() {
             let path_bytes = cached_path.path().as_os_str().as_encoded_bytes();
-            if self.alias.iter().any(|alias| alias.key_matches(path_bytes)) {
-                let alias_specifier = cached_path.path().to_string_lossy();
-                if let Some(path) =
-                    self.load_alias(cached_path, &alias_specifier, &self.alias, tsconfig, ctx)?
-                {
-                    return Ok(Some(path));
-                }
+            if self.alias.iter().any(|alias| alias.key_matches(path_bytes))
+                && let Some(alias_specifier) = cached_path.path().to_str()
+                && let Some(path) =
+                    self.load_alias(cached_path, alias_specifier, &self.alias, tsconfig, ctx)?
+            {
+                return Ok(Some(path));
             }
         }
         Ok(None)


### PR DESCRIPTION
## Summary

Follow-up to #1240. Three small changes that avoid paying for UTF-8 validation/conversion of `OsStr` paths on resolution hot paths, plus a comment cleanup.

- **file-as-alias** (`src/lib.rs`): `load_browser_field_or_alias` already gates the lookup on the resolved path's raw bytes (`key_matches`) before doing any string work. When a key does match, borrow the path via `Path::to_str()` instead of `to_string_lossy()`. `to_str()` is a zero-allocation borrow and returns `None` for non-UTF-8 paths — which can't resolve through a string alias anyway, so skipping them is equivalent while avoiding the lossy allocation.
- **.d.ts module type** (`src/dts_resolver.rs`): `dts_module_type` only checks ASCII extension suffixes (`.d.mts`, `.cts`, `.json`, …), so it now matches on `as_encoded_bytes()` directly and drops the UTF-8 validation scan. ASCII bytes never appear inside a multi-byte UTF-8/WTF-8 sequence, so this is byte-for-byte equivalent.
- **comments**: trim the verbose comments that landed with the alias byte-gate in #1240.

No observable behavior change and no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)