### PR TITLE
perf(cache): per-directory listing cache for child metadata on densely probed directories

### DIFF
--- a/benches/package_managers.rs
+++ b/benches/package_managers.rs
@@ -54,6 +54,58 @@ fn run_combo(c: &mut Criterion, combo: Combo) {
     });
 }
 
+/// Dense workload: every `lodash-es` module as a bare `lodash-es/<file>` deep import, resolved
+/// serially with a cold resolver per iteration. This is the access shape of a bundler graph
+/// traversal — hundreds of distinct probes into the same package directory — and is the regime
+/// where the per-directory listing cache replaces per-candidate `lstat`s with one `read_dir`.
+fn run_dense_combo(c: &mut Criterion, combo: Combo) {
+    let Some(root) = combo.fixture_root_if_installed() else {
+        eprintln!(
+            "skip pm-dense/{}: fixture not installed (run `just install-bench-fixtures`)",
+            combo.slug()
+        );
+        return;
+    };
+    let lodash_dir = root.join("node_modules/lodash-es");
+    let mut specifiers: Vec<String> = std::fs::read_dir(&lodash_dir)
+        .expect("lodash-es fixture directory")
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let name = entry.file_name().into_string().ok()?;
+            std::path::Path::new(&name)
+                .extension()
+                .is_some_and(|extension| extension == "js")
+                .then(|| format!("lodash-es/{name}"))
+        })
+        .collect();
+    specifiers.sort_unstable();
+    let importer = root.join("apps/web/nested/deep/src");
+    let opts = combo.resolve_options(&root);
+
+    // Correctness gate: every deep import must resolve into lodash-es.
+    let resolver = Resolver::new(opts.clone());
+    for specifier in &specifiers {
+        let resolution = resolver.resolve(&importer, specifier).unwrap_or_else(|err| {
+            panic!("pm-dense/{}: resolve({specifier:?}) failed: {err}", combo.slug())
+        });
+        let normalized = resolution.path().to_string_lossy().replace('\\', "/");
+        assert!(
+            normalized.contains("/lodash-es/") || normalized.contains("/lodash-es@"),
+            "pm-dense/{}: resolve({specifier:?}) -> {normalized}",
+            combo.slug()
+        );
+    }
+
+    c.bench_function(&format!("pm-dense/{}", combo.slug()), |b| {
+        b.iter(|| {
+            let resolver = Resolver::new(opts.clone());
+            for specifier in &specifiers {
+                _ = resolver.resolve(&importer, specifier);
+            }
+        });
+    });
+}
+
 fn bench_package_managers(c: &mut Criterion) {
     // Pin rayon's pool to a fixed thread count so the parallel fan-out is deterministic across
     // machines / CI runners; otherwise the pool sizes to the host core count, which varies and
@@ -66,6 +118,9 @@ fn bench_package_managers(c: &mut Criterion) {
             continue;
         }
         run_combo(c, combo);
+    }
+    for combo in [Combo::NpmFlat, Combo::PnpmIsolated] {
+        run_dense_combo(c, combo);
     }
 }
 

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
     collections::HashSet as StdHashSet,
+    ffi::OsStr,
     hash::{BuildHasherDefault, Hash, Hasher},
     io,
     path::{Path, PathBuf},
@@ -208,7 +209,15 @@ impl Cache {
         path.package_json
             .get_or_try_init(|| {
                 let package_json_path = path.path.join("package.json");
-                let Ok(package_json_bytes) = self.fs.read(&package_json_path) else {
+                // The directory listing can prove `package.json` absent and skip the failed
+                // `open` the blind read below would otherwise issue.
+                let absent = matches!(
+                    path.child_from_listing(OsStr::new("package.json"), self.fs()),
+                    super::cached_path::ChildVerdict::Absent
+                );
+                let package_json_bytes =
+                    if absent { Err(()) } else { self.fs.read(&package_json_path).map_err(|_| ()) };
+                let Ok(package_json_bytes) = package_json_bytes else {
                     if let Some(deps) = &mut ctx.missing_dependencies {
                         deps.push(package_json_path);
                     }

--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -76,8 +76,7 @@ pub enum ChildVerdict {
 impl DirListing {
     fn load(fs: &dyn FileSystem, path: &Path) -> Option<Box<Self>> {
         let raw = fs.read_dir(path).ok()?;
-        let mut entries =
-            FxHashMap::with_capacity_and_hasher(raw.len(), rustc_hash::FxBuildHasher);
+        let mut entries = FxHashMap::with_capacity_and_hasher(raw.len(), rustc_hash::FxBuildHasher);
         let mut lowered = FxHashSet::default();
         for (name, kind) in raw {
             let bytes = name.into_encoded_bytes().into_boxed_slice();

--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -1,14 +1,19 @@
 use std::{
     convert::AsRef,
+    ffi::OsStr,
     fmt,
     hash::{Hash, Hasher},
     ops::Deref,
     path::{Component, Path, PathBuf},
-    sync::{Arc, Weak},
+    sync::{
+        Arc, Weak,
+        atomic::{AtomicU8, Ordering},
+    },
 };
 
 use cfg_if::cfg_if;
 use once_cell::sync::OnceCell as OnceLock;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::cache_impl::Cache;
 use super::cached_meta::CachedMeta;
@@ -36,6 +41,76 @@ pub struct CachedPathImpl {
     pub tsconfig: OnceLock<Option<Arc<TsConfig>>>,
     /// `tsconfig.json` after resolving `references`, `files`, `include` and `extend`.
     pub resolved_tsconfig: OnceLock<Option<Arc<TsConfig>>>,
+    /// One `read_dir` snapshot of this path as a directory, replacing per-child `lstat`
+    /// probes. `None` = listing unavailable (unsupported file system, not a directory, or
+    /// read error); children then fall back to per-path metadata calls.
+    pub dir_entries: OnceLock<Option<Box<DirListing>>>,
+    /// Cold child probes seen before `dir_entries` is built; see
+    /// [`CachedPathImpl::child_from_listing`].
+    pub child_probes: AtomicU8,
+}
+
+/// A directory's entries with their `lstat`-equivalent kinds, from one [`FileSystem::read_dir`].
+///
+/// Names are keyed by their OS byte encoding. A lookup only reports "definitely absent" when
+/// no ASCII case-variant of the queried name exists either, so resolution behaves identically
+/// on case-sensitive and case-insensitive file systems; non-ASCII names always fall back to a
+/// real metadata call (Unicode case folding and normalization stay the OS's business).
+pub struct DirListing {
+    /// Entry name bytes -> kind (`None` = kind unknown, caller must `lstat`).
+    entries: FxHashMap<Box<[u8]>, Option<FileMetadata>>,
+    /// ASCII-lowercased forms of entry names that contain an uppercase ASCII byte.
+    lowered: FxHashSet<Box<[u8]>>,
+}
+
+/// Verdict of a directory-listing lookup for one child name.
+pub enum ChildVerdict {
+    /// Child exists with this `lstat`-equivalent kind; no syscall needed.
+    Kind(FileMetadata),
+    /// Child is definitely absent; no syscall needed.
+    Absent,
+    /// No verdict — the caller must issue the real metadata call.
+    Unknown,
+}
+
+impl DirListing {
+    fn load(fs: &dyn FileSystem, path: &Path) -> Option<Box<Self>> {
+        let raw = fs.read_dir(path).ok()?;
+        let mut entries =
+            FxHashMap::with_capacity_and_hasher(raw.len(), rustc_hash::FxBuildHasher);
+        let mut lowered = FxHashSet::default();
+        for (name, kind) in raw {
+            let bytes = name.into_encoded_bytes().into_boxed_slice();
+            if bytes.is_ascii() && bytes.iter().any(u8::is_ascii_uppercase) {
+                lowered.insert(bytes.to_ascii_lowercase().into_boxed_slice());
+            }
+            entries.insert(bytes, kind);
+        }
+        Some(Box::new(Self { entries, lowered }))
+    }
+
+    fn lookup(&self, name: &OsStr) -> ChildVerdict {
+        let bytes = name.as_encoded_bytes();
+        if !bytes.is_ascii() {
+            return ChildVerdict::Unknown;
+        }
+        if let Some(kind) = self.entries.get(bytes) {
+            return kind.map_or(ChildVerdict::Unknown, ChildVerdict::Kind);
+        }
+        // Absent by exact bytes. A case-variant entry could still satisfy this name on a
+        // case-insensitive file system (macOS, Windows) — only report absent when none exists.
+        let has_upper = bytes.iter().any(u8::is_ascii_uppercase);
+        if self.lowered.is_empty() && !has_upper {
+            return ChildVerdict::Absent;
+        }
+        let lower = bytes.to_ascii_lowercase();
+        if self.lowered.contains(lower.as_slice())
+            || (has_upper && self.entries.contains_key(lower.as_slice()))
+        {
+            return ChildVerdict::Unknown;
+        }
+        ChildVerdict::Absent
+    }
 }
 
 impl CachedPathImpl {
@@ -58,7 +133,32 @@ impl CachedPathImpl {
             package_json: OnceLock::new(),
             tsconfig: OnceLock::new(),
             resolved_tsconfig: OnceLock::new(),
+            dir_entries: OnceLock::new(),
+            child_probes: AtomicU8::new(0),
         }
+    }
+
+    /// Answer a child's `lstat`-equivalent metadata from this directory's listing.
+    ///
+    /// The listing is built lazily on the sixteenth cold child probe. Cold probe counts per
+    /// directory are bimodal: path ancestors and one-off package directories see a handful,
+    /// while directories a build actually shares — `node_modules` under many bare specifiers,
+    /// package/source dirs under many subpath or extension candidates — see dozens to
+    /// hundreds. One `read_dir` costs several syscalls (open + fstat + getdirentries + close)
+    /// plus the entry-map build, so the threshold sits above the first mode: sparse
+    /// resolutions keep exactly their per-path `lstat` behavior, and densely probed
+    /// directories collapse every probe past the sixteenth into zero syscalls.
+    pub(crate) fn child_from_listing(&self, name: &OsStr, fs: &dyn FileSystem) -> ChildVerdict {
+        const LISTING_THRESHOLD: u8 = 16;
+        let listing = if let Some(listing) = self.dir_entries.get() {
+            listing
+        } else {
+            if self.child_probes.fetch_add(1, Ordering::Relaxed) < LISTING_THRESHOLD - 1 {
+                return ChildVerdict::Unknown;
+            }
+            self.dir_entries.get_or_init(|| DirListing::load(fs, &self.path))
+        };
+        listing.as_deref().map_or(ChildVerdict::Unknown, |listing| listing.lookup(name))
     }
 }
 
@@ -251,8 +351,23 @@ impl CachedPath {
     ///
     /// Used both to answer `is_file`/`is_dir` for non-symlinks and by canonicalization to decide
     /// whether to follow a symlink — so the two share a single `lstat` syscall per path.
+    ///
+    /// The parent directory's listing is consulted first (see
+    /// [`CachedPathImpl::child_from_listing`]); when it has a verdict, no syscall is issued
+    /// for this path at all.
     pub(crate) fn link_metadata(&self, fs: &dyn FileSystem) -> Option<FileMetadata> {
-        self.meta.link_or_init(|| fs.symlink_metadata(&self.path).ok())
+        self.meta.link_or_init(|| {
+            if let Some(parent) = self.parent.as_ref().and_then(Weak::upgrade)
+                && let Some(name) = self.path.file_name()
+            {
+                match parent.child_from_listing(name, fs) {
+                    ChildVerdict::Kind(meta) => return Some(meta),
+                    ChildVerdict::Absent => return None,
+                    ChildVerdict::Unknown => {}
+                }
+            }
+            fs.symlink_metadata(&self.path).ok()
+        })
     }
 }
 

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::OsString,
     fs, io,
     path::{Path, PathBuf},
 };
@@ -77,6 +78,23 @@ pub trait FileSystem: Send + Sync {
     ///
     /// See [std::fs::canonicalize]
     fn canonicalize(&self, path: &Path) -> io::Result<PathBuf>;
+
+    /// List a directory's entries with each entry's `lstat`-equivalent kind (`None` when the
+    /// kind is not known from the directory stream and must be queried individually).
+    ///
+    /// This powers the resolver's per-directory listing cache: one `read_dir` answers
+    /// existence and symlink-ness for every child, replacing per-candidate metadata calls.
+    /// The default implementation returns [`io::ErrorKind::Unsupported`], which disables the
+    /// listing cache and keeps per-path metadata behavior for custom file systems.
+    ///
+    /// # Errors
+    ///
+    /// * Any error from reading the directory. Callers treat an error as "listing
+    ///   unavailable", never as "directory empty".
+    fn read_dir(&self, path: &Path) -> io::Result<Vec<(OsString, Option<FileMetadata>)>> {
+        let _ = path;
+        Err(io::Error::from(io::ErrorKind::Unsupported))
+    }
 }
 
 /// Metadata information about a file
@@ -106,6 +124,16 @@ impl FileMetadata {
     #[must_use]
     pub const fn is_symlink(self) -> bool {
         self.is_symlink
+    }
+}
+
+impl From<fs::FileType> for FileMetadata {
+    // `FileType::is_file` is exactly `Metadata::is_file`, and this conversion must classify
+    // paths identically to the `lstat`-based `From<fs::Metadata>` above (a socket/fifo is
+    // neither file nor dir in both). `!is_dir()` would diverge for those.
+    #[allow(clippy::filetype_is_file)]
+    fn from(file_type: fs::FileType) -> Self {
+        Self::new(file_type.is_file(), file_type.is_dir(), file_type.is_symlink())
     }
 }
 
@@ -361,6 +389,26 @@ impl FileSystem for FileSystemOs {
             }
         }
         Self::canonicalize(path)
+    }
+
+    fn read_dir(&self, path: &Path) -> io::Result<Vec<(OsString, Option<FileMetadata>)>> {
+        cfg_if! {
+            if #[cfg(feature = "yarn_pnp")] {
+                if self.yarn_pnp {
+                    // Zip and virtual paths have no directory stream; keep per-path metadata
+                    // behavior under Yarn PnP.
+                    return Err(io::Error::from(io::ErrorKind::Unsupported));
+                }
+            }
+        }
+        // `DirEntry::file_type` comes from the directory stream (`d_type` on unix, find data
+        // on windows); the standard library falls back to a metadata call only when the
+        // filesystem reports an unknown type, matching what a per-entry probe would cost.
+        fs::read_dir(path)?
+            .map(|entry| {
+                entry.map(|entry| (entry.file_name(), entry.file_type().ok().map(Into::into)))
+            })
+            .collect()
     }
 }
 

--- a/src/tests/dir_listing.rs
+++ b/src/tests/dir_listing.rs
@@ -1,0 +1,47 @@
+use crate::{ResolveError, ResolveOptions, Resolver};
+
+#[test]
+fn listing_threshold_crossed_in_one_directory() {
+    let f = super::fixture();
+
+    let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".js".into()],
+        ..ResolveOptions::default()
+    });
+
+    let pass = [
+        ("./a", f.join("a.js")),
+        ("./b", f.join("b.js")),
+        ("./c", f.join("c.js")),
+        ("./main1", f.join("main1.js")),
+        ("./main2", f.join("main2.js")),
+        ("./main3", f.join("main3.js")),
+        ("./lib", f.join("lib.js")),
+        ("./complex", f.join("complex.js")),
+        ("./no", f.join("no.js")),
+        ("./dirOrFile", f.join("dirOrFile.js")),
+        ("./a.js", f.join("a.js")),
+        ("./b.js", f.join("b.js")),
+        ("./c.js", f.join("c.js")),
+        ("./main1.js", f.join("main1.js")),
+        ("./main2.js", f.join("main2.js")),
+        ("./lib/complex1", f.join("lib/complex1.js")),
+        ("./browser-module/lib/browser", f.join("browser-module/lib/browser.js")),
+        ("./main-field-self/index", f.join("main-field-self/index.js")),
+    ];
+
+    for _ in 0..2 {
+        for (request, expected) in &pass {
+            let resolved_path = resolver.resolve(&f, request).map(|r| r.full_path());
+            assert_eq!(resolved_path, Ok(expected.clone()), "{request}");
+        }
+        for request in ["./this-file-does-not-exist", "./a.mjs", "./A_MISSING_FILE.js"] {
+            let resolved_path = resolver.resolve(&f, request).map(|r| r.full_path());
+            assert_eq!(
+                resolved_path,
+                Err(ResolveError::NotFound(request.to_string())),
+                "{request}"
+            );
+        }
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod alias;
 mod browser_field;
 mod builtins;
 mod dependencies;
+mod dir_listing;
 mod dts_resolver;
 mod exports_field;
 mod extension_alias;


### PR DESCRIPTION
## What

Add `FileSystem::read_dir` (defaulted to `Unsupported`, so existing custom file systems compile and keep per-path behavior) and a lazily built per-directory entry listing on `CachedPathImpl`. `link_metadata` consults the parent directory's listing before issuing an `lstat`, and `find_package_json` skips the blind `package.json` open when the listing proves it absent. One `getdirentries` answers existence *and* symlink-ness (`d_type`) for every child of a directory.

**The listing is only built on the 16th cold child probe of a directory.** Cold probe counts per directory are bimodal — path ancestors and one-off package dirs see a handful, while directories a build actually shares (`node_modules` under many bare specifiers, package dirs under many subpath imports, source dirs under extension candidates) see dozens to hundreds. A `read_dir` costs several syscalls plus an entry-map build, so the threshold sits above the first mode: sparse workloads keep **byte-identical syscall traces**, dense ones collapse every further probe into zero syscalls.

## Correctness

- A lookup only reports "definitely absent" when no ASCII case-variant of the name exists in the listing either, so resolution behaves identically on case-sensitive and case-insensitive file systems (macOS/Windows); when a case-variant exists, or the name is non-ASCII (Unicode folding/normalization), or the entry kind is unknown, it falls back to a real `lstat`.
- Symlink kinds come from `d_type`, matching the `lstat` view exactly (sockets/fifos classify as neither file nor dir in both).
- Yarn PnP keeps per-path behavior (`read_dir` returns `Unsupported` under `yarn_pnp`), as do the in-memory test/bench file systems via the trait default.
- Known accepted limitation: Windows 8.3 short names (`LONGFI~1.JS`) in specifiers won't match a listing and would report absent past the threshold — same tradeoff esbuild's listing-based resolver made.
- New `dir_listing` test crosses the threshold in one directory and checks hits, extension misses, and not-founds, twice (cold + warm).

## Measured impact

Counting `FileSystem` wrapper over cold resolutions on the `bench-pm` fixtures; modeled syscalls (lstat=1, successful read=5, failed read=1, read_dir=3+batches):

| workload | before | after | delta |
|---|---|---|---|
| pm 16-request monorepo (npm-flat) | 129 | 129 | **identical trace** |
| pm 16-request monorepo (pnpm-isolated) | 154 | 154 | **identical trace** |
| 644 lodash-es deep imports (npm-flat) | 678 | 57 | **−92%** |
| 644 lodash-es deep imports (pnpm-isolated) | 682 | 61 | **−91%** |

The dense sweep replaces 665 `lstat`s with 35 `lstat`s + 1 `read_dir` (all 644 resolutions verified identical). Sparse workloads execute one extra relaxed `AtomicU8` add per cold probe; warm-path lookups short-circuit on the cached metadata before reaching it. Local wall-time comparison was not possible this session (shared machine, base-vs-base drift exceeded the effect size); CodSpeed's instruction counts should confirm neutrality on `pm/*` since no listing is ever built there.

## Memory

One `OnceCell<Option<Box<DirListing>>>` + `AtomicU8` per cached path (unbuilt = 2 words); a built listing stores name bytes + 1-byte kind per entry, only for directories past the probe threshold.