### PR TITLE
chore: bump cargo-shear to 1.13.1

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: oxc-project/setup-rust@3d6fb132fbe7cdcb66bf8ec193911c2945369d12 # v1.0.17
         with:
           restore-cache: false
-          tools: just,cargo-shear@1
+          tools: just,cargo-shear@1.13.1
           components: rustfmt
 
       - uses: ./.github/actions/pnpm

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ alias r := ready
 # or install via `cargo install cargo-binstall`
 # Initialize the project by installing all the necessary tools.
 init:
-  cargo binstall cargo-shear typos-cli watchexec-cli -y
+  cargo binstall cargo-shear@1.13.1 typos-cli watchexec-cli -y
   rustup target add s390x-unknown-linux-gnu
 
 install:
@@ -49,7 +49,7 @@ example target *args='':
 
 # Format all files
 fmt:
-  cargo shear --fix # remove all unused dependencies
+  cargo shear --fix --check-test-targets # remove all unused dependencies
   cargo fmt --all
   node --run fmt
 


### PR DESCRIPTION
Bumps cargo-shear to 1.13.1 and runs cargo shear with `--check-test-targets`.