### PR TITLE
perf(alias): scan a packed first-byte array instead of striding over alias entries

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -8,7 +8,60 @@ use crate::{
     path::{PathUtil, SLASH_START},
 };
 
-pub type CompiledAlias = Vec<CompiledAliasEntry>;
+#[derive(Clone, Default)]
+pub struct CompiledAlias {
+    entries: Vec<CompiledAliasEntry>,
+    /// First byte of each entry's key (or wildcard prefix), parallel to `entries`. Packed
+    /// contiguously so the per-specifier scan touches one or two cache lines instead of striding
+    /// over the ~100-byte entries. `0` marks an entry that must always be evaluated (an empty
+    /// key/prefix can match any specifier); a key genuinely starting with NUL also maps to `0`,
+    /// which just skips its fast-reject.
+    first_bytes: Box<[u8]>,
+    /// 256-bit set of `first_bytes` values for an O(1) "no entry can match" exit.
+    byte_mask: [u64; 4],
+}
+
+impl CompiledAlias {
+    fn mask_contains(&self, byte: u8) -> bool {
+        self.byte_mask[usize::from(byte >> 6)] & (1u64 << (byte & 63)) != 0
+    }
+
+    /// Whether any entry's first byte is compatible with `specifier`, without touching the
+    /// entries. `0` in the mask means an always-evaluated entry exists.
+    fn may_match(&self, specifier: &[u8]) -> bool {
+        self.mask_contains(0) || specifier.first().is_some_and(|&byte| self.mask_contains(byte))
+    }
+
+    /// Entries whose first byte is compatible with `specifier`, in declaration order. This is
+    /// only the fast-reject; callers still confirm with [`CompiledAliasEntry::key_matches`].
+    fn matching<'a>(&'a self, specifier: &'a [u8]) -> impl Iterator<Item = &'a CompiledAliasEntry> {
+        let first = specifier.first().copied();
+        self.first_bytes
+            .iter()
+            .zip(&self.entries)
+            .filter(move |&(&byte, _)| byte == 0 || Some(byte) == first)
+            .map(|(_, entry)| entry)
+    }
+
+    /// Whether any entry's key matches `specifier` (raw bytes), gated by the first-byte mask.
+    /// This runs for every file candidate when `alias` is configured, so on the common path
+    /// (no always-evaluated entry) it jumps straight to candidate entries with `memchr` instead
+    /// of scanning `first_bytes` with a branch per entry.
+    pub(crate) fn any_key_matches(&self, specifier: &[u8]) -> bool {
+        if !self.may_match(specifier) {
+            return false;
+        }
+        if self.mask_contains(0) {
+            return self.matching(specifier).any(|entry| entry.key_matches(specifier));
+        }
+        // `may_match` returned true without a `0` entry, so the specifier is non-empty.
+        let Some(&first) = specifier.first() else {
+            return false;
+        };
+        memchr::memchr_iter(first, &self.first_bytes)
+            .any(|index| self.entries[index].key_matches(specifier))
+    }
+}
 
 #[derive(Clone)]
 pub struct CompiledAliasEntry {
@@ -30,7 +83,7 @@ pub enum AliasMatchKind {
 }
 
 pub fn compile_alias(aliases: &Alias) -> CompiledAlias {
-    aliases
+    let entries: Vec<CompiledAliasEntry> = aliases
         .iter()
         .map(|(key, specifiers)| {
             let (key, match_kind) = key.strip_suffix('$').map_or_else(
@@ -55,7 +108,14 @@ pub fn compile_alias(aliases: &Alias) -> CompiledAlias {
             };
             CompiledAliasEntry { key, match_kind, specifiers: specifiers.clone(), match_first_byte }
         })
-        .collect()
+        .collect();
+    let first_bytes: Box<[u8]> =
+        entries.iter().map(|entry| entry.match_first_byte.unwrap_or(0)).collect();
+    let mut byte_mask = [0u64; 4];
+    for &byte in &first_bytes {
+        byte_mask[usize::from(byte >> 6)] |= 1u64 << (byte & 63);
+    }
+    CompiledAlias { entries, first_bytes, byte_mask }
 }
 
 impl CompiledAliasEntry {
@@ -101,7 +161,10 @@ impl ResolverImpl {
         tsconfig: Option<&TsConfig>,
         ctx: &mut Ctx,
     ) -> Result<Option<CachedPath>, ResolveError> {
-        for alias in aliases {
+        if !aliases.may_match(specifier.as_bytes()) {
+            return Ok(None);
+        }
+        for alias in aliases.matching(specifier.as_bytes()) {
             if !alias.key_matches(specifier.as_bytes()) {
                 continue;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,7 +932,7 @@ impl ResolverImpl {
         // hot path when no alias key matches; a non-UTF-8 path can't match a string alias anyway.
         if !self.options.alias.is_empty() {
             let path_bytes = cached_path.path().as_os_str().as_encoded_bytes();
-            if self.alias.iter().any(|alias| alias.key_matches(path_bytes))
+            if self.alias.any_key_matches(path_bytes)
                 && let Some(alias_specifier) = cached_path.path().to_str()
                 && let Some(path) =
                     self.load_alias(cached_path, alias_specifier, &self.alias, tsconfig, ctx)?


### PR DESCRIPTION
## What

Turn `CompiledAlias` from a `Vec<CompiledAliasEntry>` type alias into a struct that packs each entry's cached first byte into a contiguous side array plus a 256-bit presence mask:

- `may_match` — O(1) "no entry can match" exit via the mask, without touching any entry.
- `matching` — scans the packed byte array and only dereferences entries whose first byte is compatible.
- `any_key_matches` — the per-file-candidate check in `load_browser_field_or_alias` jumps straight to candidate indices with `memchr` when no always-evaluated entry exists.

Matching semantics are unchanged: candidates are still confirmed with `key_matches` in declaration order (first match wins), and empty-key/empty-wildcard-prefix entries remain always-evaluated (stored as `0` in the byte array; a key genuinely starting with NUL also maps to `0` and just loses its fast-reject).

## Why

#1142 cached the first byte on each entry, but the reject loop still strides over every ~100-byte `CompiledAliasEntry` — once per file candidate in `load_browser_field_or_alias` and once per require in `load_alias`. With the benchmark's 23-entry alias list that is ~2.5 KiB of scattered loads per scan.

samply profiles of the bench workloads attribute **12.5%** of CPU on `resolver_memory/single-thread` and **~31%** on `resolver_memory/resolve from symlinks` to this scan (`key_matches` self time plus the `any()` loop at `lib.rs:935`). After the change, `key_matches` drops out of the top self-time entries entirely in both profiles.

## Measured impact (criterion, macOS arm64)

| bench | before | after | delta |
|---|---|---|---|
| resolver_memory/single-thread | 26.3 µs | 21.9 µs | **−17%** |
| resolver_memory/multi-thread | 23.4 µs | 20.6 µs | −12% |
| resolver_memory/resolve from symlinks | 5.0 ms | 3.5 ms | **−30%** |
| resolver_real/single-thread | 27.0 µs | 23.5 µs | −13% |
| resolver_real/multi-thread | 23.4 µs | 21.0 µs | −10% |
| resolver_real/resolve from symlinks | 10.5 ms | 7.5 ms | **−29%** |

`tsconfig_paths_aliases_memory`, `package_json_deserialization`, and `resolver_memory/find tsconfig` are unchanged. With an empty alias list the new fields are an empty box + 32 zero bytes and `may_match` exits on the first mask word.