### PR TITLE
perf: type-erase the filesystem into a non-generic ResolverImpl core

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, path::Path};
 use compact_str::CompactString;
 
 use crate::{
-    Alias, AliasValue, CachedPath, FileSystem, ResolveError, ResolverGeneric, TsConfig,
+    Alias, AliasValue, CachedPath, ResolveError, ResolverImpl, TsConfig,
     context::ResolveContext as Ctx,
     path::{PathUtil, SLASH_START},
 };
@@ -79,7 +79,7 @@ impl CompiledAliasEntry {
     }
 }
 
-impl<Fs: FileSystem> ResolverGeneric<Fs> {
+impl ResolverImpl {
     pub(super) fn load_alias_by_options(
         &self,
         cached_path: &CachedPath,

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -138,9 +138,7 @@ impl Cache {
         path.meta.followed_or_init(|| match path.link_metadata(self.fs()) {
             Some(meta) if meta.is_symlink() => {
                 let followed = if symlinks {
-                    self.canonicalize_impl(path)
-                        .ok()
-                        .and_then(|c| c.link_metadata(self.fs()))
+                    self.canonicalize_impl(path).ok().and_then(|c| c.link_metadata(self.fs()))
                 } else {
                     None
                 };

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -21,9 +21,8 @@ use crate::{
 };
 
 /// Cache implementation used for caching filesystem access.
-#[derive(Default)]
-pub struct Cache<Fs> {
-    pub(crate) fs: Fs,
+pub struct Cache {
+    pub(crate) fs: Arc<dyn FileSystem>,
     pub(crate) paths: DashMap<CachedPath, (), BuildHasherDefault<IdentityHasher>>,
     /// Cache for raw/unbuilt tsconfigs (used when extending).
     pub(crate) tsconfigs_raw: DashMap<PathBuf, Arc<TsConfig>, BuildHasherDefault<FxHasher>>,
@@ -33,7 +32,7 @@ pub struct Cache<Fs> {
     pub(crate) yarn_pnp_manifest: OnceCell<pnp::Manifest>,
 }
 
-impl<Fs: FileSystem> Cache<Fs> {
+impl Cache {
     pub fn clear(&self) {
         self.paths.clear();
         self.tsconfigs_raw.clear();
@@ -130,10 +129,10 @@ impl<Fs: FileSystem> Cache<Fs> {
     /// additive: a custom [`FileSystem`] whose `canonicalize` and `metadata` disagree still gets
     /// the same answer `stat` gave before.
     fn followed_metadata(&self, path: &CachedPath, symlinks: bool) -> Option<FileMetadata> {
-        path.meta.followed_or_init(|| match path.link_metadata(&self.fs) {
+        path.meta.followed_or_init(|| match path.link_metadata(self.fs.as_ref()) {
             Some(meta) if meta.is_symlink() => {
                 let followed = if symlinks {
-                    self.canonicalize_impl(path).ok().and_then(|c| c.link_metadata(&self.fs))
+                    self.canonicalize_impl(path).ok().and_then(|c| c.link_metadata(self.fs.as_ref()))
                 } else {
                     None
                 };
@@ -221,7 +220,12 @@ impl<Fs: FileSystem> Cache<Fs> {
                 // `JSONError.path` carries the same path, so the file-dependency record reads it
                 // back without a second allocation.
                 // https://github.com/webpack/enhanced-resolve/blob/58464fc7cb56673c9aa849e68e6300239601e615/lib/DescriptionFileUtils.js#L68-L82
-                match PackageJson::parse(&self.fs, package_json_path, real_path, package_json_bytes)
+                match PackageJson::parse(
+                    self.fs.as_ref(),
+                    package_json_path,
+                    real_path,
+                    package_json_bytes,
+                )
                 {
                     Ok(package_json) => {
                         ctx.add_file_dependency(package_json.path());
@@ -261,7 +265,7 @@ impl<Fs: FileSystem> Cache<Fs> {
         // link with a `stat` when `path` is actually a symlink, preserving the symlink-following
         // classification while saving one metadata syscall per tsconfig in the common case.
         let cached_path = self.value(path);
-        let meta = match cached_path.link_metadata(&self.fs) {
+        let meta = match cached_path.link_metadata(self.fs.as_ref()) {
             Some(m) if m.is_symlink() => self.fs.metadata(path).ok(),
             other => other,
         };
@@ -336,8 +340,8 @@ impl<Fs: FileSystem> Cache<Fs> {
     }
 }
 
-impl<Fs: FileSystem> Cache<Fs> {
-    pub fn new(fs: Fs) -> Self {
+impl Cache {
+    pub fn new(fs: Arc<dyn FileSystem>) -> Self {
         Self {
             fs,
             paths: DashMap::with_hasher(BuildHasherDefault::default()),
@@ -398,7 +402,7 @@ impl<Fs: FileSystem> Cache<Fs> {
                     let normalized = parent_canonical
                         .normalize_with(path.path().strip_prefix(parent.path()).unwrap(), self);
 
-                    if path.link_metadata(&self.fs).is_some_and(|m| m.is_symlink) {
+                    if path.link_metadata(self.fs.as_ref()).is_some_and(|m| m.is_symlink) {
                         let link = self.fs.read_link(normalized.path())?;
                         if link.is_absolute() {
                             return self.canonicalize_with_visited(

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -132,7 +132,9 @@ impl Cache {
         path.meta.followed_or_init(|| match path.link_metadata(self.fs.as_ref()) {
             Some(meta) if meta.is_symlink() => {
                 let followed = if symlinks {
-                    self.canonicalize_impl(path).ok().and_then(|c| c.link_metadata(self.fs.as_ref()))
+                    self.canonicalize_impl(path)
+                        .ok()
+                        .and_then(|c| c.link_metadata(self.fs.as_ref()))
                 } else {
                     None
                 };
@@ -225,8 +227,7 @@ impl Cache {
                     package_json_path,
                     real_path,
                     package_json_bytes,
-                )
-                {
+                ) {
                     Ok(package_json) => {
                         ctx.add_file_dependency(package_json.path());
                         Ok(Some(Arc::new(package_json)))

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -39,6 +39,12 @@ impl Cache {
         self.tsconfigs_built.clear();
     }
 
+    /// The underlying filesystem as a trait object.
+    #[inline]
+    fn fs(&self) -> &dyn FileSystem {
+        &*self.fs
+    }
+
     #[allow(clippy::cast_possible_truncation)]
     pub(crate) fn value(&self, path: &Path) -> CachedPath {
         // `Path::hash` is slow: https://doc.rust-lang.org/std/path/struct.Path.html#impl-Hash-for-Path
@@ -129,12 +135,12 @@ impl Cache {
     /// additive: a custom [`FileSystem`] whose `canonicalize` and `metadata` disagree still gets
     /// the same answer `stat` gave before.
     fn followed_metadata(&self, path: &CachedPath, symlinks: bool) -> Option<FileMetadata> {
-        path.meta.followed_or_init(|| match path.link_metadata(self.fs.as_ref()) {
+        path.meta.followed_or_init(|| match path.link_metadata(self.fs()) {
             Some(meta) if meta.is_symlink() => {
                 let followed = if symlinks {
                     self.canonicalize_impl(path)
                         .ok()
-                        .and_then(|c| c.link_metadata(self.fs.as_ref()))
+                        .and_then(|c| c.link_metadata(self.fs()))
                 } else {
                     None
                 };
@@ -223,7 +229,7 @@ impl Cache {
                 // back without a second allocation.
                 // https://github.com/webpack/enhanced-resolve/blob/58464fc7cb56673c9aa849e68e6300239601e615/lib/DescriptionFileUtils.js#L68-L82
                 match PackageJson::parse(
-                    self.fs.as_ref(),
+                    self.fs(),
                     package_json_path,
                     real_path,
                     package_json_bytes,
@@ -266,7 +272,7 @@ impl Cache {
         // link with a `stat` when `path` is actually a symlink, preserving the symlink-following
         // classification while saving one metadata syscall per tsconfig in the common case.
         let cached_path = self.value(path);
-        let meta = match cached_path.link_metadata(self.fs.as_ref()) {
+        let meta = match cached_path.link_metadata(self.fs()) {
             Some(m) if m.is_symlink() => self.fs.metadata(path).ok(),
             other => other,
         };
@@ -403,7 +409,7 @@ impl Cache {
                     let normalized = parent_canonical
                         .normalize_with(path.path().strip_prefix(parent.path()).unwrap(), self);
 
-                    if path.link_metadata(self.fs.as_ref()).is_some_and(|m| m.is_symlink) {
+                    if path.link_metadata(self.fs()).is_some_and(|m| m.is_symlink) {
                         let link = self.fs.read_link(normalized.path())?;
                         if link.is_absolute() {
                             return self.canonicalize_with_visited(

--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -79,7 +79,7 @@ impl CachedPath {
         self.path.to_path_buf()
     }
 
-    pub(crate) fn parent<Fs: FileSystem>(&self, cache: &Cache<Fs>) -> Option<Self> {
+    pub(crate) fn parent(&self, cache: &Cache) -> Option<Self> {
         self.0.parent.as_ref().and_then(|weak| {
             weak.upgrade().map(CachedPath).or_else(|| {
                 // Weak pointer upgrade failed - parent was cleared from cache
@@ -97,21 +97,21 @@ impl CachedPath {
         self.inside_node_modules
     }
 
-    pub(crate) fn module_directory<Fs: FileSystem>(
+    pub(crate) fn module_directory(
         &self,
         module_name: &str,
         symlinks: bool,
-        cache: &Cache<Fs>,
+        cache: &Cache,
         ctx: &mut Ctx,
     ) -> Option<Self> {
         let cached_path = self.push(module_name, cache);
         cache.is_dir(&cached_path, symlinks, ctx).then_some(cached_path)
     }
 
-    pub(crate) fn cached_node_modules<Fs: FileSystem>(
+    pub(crate) fn cached_node_modules(
         &self,
         symlinks: bool,
-        cache: &Cache<Fs>,
+        cache: &Cache,
         ctx: &mut Ctx,
     ) -> Option<Self> {
         self.node_modules
@@ -128,7 +128,7 @@ impl CachedPath {
             })
     }
 
-    pub(crate) fn push<Fs: FileSystem>(&self, target: &str, cache: &Cache<Fs>) -> Self {
+    pub(crate) fn push(&self, target: &str, cache: &Cache) -> Self {
         SCRATCH_PATH.with_borrow_mut(|path| {
             path.clear();
             path.push(&self.path);
@@ -137,7 +137,7 @@ impl CachedPath {
         })
     }
 
-    pub(crate) fn add_extension<Fs: FileSystem>(&self, target: &str, cache: &Cache<Fs>) -> Self {
+    pub(crate) fn add_extension(&self, target: &str, cache: &Cache) -> Self {
         SCRATCH_PATH.with_borrow_mut(|path| {
             path.clear();
             let s = path.as_mut_os_string();
@@ -147,12 +147,7 @@ impl CachedPath {
         })
     }
 
-    pub(crate) fn add_name_and_extension<Fs: FileSystem>(
-        &self,
-        name: &str,
-        ext: &str,
-        cache: &Cache<Fs>,
-    ) -> Self {
+    pub(crate) fn add_name_and_extension(&self, name: &str, ext: &str, cache: &Cache) -> Self {
         SCRATCH_PATH.with_borrow_mut(|path| {
             path.clear();
             let s = path.as_mut_os_string();
@@ -164,7 +159,7 @@ impl CachedPath {
         })
     }
 
-    pub(crate) fn replace_extension<Fs: FileSystem>(&self, ext: &str, cache: &Cache<Fs>) -> Self {
+    pub(crate) fn replace_extension(&self, ext: &str, cache: &Cache) -> Self {
         SCRATCH_PATH.with_borrow_mut(|path| {
             path.clear();
             let s = path.as_mut_os_string();
@@ -182,17 +177,13 @@ impl CachedPath {
 
     /// Returns a new path by resolving the given subpath (including "." and ".." components) with this path.
     #[inline]
-    pub(crate) fn normalize_with<Fs: FileSystem, P: AsRef<Path>>(
-        &self,
-        subpath: P,
-        cache: &Cache<Fs>,
-    ) -> Self {
-        // Forward to a single instantiation (per `Fs`) so the many `AsRef<Path>` call
+    pub(crate) fn normalize_with<P: AsRef<Path>>(&self, subpath: P, cache: &Cache) -> Self {
+        // Forward to a single instantiation so the many `AsRef<Path>` call
         // sites don't each monomorphize the full body (binary-size win).
         self.normalize_with_impl(subpath.as_ref(), cache)
     }
 
-    fn normalize_with_impl<Fs: FileSystem>(&self, subpath: &Path, cache: &Cache<Fs>) -> Self {
+    fn normalize_with_impl(&self, subpath: &Path, cache: &Cache) -> Self {
         let mut components = subpath.components();
         let Some(head) = components.next() else { return cache.value(subpath) };
         if matches!(head, Component::Prefix(..) | Component::RootDir) {
@@ -214,7 +205,7 @@ impl CachedPath {
 
     #[inline]
     #[cfg(windows)]
-    pub(crate) fn normalize_root<Fs: FileSystem>(&self, cache: &Cache<Fs>) -> Self {
+    pub(crate) fn normalize_root(&self, cache: &Cache) -> Self {
         if self.path().as_os_str().as_encoded_bytes().last() == Some(&b'/') {
             let mut path_string = self.path.to_string_lossy().into_owned();
             path_string.pop();
@@ -227,7 +218,7 @@ impl CachedPath {
 
     #[inline]
     #[cfg(not(windows))]
-    pub(crate) fn normalize_root<Fs: FileSystem>(&self, _cache: &Cache<Fs>) -> Self {
+    pub(crate) fn normalize_root(&self, _cache: &Cache) -> Self {
         self.clone()
     }
 }
@@ -260,7 +251,7 @@ impl CachedPath {
     ///
     /// Used both to answer `is_file`/`is_dir` for non-symlinks and by canonicalization to decide
     /// whether to follow a symlink — so the two share a single `lstat` syscall per path.
-    pub(crate) fn link_metadata<Fs: FileSystem>(&self, fs: &Fs) -> Option<FileMetadata> {
+    pub(crate) fn link_metadata(&self, fs: &dyn FileSystem) -> Option<FileMetadata> {
         self.meta.link_or_init(|| fs.symlink_metadata(&self.path).ok())
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -12,13 +12,14 @@ mod tests {
     use super::cache_impl::Cache;
     use crate::FileSystem;
     use std::path::Path;
+    use std::sync::Arc;
 
     #[test]
     fn test_cached_path_debug() {
         #[cfg(feature = "yarn_pnp")]
-        let cache = Cache::new(crate::FileSystemOs::new(false));
+        let cache = Cache::new(Arc::new(crate::FileSystemOs::new(false)));
         #[cfg(not(feature = "yarn_pnp"))]
-        let cache = Cache::new(crate::FileSystemOs::new());
+        let cache = Cache::new(Arc::new(crate::FileSystemOs::new()));
 
         let path = Path::new("/foo/bar");
         let cached_path = cache.value(path);

--- a/src/dts_resolver.rs
+++ b/src/dts_resolver.rs
@@ -14,7 +14,7 @@
 use std::{borrow::Cow, path::Path};
 
 use crate::{
-    CachedPath, FileSystem, PackageJson, ResolveError, ResolverGeneric,
+    CachedPath, PackageJson, ResolveError, ResolverImpl,
     context::ResolveContext as Ctx,
     resolution::{ModuleType, Resolution},
     specifier::Specifier,
@@ -69,7 +69,7 @@ impl std::ops::BitAnd for Extensions {
     }
 }
 
-impl<Fs: FileSystem> ResolverGeneric<Fs> {
+impl ResolverImpl {
     /// Resolve a module specifier for TypeScript declaration files.
     ///
     /// Matches `ts.resolveModuleName` with `moduleResolution: "bundler"`.
@@ -762,5 +762,16 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         ctx: &mut Ctx,
     ) -> ResolveResult {
         self.load_package_self(cached_path, specifier, None, ctx)
+    }
+}
+
+#[cfg(test)]
+impl<Fs> crate::ResolverGeneric<Fs> {
+    /// Thin forwarder kept on the generic shell so existing
+    /// `ResolverGeneric::<Fs>::dts_mangle_scoped_name(..)` associated-function call sites keep
+    /// resolving (inherent associated functions are not reachable through `Deref`). The actual
+    /// (non-generic) implementation lives in `impl ResolverImpl`.
+    pub(crate) fn dts_mangle_scoped_name(name: &str) -> String {
+        ResolverImpl::dts_mangle_scoped_name(name)
     }
 }

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -14,10 +14,14 @@ use crate::ResolveError;
 /// File System abstraction used for `ResolverGeneric`
 pub trait FileSystem: Send + Sync {
     #[cfg(feature = "yarn_pnp")]
-    fn new(yarn_pnp: bool) -> Self;
+    fn new(yarn_pnp: bool) -> Self
+    where
+        Self: Sized;
 
     #[cfg(not(feature = "yarn_pnp"))]
-    fn new() -> Self;
+    fn new() -> Self
+    where
+        Self: Sized;
 
     /// See [std::fs::read]
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,26 +118,45 @@ pub struct ResolveContext {
 /// Resolver with the current operating system as the file system
 pub type Resolver = ResolverGeneric<FileSystemOs>;
 
+/// Non-generic core of the resolver holding the heavy resolution algorithm.
+///
+/// The filesystem is type-erased to `Arc<dyn FileSystem>` here so that the resolver
+/// algorithm compiles exactly once, regardless of the concrete `Fs` type used by
+/// [`ResolverGeneric`]. All public resolution methods live on this struct and are reachable
+/// through [`ResolverGeneric`]'s [`Deref`](std::ops::Deref) implementation.
+pub struct ResolverImpl {
+    options: ResolveOptions,
+    cache: Arc<Cache>,
+    alias: CompiledAlias,
+}
+
 /// Generic implementation of the resolver, can be configured by the [Cache] trait
 pub struct ResolverGeneric<Fs> {
-    options: ResolveOptions,
-    cache: Arc<Cache<Fs>>,
-    alias: CompiledAlias,
+    inner: ResolverImpl,
+    _marker: std::marker::PhantomData<Fs>,
+}
+
+impl<Fs> std::ops::Deref for ResolverGeneric<Fs> {
+    type Target = ResolverImpl;
+
+    fn deref(&self) -> &ResolverImpl {
+        &self.inner
+    }
 }
 
 impl<Fs> fmt::Debug for ResolverGeneric<Fs> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.options.fmt(f)
+        self.inner.options.fmt(f)
     }
 }
 
-impl<Fs: FileSystem> Default for ResolverGeneric<Fs> {
+impl<Fs: FileSystem + 'static> Default for ResolverGeneric<Fs> {
     fn default() -> Self {
         Self::new(ResolveOptions::default())
     }
 }
 
-impl<Fs: FileSystem> ResolverGeneric<Fs> {
+impl<Fs: FileSystem + 'static> ResolverGeneric<Fs> {
     #[must_use]
     pub fn new(options: ResolveOptions) -> Self {
         let options = options.sanitize();
@@ -149,14 +168,17 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
                 let fs = Fs::new();
             }
         }
-        let cache = Arc::new(Cache::new(fs));
-        Self { options, cache, alias }
+        let cache = Arc::new(Cache::new(Arc::new(fs) as Arc<dyn FileSystem>));
+        let inner = ResolverImpl { options, cache, alias };
+        Self { inner, _marker: std::marker::PhantomData }
     }
 
     pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
-        Self { cache: Arc::new(Cache::new(file_system)), options, alias }
+        let cache = Arc::new(Cache::new(Arc::new(file_system) as Arc<dyn FileSystem>));
+        let inner = ResolverImpl { options, cache, alias };
+        Self { inner, _marker: std::marker::PhantomData }
     }
 
     /// Clone the resolver using the same underlying cache.
@@ -167,20 +189,23 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         let alias = compile_alias(&options.alias);
         cfg_if::cfg_if! {
             if #[cfg(feature = "yarn_pnp")] {
-                let cache = if (options.yarn_pnp && !self.options.yarn_pnp)
-                    || (!options.yarn_pnp && self.options.yarn_pnp)
+                let cache = if (options.yarn_pnp && !self.inner.options.yarn_pnp)
+                    || (!options.yarn_pnp && self.inner.options.yarn_pnp)
                 {
-                    Arc::new(Cache::new(Fs::new(options.yarn_pnp)))
+                    Arc::new(Cache::new(Arc::new(Fs::new(options.yarn_pnp)) as Arc<dyn FileSystem>))
                 } else {
-                    Arc::clone(&self.cache)
+                    Arc::clone(&self.inner.cache)
                 };
             } else {
-                let cache = Arc::clone(&self.cache);
+                let cache = Arc::clone(&self.inner.cache);
             }
         }
-        Self { options, cache, alias }
+        let inner = ResolverImpl { options, cache, alias };
+        Self { inner, _marker: std::marker::PhantomData }
     }
+}
 
+impl ResolverImpl {
     /// Returns the options.
     #[must_use]
     pub const fn options(&self) -> &ResolveOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ use crate::{
 
 type ResolveResult = Result<Option<CachedPath>, ResolveError>;
 
-/// Context returned from the [Resolver::resolve_with_context] API
+/// Context returned from the [ResolverImpl::resolve_with_context] API
 #[derive(Debug, Default, Clone)]
 pub struct ResolveContext {
     /// Files that was found on file system
@@ -234,7 +234,7 @@ impl ResolverImpl {
     /// For CommonJS modules, it is the `__dirname` variable that contains the absolute path to the folder containing current module.
     /// For ECMAScript modules, it is the value of `import.meta.url`.
     ///
-    /// NOTE: [TsconfigDiscovery::Auto] does not work for this API, use [ResolverGeneric::resolve_file] instead.
+    /// NOTE: [TsconfigDiscovery::Auto] does not work for this API, use [ResolverImpl::resolve_file] instead.
     ///
     /// # Errors
     ///

--- a/src/package_json/serde.rs
+++ b/src/package_json/serde.rs
@@ -88,8 +88,8 @@ impl PackageJson {
     /// Parse a package.json file from JSON bytes
     ///
     /// # Errors
-    pub fn parse<Fs: FileSystem>(
-        _fs: &Fs,
+    pub fn parse(
+        _fs: &dyn FileSystem,
         path: PathBuf,
         realpath: PathBuf,
         json: Vec<u8>,

--- a/src/package_json/simd.rs
+++ b/src/package_json/simd.rs
@@ -108,8 +108,8 @@ impl PackageJson {
     ///
     /// # Panics
     /// # Errors
-    pub fn parse<Fs: FileSystem>(
-        fs: &Fs,
+    pub fn parse(
+        fs: &dyn FileSystem,
         path: PathBuf,
         realpath: PathBuf,
         json: Vec<u8>,

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use crate::{
-    CachedPath, Ctx, FileSystem, ResolveError, ResolveOptions, ResolveResult, ResolverGeneric,
-    Specifier, SpecifierError, TsConfig, TsconfigDiscovery, TsconfigOptions, TsconfigReferences,
+    CachedPath, Ctx, ResolveError, ResolveOptions, ResolveResult, ResolverImpl, Specifier,
+    SpecifierError, TsConfig, TsconfigDiscovery, TsconfigOptions, TsconfigReferences,
     path::PathUtil,
 };
 
@@ -34,7 +34,7 @@ impl TsconfigResolveContext {
     }
 }
 
-impl<Fs: FileSystem> ResolverGeneric<Fs> {
+impl ResolverImpl {
     /// Finds the `tsconfig` to which this `path` belongs.
     ///
     /// If the `path` is inside `node_modules`, this function always returns `None`.
@@ -402,7 +402,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     /// `imports` field). Both use the same conditions so that, for example,
     /// `extends: "pkg"` and `extends: "#pkg"` agree on which condition wins.
     fn tsconfig_extends_resolver(&self) -> Self {
-        self.clone_with_options(ResolveOptions {
+        let options = ResolveOptions {
             tsconfig: None,
             condition_names: vec!["node".into(), "import".into()],
             extensions: vec![".json".into()],
@@ -412,7 +412,12 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
             #[cfg(feature = "yarn_pnp")]
             cwd: self.options.cwd.clone(),
             ..ResolveOptions::default()
-        })
+        }
+        .sanitize();
+        let alias = crate::alias::compile_alias(&options.alias);
+        // Extends-resolution never toggles `yarn_pnp`, so reuse the same cache (and thus the
+        // same underlying filesystem) rather than rebuilding it.
+        Self { options, cache: Arc::clone(&self.cache), alias }
     }
 
     fn get_extended_tsconfig_path(


### PR DESCRIPTION
## What

Refactor `ResolverGeneric<Fs>` into a thin generic shell over a new non-generic `ResolverImpl` that type-erases the filesystem to `Arc<dyn FileSystem>`. The heavy resolution algorithm now lives on `ResolverImpl` and is reached through `ResolverGeneric<Fs>`'s `Deref`, so the public API is unchanged.

## Why

`ResolverGeneric<Fs>` monomorphizes the entire resolution algorithm once per `Fs` type **and** once per downstream crate — cross-crate generic instantiations aren't shared in optimized builds, and fat-LTO doesn't merge them. In a real consumer (rolldown) the heavy methods (`load_node_modules`, `package_target_resolve`, `load_tsconfig`, `load_as_file`, ...) were each emitted **8×**. Making the core non-generic emits it **once**.

## Measured impact (rolldown, fat-LTO release)

- Every heavy resolver method: **8 copies → 1**
- `oxc_resolver` code in the binary: **728 KiB → 282 KiB (−61%)**
- Whole-binary `__text`: **−650 KiB** (downstream generic wrappers de-duplicate too)
- All existing tests pass; no public API change.

## Perf

Resolution is I/O-bound and the metadata cache absorbs most FS calls, so the `dyn` dispatch is perf-neutral. An A/B on `benches/resolver.rs` (static `ResolverGeneric<FileSystemOs>` vs an `Arc<dyn FileSystem>`-backed resolver) showed **≤0.6%** on the in-memory benchmark — the worst case, where there are no syscalls to amortize the vtable against — and **no measurable change** on real-disk resolution.

## Notes

- `FileSystem::new` is gated `where Self: Sized` so the trait is object-safe; trait objects never call `new`.
- The generic constructors gain `Fs: 'static` (required to coerce into `Arc<dyn FileSystem>`; satisfied by every real FS type).
- `ResolverImpl` is currently `pub` and reached through `Deref`. If you'd rather keep it private, the shell can carry explicit forwarding methods instead — easy to switch.
