### PR TITLE
perf(package-json): index the browser field reverse lookup by file name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,9 @@ pub struct ResolverImpl {
     options: ResolveOptions,
     cache: Arc<Cache>,
     alias: CompiledAlias,
+    /// Hash of `options.alias_fields`, validating lazily built per-`PackageJson` browser-field
+    /// indexes (the package.json cache is shared across `clone_with_options` resolvers).
+    alias_fields_hash: u64,
 }
 
 /// Generic implementation of the resolver, can be configured by the [Cache] trait
@@ -169,7 +172,8 @@ impl<Fs: FileSystem + 'static> ResolverGeneric<Fs> {
             }
         }
         let cache = Arc::new(Cache::new(Arc::new(fs) as Arc<dyn FileSystem>));
-        let inner = ResolverImpl { options, cache, alias };
+        let alias_fields_hash = package_json::hash_alias_fields(&options.alias_fields);
+        let inner = ResolverImpl { options, cache, alias, alias_fields_hash };
         Self { inner, _marker: std::marker::PhantomData }
     }
 
@@ -177,7 +181,8 @@ impl<Fs: FileSystem + 'static> ResolverGeneric<Fs> {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
         let cache = Arc::new(Cache::new(Arc::new(file_system) as Arc<dyn FileSystem>));
-        let inner = ResolverImpl { options, cache, alias };
+        let alias_fields_hash = package_json::hash_alias_fields(&options.alias_fields);
+        let inner = ResolverImpl { options, cache, alias, alias_fields_hash };
         Self { inner, _marker: std::marker::PhantomData }
     }
 
@@ -200,7 +205,8 @@ impl<Fs: FileSystem + 'static> ResolverGeneric<Fs> {
                 let cache = Arc::clone(&self.inner.cache);
             }
         }
-        let inner = ResolverImpl { options, cache, alias };
+        let alias_fields_hash = package_json::hash_alias_fields(&options.alias_fields);
+        let inner = ResolverImpl { options, cache, alias, alias_fields_hash };
         Self { inner, _marker: std::marker::PhantomData }
     }
 }
@@ -1275,6 +1281,7 @@ impl ResolverImpl {
             path,
             module_specifier,
             &self.options.alias_fields,
+            self.alias_fields_hash,
         )?
         else {
             return Ok(None);

--- a/src/package_json/mod.rs
+++ b/src/package_json/mod.rs
@@ -16,11 +16,57 @@ pub use serde::*;
 pub use simd::*;
 
 use std::{
+    ffi::OsStr,
     fmt,
+    hash::{Hash, Hasher},
     path::{Path, PathBuf},
+    sync::OnceLock,
 };
 
+use compact_str::CompactString;
+use rustc_hash::{FxHashMap, FxHasher};
+
 use crate::{JSONError, ResolveError, path::PathUtil};
+
+/// Hash of a [`crate::ResolveOptions::alias_fields`] configuration, used to validate that a
+/// lazily built [`BrowserIndex`] belongs to the querying resolver's configuration (resolvers
+/// created via `clone_with_options` share cached `package.json`s across differing options).
+pub fn hash_alias_fields(alias_fields: &[Vec<String>]) -> u64 {
+    let mut hasher = FxHasher::default();
+    alias_fields.len().hash(&mut hasher);
+    for field_path in alias_fields {
+        field_path.len().hash(&mut hasher);
+        for segment in field_path {
+            segment.hash(&mut hasher);
+        }
+    }
+    hasher.finish()
+}
+
+/// Lazily built reverse index over the `"browser"` field(s), see
+/// [`PackageJsonGeneric::resolve_browser_field`]. `None` when the configuration has no
+/// browser field objects in this `package.json`.
+pub struct BrowserIndexSlot {
+    alias_fields_hash: u64,
+    index: Option<Box<BrowserIndex>>,
+}
+
+struct BrowserIndex {
+    /// Key file name → entries whose key ends in that file name, in declaration order.
+    /// `normalize_with` keeps a key's last `Normal` component, so only these keys can map to
+    /// a candidate path with the same file name.
+    by_file_name: FxHashMap<Box<OsStr>, Vec<BrowserEntry>>,
+    /// Keys without a file name (`.`, `..`, `./`) can map to any path and are always confirmed.
+    unindexable: Vec<BrowserEntry>,
+}
+
+struct BrowserEntry {
+    /// Index into the `browser_fields(alias_fields)` sequence the key came from.
+    field: usize,
+    /// Position within that field's object, for declaration-order matching.
+    pos: usize,
+    key: CompactString,
+}
 
 /// Check if JSON content is empty or contains only whitespace
 fn check_if_empty(json_bytes: &[u8], path: &Path) -> Result<(), JSONError> {
@@ -151,6 +197,9 @@ pub struct PackageJsonGeneric<S> {
     pub realpath: PathBuf,
 
     pub(crate) store: S,
+
+    /// Reverse index for the `"browser"` field, built on first reverse lookup.
+    pub(crate) browser_index: OnceLock<BrowserIndexSlot>,
 }
 
 impl<S: PackageJsonBackend> fmt::Debug for PackageJsonGeneric<S> {
@@ -367,30 +416,125 @@ impl<S: PackageJsonBackend> PackageJsonGeneric<S> {
         path: &Path,
         request: Option<&str>,
         alias_fields: &'a [Vec<String>],
+        alias_fields_hash: u64,
     ) -> Result<Option<&'a str>, ResolveError> {
-        for object in self.browser_fields(alias_fields) {
-            if let Some(request) = request {
+        if let Some(request) = request {
+            for object in self.browser_fields(alias_fields) {
                 // Find matching key in object
                 if let Some(value) = object.get(request) {
                     return alias_value(path, value);
                 }
-            } else {
-                let dir = self.path.parent().unwrap();
-                let path_file_name = path.file_name();
-                for (key, value) in object.iter() {
-                    // Fast path: `normalize_with` keeps `key`'s last component, so a key whose
-                    // file name differs from the candidate's can't match — skip without
-                    // allocating. `.`/`..` keys have no `file_name` and fall through.
-                    if let Some(key_file_name) = Path::new(key).file_name()
-                        && Some(key_file_name) != path_file_name
-                    {
-                        continue;
-                    }
-                    let joined = dir.normalize_with(key);
-                    if joined == path {
-                        return alias_value(path, value);
+            }
+            return Ok(None);
+        }
+        // The reverse lookup runs for every file candidate when `alias_fields` is set, so it
+        // goes through a lazily built `file name -> keys` index instead of scanning every key
+        // with a `Path::new(key).file_name()` parse each.
+        let slot = self.browser_index.get_or_init(|| BrowserIndexSlot {
+            alias_fields_hash,
+            index: self.build_browser_index(alias_fields),
+        });
+        if slot.alias_fields_hash == alias_fields_hash {
+            let Some(index) = &slot.index else { return Ok(None) };
+            return self.browser_reverse_lookup(index, path, alias_fields);
+        }
+        // The index was built for a resolver with different `alias_fields` sharing this cached
+        // `package.json` (`clone_with_options`): fall back to the linear scan.
+        let dir = self.path.parent().unwrap();
+        let path_file_name = path.file_name();
+        for object in self.browser_fields(alias_fields) {
+            for (key, value) in object.iter() {
+                // Fast path: `normalize_with` keeps `key`'s last component, so a key whose
+                // file name differs from the candidate's can't match — skip without
+                // allocating. `.`/`..` keys have no `file_name` and fall through.
+                if let Some(key_file_name) = Path::new(key).file_name()
+                    && Some(key_file_name) != path_file_name
+                {
+                    continue;
+                }
+                let joined = dir.normalize_with(key);
+                if joined == path {
+                    return alias_value(path, value);
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn build_browser_index(&self, alias_fields: &[Vec<String>]) -> Option<Box<BrowserIndex>> {
+        let mut by_file_name: FxHashMap<Box<OsStr>, Vec<BrowserEntry>> = FxHashMap::default();
+        let mut unindexable = Vec::new();
+        let mut has_fields = false;
+        for (field, object) in self.browser_fields(alias_fields).enumerate() {
+            has_fields = true;
+            for (pos, (key, _)) in object.iter().enumerate() {
+                let entry = BrowserEntry { field, pos, key: CompactString::new(key) };
+                match Path::new(key).file_name() {
+                    Some(name) => by_file_name.entry(Box::from(name)).or_default().push(entry),
+                    None => unindexable.push(entry),
+                }
+            }
+        }
+        has_fields.then(|| Box::new(BrowserIndex { by_file_name, unindexable }))
+    }
+
+    /// Reverse lookup through the index: only keys sharing the candidate's file name (plus the
+    /// rare file-name-less keys) are confirmed with `normalize_with` + equality, in the same
+    /// declaration order (field order, then object order) as the linear scan — first confirmed
+    /// key wins.
+    fn browser_reverse_lookup<'a>(
+        &'a self,
+        index: &BrowserIndex,
+        path: &Path,
+        alias_fields: &'a [Vec<String>],
+    ) -> Result<Option<&'a str>, ResolveError> {
+        let indexed = path
+            .file_name()
+            .and_then(|name| index.by_file_name.get(name))
+            .map_or(&[][..], Vec::as_slice);
+        if indexed.is_empty() && index.unindexable.is_empty() {
+            return Ok(None);
+        }
+        let dir = self.path.parent().unwrap();
+        let mut fields = self.browser_fields(alias_fields).enumerate();
+        let mut field = fields.next();
+        // Merge the two position-sorted entry lists in ascending (field, pos) order.
+        let (mut i, mut j) = (0, 0);
+        loop {
+            let entry = match (indexed.get(i), index.unindexable.get(j)) {
+                (Some(a), Some(b)) => {
+                    if (a.field, a.pos) < (b.field, b.pos) {
+                        i += 1;
+                        a
+                    } else {
+                        j += 1;
+                        b
                     }
                 }
+                (Some(a), None) => {
+                    i += 1;
+                    a
+                }
+                (None, Some(b)) => {
+                    j += 1;
+                    b
+                }
+                (None, None) => break,
+            };
+            // `browser_fields` enumerates densely and the index was built from the same
+            // sequence, so advancing to `entry.field` always lands on it.
+            while field.is_some_and(|(f, _)| f < entry.field) {
+                field = fields.next();
+            }
+            let Some((f, object)) = field else { break };
+            if f != entry.field {
+                continue;
+            }
+            let joined = dir.normalize_with(entry.key.as_str());
+            if joined == path
+                && let Some(value) = object.get(entry.key.as_str())
+            {
+                return alias_value(path, value);
             }
         }
         Ok(None)

--- a/src/package_json/serde.rs
+++ b/src/package_json/serde.rs
@@ -103,6 +103,6 @@ impl PackageJson {
             line: error.line(),
             column: error.column(),
         })?;
-        Ok(Self { path, realpath, store: value })
+        Ok(Self { path, realpath, store: value, browser_index: std::sync::OnceLock::new() })
     }
 }

--- a/src/package_json/simd.rs
+++ b/src/package_json/simd.rs
@@ -163,6 +163,6 @@ impl PackageJson {
             }
         })?;
 
-        Ok(Self { path, realpath, store: cell })
+        Ok(Self { path, realpath, store: cell, browser_index: std::sync::OnceLock::new() })
     }
 }

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -415,9 +415,10 @@ impl ResolverImpl {
         }
         .sanitize();
         let alias = crate::alias::compile_alias(&options.alias);
+        let alias_fields_hash = crate::package_json::hash_alias_fields(&options.alias_fields);
         // Extends-resolution never toggles `yarn_pnp`, so reuse the same cache (and thus the
         // same underlying filesystem) rather than rebuilding it.
-        Self { options, cache: Arc::clone(&self.cache), alias }
+        Self { options, cache: Arc::clone(&self.cache), alias, alias_fields_hash }
     }
 
     fn get_extended_tsconfig_path(


### PR DESCRIPTION
## What

Add a lazily built `file name -> keys` index (`OnceLock` per `PackageJson`) for the **reverse** browser-field lookup — mapping an already-resolved path back through the `"browser"` object. A lookup now hashes the candidate's file name and confirms only the (usually zero or one) keys sharing it with `normalize_with` + equality, in the same declaration order as the linear scan; keys without a file name (`.`, `..`) are kept in a separate always-confirmed list and merged by declaration position, preserving first-match-wins semantics exactly.

Package.jsons without browser fields build a `None` index, so their per-candidate check collapses to a single atomic load — previously every candidate re-navigated `alias_fields` via `get_value_by_path`.

Since resolvers created via `clone_with_options` share cached `PackageJson`s across differing options, the index stores a hash of the `alias_fields` configuration it was built for; a mismatch falls back to the previous linear scan (exercised by the existing `shared_resolvers` test).

## Why

The reverse lookup runs for **every file candidate** when `alias_fields` is set (`load_alias_or_file → load_browser_field_or_alias → load_browser_field`), and it iterated every key of every browser object with a `Path::new(key).file_name()` backward parse per key — `browser-module`'s browser field alone has 14 keys. samply profiles of the resolver benchmark attribute **~12% of warm-resolve CPU** to this scan: `std::path::Components` iteration under `load_browser_field` (11.9% of total) plus the halfbrown object iteration (~2.5%).

After this change, `Components` under `load_browser_field` drops to 3.1% (the remaining cost is the candidate's own `file_name()` plus the confirm step on real hits) and the halfbrown iteration leaves the top self-time profile entirely.

## Measured impact (criterion, macOS arm64)

Interleaved warm-to-warm A/B (measured on top of #1260; the local machine had concurrent load, so only benches with tight confidence intervals are reported):

| bench | before | after | delta |
|---|---|---|---|
| resolver_memory/single-thread | 22.1 µs | 19.9 µs | **−10%** |

Reproduced twice (−11.2%, −9.8%), both runs with ±0.5 µs intervals. `resolver_real/single-thread` showed −8% in a full-suite run. No mechanism for multi-thread divergence: the index is read-only after its one-time init and adds no locks to the hot path (a `OnceLock` acquire-load per reverse lookup). Memory cost: one small map per package.json with a browser field, built only when reverse lookups actually happen.