### PR TITLE
refactor: remove dead code and redundant work

### DIFF
--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -180,20 +180,6 @@ pub enum EnforceExtension {
     Disabled,
 }
 
-impl EnforceExtension {
-    pub fn is_auto(&self) -> bool {
-        *self == Self::Auto
-    }
-
-    pub fn is_enabled(&self) -> bool {
-        *self == Self::Enabled
-    }
-
-    pub fn is_disabled(&self) -> bool {
-        *self == Self::Disabled
-    }
-}
-
 /// Alias Value for [ResolveOptions::alias] and [ResolveOptions::fallback].
 /// Use struct because napi don't support structured union now
 #[napi(object)]

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -140,18 +140,6 @@ impl CompiledAliasEntry {
 }
 
 impl ResolverImpl {
-    pub(super) fn load_alias_by_options(
-        &self,
-        cached_path: &CachedPath,
-        specifier: &str,
-        aliases: &Alias,
-        tsconfig: Option<&TsConfig>,
-        ctx: &mut Ctx,
-    ) -> Result<Option<CachedPath>, ResolveError> {
-        let compiled_aliases = compile_alias(aliases);
-        self.load_alias(cached_path, specifier, &compiled_aliases, tsconfig, ctx)
-    }
-
     /// enhanced-resolve: AliasPlugin for [crate::ResolveOptions::alias] and [crate::ResolveOptions::fallback].
     pub(super) fn load_alias(
         &self,

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -67,7 +67,7 @@ impl Cache {
             }
         }
         let parent = path.parent().map(|p| self.value(p));
-        let is_node_modules = path.file_name().as_ref().is_some_and(|&name| name == "node_modules");
+        let is_node_modules = path.file_name().is_some_and(|name| name == "node_modules");
         let inside_node_modules =
             is_node_modules || parent.as_ref().is_some_and(|parent| parent.inside_node_modules);
         let parent_weak = parent.as_ref().map(|p| Arc::downgrade(&p.0));
@@ -303,10 +303,8 @@ impl Cache {
 
         // Cache raw version (callback applied, not built)
         tsconfig.set_should_build(false);
-        let raw_tsconfig = Arc::new(tsconfig.clone());
-        self.tsconfigs_raw.insert(path.to_path_buf(), Arc::clone(&raw_tsconfig));
-
         if root {
+            self.tsconfigs_raw.insert(path.to_path_buf(), Arc::new(tsconfig.clone()));
             // Build and cache built version
             tsconfig.set_should_build(true);
             let tsconfig = Arc::new(tsconfig.build());
@@ -314,7 +312,9 @@ impl Cache {
             Ok(tsconfig)
         } else {
             // Return unbuilt version
-            Ok(raw_tsconfig)
+            let tsconfig = Arc::new(tsconfig);
+            self.tsconfigs_raw.insert(path.to_path_buf(), Arc::clone(&tsconfig));
+            Ok(tsconfig)
         }
     }
 

--- a/src/dts_resolver.rs
+++ b/src/dts_resolver.rs
@@ -55,13 +55,6 @@ impl Extensions {
     }
 }
 
-impl std::ops::BitOr for Extensions {
-    type Output = Self;
-    fn bitor(self, rhs: Self) -> Self {
-        self.union(rhs)
-    }
-}
-
 impl std::ops::BitAnd for Extensions {
     type Output = Self;
     fn bitand(self, rhs: Self) -> Self {
@@ -123,7 +116,7 @@ impl ResolverImpl {
         // 1. tsconfig paths (non-relative only)
         if !specifier.starts_with('.')
             && !specifier.starts_with('/')
-            && let Some(path) = self.dts_resolve_tsconfig_paths(&cached_dir, specifier, &mut ctx)?
+            && let Some(path) = self.dts_resolve_tsconfig_paths(specifier, &mut ctx)?
         {
             return self.dts_finalize(&path, &mut ctx);
         }
@@ -371,6 +364,27 @@ impl ResolverImpl {
         if self.is_file(&candidate, ctx) { Some(candidate) } else { None }
     }
 
+    /// Package entry for directory resolution: `typings`/`types`, falling back to `main`.
+    fn dts_package_entry<'a>(
+        pkg: &'a PackageJson,
+        extensions: Extensions,
+        main_fields: &'a [String],
+    ) -> Option<&'a str> {
+        let mut entry = if extensions.contains(Extensions::DECLARATION) {
+            pkg.typings().or_else(|| pkg.types())
+        } else {
+            None
+        };
+        if entry.is_none()
+            && extensions.intersects(
+                Extensions::TYPESCRIPT.union(Extensions::JAVASCRIPT).union(Extensions::DECLARATION),
+            )
+        {
+            entry = pkg.main_fields(main_fields).next();
+        }
+        entry
+    }
+
     /// TS: `loadNodeModuleFromDirectoryWorker`
     fn dts_resolve_as_directory(
         &self,
@@ -389,20 +403,7 @@ impl ResolverImpl {
         if let Some(ref pkg) = pkg
             && let Some(version_paths) = Self::dts_get_matching_version_paths(pkg)
         {
-            let mut entry = if extensions.contains(Extensions::DECLARATION) {
-                pkg.typings().or_else(|| pkg.types())
-            } else {
-                None
-            };
-            if entry.is_none()
-                && extensions.intersects(
-                    Extensions::TYPESCRIPT
-                        .union(Extensions::JAVASCRIPT)
-                        .union(Extensions::DECLARATION),
-                )
-            {
-                entry = pkg.main_fields(&main_fields).next();
-            }
+            let entry = Self::dts_package_entry(pkg, extensions, &main_fields);
 
             // TS uses getRelativePathFromDirectory to compute the specifier,
             // which strips the "./" prefix from package.json entry values.
@@ -419,38 +420,24 @@ impl ResolverImpl {
         }
 
         // Determine entry file (types/typings/main)
-        if let Some(ref pkg) = pkg {
-            let mut entry = if extensions.contains(Extensions::DECLARATION) {
-                pkg.typings().or_else(|| pkg.types())
+        if let Some(ref pkg) = pkg
+            && let Some(entry_str) = Self::dts_package_entry(pkg, extensions, &main_fields)
+        {
+            // TS: "Even if extensions is DtsOnly, we can still look up a .ts file
+            // as a result of package.json 'types'"
+            let expanded = if extensions == Extensions::DECLARATION {
+                Extensions::TYPESCRIPT.union(Extensions::DECLARATION)
             } else {
-                None
+                extensions
             };
-            if entry.is_none()
-                && extensions.intersects(
-                    Extensions::TYPESCRIPT
-                        .union(Extensions::JAVASCRIPT)
-                        .union(Extensions::DECLARATION),
-                )
-            {
-                entry = pkg.main_fields(&main_fields).next();
+            let entry_path = candidate.normalize_with(entry_str, &self.cache);
+            if let Some(path) = self.dts_resolve_as_file(expanded, &entry_path, ctx) {
+                return Ok(Some(path));
             }
-            if let Some(entry_str) = entry {
-                // TS: "Even if extensions is DtsOnly, we can still look up a .ts file
-                // as a result of package.json 'types'"
-                let expanded = if extensions == Extensions::DECLARATION {
-                    Extensions::TYPESCRIPT.union(Extensions::DECLARATION)
-                } else {
-                    extensions
-                };
-                let entry_path = candidate.normalize_with(entry_str, &self.cache);
-                if let Some(path) = self.dts_resolve_as_file(expanded, &entry_path, ctx) {
+            if self.is_dir(&entry_path, ctx) {
+                let index = entry_path.push("index", &self.cache);
+                if let Some(path) = self.dts_resolve_as_file(expanded, &index, ctx) {
                     return Ok(Some(path));
-                }
-                if self.is_dir(&entry_path, ctx) {
-                    let index = entry_path.push("index", &self.cache);
-                    if let Some(path) = self.dts_resolve_as_file(expanded, &index, ctx) {
-                        return Ok(Some(path));
-                    }
                 }
             }
         }
@@ -704,12 +691,7 @@ impl ResolverImpl {
 
     // -------- tsconfig paths --------
 
-    fn dts_resolve_tsconfig_paths(
-        &self,
-        _cached_path: &CachedPath,
-        specifier: &str,
-        ctx: &mut Ctx,
-    ) -> ResolveResult {
+    fn dts_resolve_tsconfig_paths(&self, specifier: &str, ctx: &mut Ctx) -> ResolveResult {
         // Reuse the existing tsconfig resolution
         let tsconfig = match &self.options.tsconfig {
             Some(crate::TsconfigDiscovery::Manual(o)) => self.find_tsconfig_manual(o)?,

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -371,7 +371,6 @@ fn metadata() {
         format!("{meta:?}"),
         "FileMetadata { is_file: true, is_dir: true, is_symlink: true }"
     );
-    let _ = meta;
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ pub struct ResolverImpl {
     options: ResolveOptions,
     cache: Arc<Cache>,
     alias: CompiledAlias,
+    fallback: CompiledAlias,
 }
 
 /// Generic implementation of the resolver, can be configured by the [Cache] trait
@@ -161,6 +162,7 @@ impl<Fs: FileSystem + 'static> ResolverGeneric<Fs> {
     pub fn new(options: ResolveOptions) -> Self {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
+        let fallback = compile_alias(&options.fallback);
         cfg_if::cfg_if! {
             if #[cfg(feature = "yarn_pnp")] {
                 let fs = Fs::new(options.yarn_pnp);
@@ -169,38 +171,37 @@ impl<Fs: FileSystem + 'static> ResolverGeneric<Fs> {
             }
         }
         let cache = Arc::new(Cache::new(Arc::new(fs) as Arc<dyn FileSystem>));
-        let inner = ResolverImpl { options, cache, alias };
+        let inner = ResolverImpl { options, cache, alias, fallback };
         Self { inner, _marker: std::marker::PhantomData }
     }
 
     pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
+        let fallback = compile_alias(&options.fallback);
         let cache = Arc::new(Cache::new(Arc::new(file_system) as Arc<dyn FileSystem>));
-        let inner = ResolverImpl { options, cache, alias };
+        let inner = ResolverImpl { options, cache, alias, fallback };
         Self { inner, _marker: std::marker::PhantomData }
     }
 
     /// Clone the resolver using the same underlying cache.
-    #[allow(clippy::unused_self)]
     #[must_use]
     pub fn clone_with_options(&self, options: ResolveOptions) -> Self {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
+        let fallback = compile_alias(&options.fallback);
         cfg_if::cfg_if! {
             if #[cfg(feature = "yarn_pnp")] {
-                let cache = if (options.yarn_pnp && !self.inner.options.yarn_pnp)
-                    || (!options.yarn_pnp && self.inner.options.yarn_pnp)
-                {
-                    Arc::new(Cache::new(Arc::new(Fs::new(options.yarn_pnp)) as Arc<dyn FileSystem>))
-                } else {
+                let cache = if options.yarn_pnp == self.inner.options.yarn_pnp {
                     Arc::clone(&self.inner.cache)
+                } else {
+                    Arc::new(Cache::new(Arc::new(Fs::new(options.yarn_pnp)) as Arc<dyn FileSystem>))
                 };
             } else {
                 let cache = Arc::clone(&self.inner.cache);
             }
         }
-        let inner = ResolverImpl { options, cache, alias };
+        let inner = ResolverImpl { options, cache, alias, fallback };
         Self { inner, _marker: std::marker::PhantomData }
     }
 }
@@ -496,14 +497,8 @@ impl ResolverImpl {
                 return Err(err);
             }
             // enhanced-resolve: try fallback
-            self.load_alias_by_options(
-                cached_path,
-                specifier,
-                &self.options.fallback,
-                tsconfig,
-                ctx,
-            )
-            .and_then(|value| value.ok_or(err))
+            self.load_alias(cached_path, specifier, &self.fallback, tsconfig, ctx)
+                .and_then(|value| value.ok_or(err))
         })
     }
 
@@ -598,7 +593,7 @@ impl ResolverImpl {
         debug_assert_eq!(specifier.chars().next(), Some('#'));
         // a. LOAD_PACKAGE_IMPORTS(X, dirname(Y))
         self.load_package_imports(cached_path, specifier, tsconfig, ctx)?
-            .map_or_else(|| Err(ResolveError::NotFound(specifier.to_string())), Ok)
+            .ok_or_else(|| ResolveError::NotFound(specifier.to_string()))
     }
 
     fn require_bare(
@@ -683,21 +678,18 @@ impl ResolverImpl {
         // it's kind of bug feature
         if specifier.contains("/../..") || specifier.contains("../../") {
             let path = Path::new(specifier).normalize_relative();
-            let mut owned = path.to_string_lossy().into_owned();
+            let mut normalized_specifier = path.to_string_lossy().into_owned();
 
             if specifier.ends_with('/') {
-                owned += "/";
+                normalized_specifier += "/";
             }
 
-            let specifier_owned = Some(owned);
-            let normalized_specifier = specifier_owned.as_deref().unwrap();
-
-            let (package_name, subpath) = Self::parse_package_specifier(normalized_specifier);
+            let (package_name, subpath) = Self::parse_package_specifier(&normalized_specifier);
 
             if package_name == ".."
                 && let Some(path) = self.load_node_modules(
                     cached_path,
-                    normalized_specifier,
+                    &normalized_specifier,
                     package_name,
                     subpath,
                     tsconfig,
@@ -1836,7 +1828,7 @@ impl ResolverImpl {
                 });
             }
             // 2. For each item targetValue in target, do
-            for (i, target_value) in targets.iter().enumerate() {
+            for target_value in targets.iter() {
                 // 1. Let resolved be the result of PACKAGE_TARGET_RESOLVE( packageURL, targetValue, patternMatch, isImports, conditions), continuing the loop on any Invalid Package Target error.
                 let resolved = self.package_target_resolve(
                     package_url,
@@ -1849,18 +1841,14 @@ impl ResolverImpl {
                     ctx,
                 );
 
-                if resolved.is_err() && i == targets.len() {
-                    return resolved;
-                }
-
                 // 2. If resolved is undefined, continue the loop.
+                // Note: errors are treated the same as undefined - fall through to the next
+                // array entry, and return null if the array is exhausted.
                 if let Ok(Some(path)) = resolved {
                     // 3. Return resolved.
                     return Ok(Some(path));
                 }
             }
-            // 3. Return or throw the last fallback resolution null return or error.
-            // Note: see `resolved.is_err() && i == targets.len()`
         }
         // 4. Otherwise, if target is null, return null.
         Ok(None)

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -16,6 +16,7 @@ pub enum ModuleType {
 }
 
 /// The final path resolution with optional `?query` and `#fragment`
+#[derive(Clone)]
 pub struct Resolution {
     pub(crate) path: PathBuf,
 
@@ -36,18 +37,6 @@ pub struct Resolution {
     ///
     ///  The algorithm uses the file extension or finds the closest `package.json` with the `type` field.
     pub(crate) module_type: Option<ModuleType>,
-}
-
-impl Clone for Resolution {
-    fn clone(&self) -> Self {
-        Self {
-            path: self.path.clone(),
-            query: self.query.clone(),
-            fragment: self.fragment.clone(),
-            package_json: self.package_json.clone(),
-            module_type: self.module_type,
-        }
-    }
 }
 
 impl fmt::Debug for Resolution {

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -15,12 +15,12 @@ impl<'a> Specifier<'a> {
     }
 
     pub fn parse(specifier: &'a str) -> Result<Self, SpecifierError> {
+        #[cold]
+        fn empty_error(specifier: &str) -> SpecifierError {
+            SpecifierError::Empty(specifier.to_string())
+        }
         if specifier.is_empty() {
-            #[cold]
-            fn empty_specifier_error(specifier: &str) -> SpecifierError {
-                SpecifierError::Empty(specifier.to_string())
-            }
-            return Err(empty_specifier_error(specifier));
+            return Err(empty_error(specifier));
         }
         let offset = match specifier.as_bytes()[0] {
             b'/' | b'.' | b'#' => 1,
@@ -28,11 +28,7 @@ impl<'a> Specifier<'a> {
         };
         let (path, query, fragment) = Self::parse_query_fragment(specifier, offset);
         if path.is_empty() {
-            #[cold]
-            fn empty_path_error(specifier: &str) -> SpecifierError {
-                SpecifierError::Empty(specifier.to_string())
-            }
-            return Err(empty_path_error(specifier));
+            return Err(empty_error(specifier));
         }
         Ok(Self { path, query, fragment })
     }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -37,7 +37,7 @@ pub struct ProjectReference {
 #[serde(rename_all = "camelCase")]
 pub struct TsConfig {
     /// Whether this is the caller tsconfig.
-    /// Used for final template variable substitution when all configs are extended and merged.
+    /// `false` for configs loaded through `extends`.
     #[serde(skip)]
     pub root: bool,
 
@@ -139,7 +139,7 @@ impl TsConfig {
     }
 
     /// Whether this is the caller tsconfig.
-    /// Used for final template variable substitution when all configs are extended and merged.
+    /// `false` for configs loaded through `extends`.
     #[must_use]
     pub fn root(&self) -> bool {
         self.root

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -415,9 +415,10 @@ impl ResolverImpl {
         }
         .sanitize();
         let alias = crate::alias::compile_alias(&options.alias);
+        let fallback = crate::alias::compile_alias(&options.fallback);
         // Extends-resolution never toggles `yarn_pnp`, so reuse the same cache (and thus the
         // same underlying filesystem) rather than rebuilding it.
-        Self { options, cache: Arc::clone(&self.cache), alias }
+        Self { options, cache: Arc::clone(&self.cache), alias, fallback }
     }
 
     fn get_extended_tsconfig_path(


### PR DESCRIPTION
Behavior-preserving cleanup pass across the crate (+74/−145). Verified with clippy (all features/targets), `cargo test` + `--all-features`, s390x check, docs with `-D warnings`, Node tests, and the Yarn PnP fixture tests.

## Dead code

- `package_target_resolve`: the `i == targets.len()` branch could never execute (`i` comes from `enumerate()` so it maxes out at `len − 1`), meaning errors from array entries always fall through to the next entry. Removed the branch and corrected the comment to describe the actual behavior. If the original intent was Node's `lastException` semantics (propagate the last entry's error), that would be `i + 1 == targets.len()` — deliberately not done here to keep this PR behavior-preserving.
- `impl BitOr for Extensions` in the dts resolver: never invoked, all unions go through `.union()`.
- `dts_resolve_tsconfig_paths`: unused `_cached_path` parameter.
- napi `EnforceExtension::{is_auto,is_enabled,is_disabled}`: zero callers and not `#[napi]`-exported.
- A no-op `let _ = meta;` in the `metadata` test.

## Redundant work

- `fallback` aliases are now compiled once at construction into `ResolverImpl.fallback` (mirroring `alias`) instead of `compile_alias` re-running on every failed resolution; `load_alias_by_options` is deleted.
- `Cache::get_tsconfig` no longer deep-clones the `TsConfig` on the non-root (`extends`) path, where the clone was immediately dropped. The clone only ever mattered for the root branch because `build()` consumes `self`.

## Simplifications

- The byte-identical typings/types/main entry-selection block duplicated twice in `dts_resolve_as_directory` is factored into `dts_package_entry`, and the nested `if let` collapsed into a let-chain.
- `clone_with_options`: `(a && !b) || (!a && b)` → plain `==` comparison; its stale `#[allow(clippy::unused_self)]` is removed.
- `Resolution` uses `#[derive(Clone)]` (the manual impl was field-for-field identical), the two identical `#[cold]` error constructors in `Specifier::parse` are merged, `require_hash` uses `ok_or_else` instead of `map_or_else(|| Err(..), Ok)`, plus a redundant `.as_ref()` on `file_name()` and a `Some(x).as_deref().unwrap()` dance are gone.
- Stale doc on `TsConfig::root` fixed: template-variable substitution is driven by `should_build` now, not `root`.

## Noticed but intentionally not changed (behavior changes, separate discussion)

- The escaped-`\0#` path in `Specifier::parse_query_fragment` rebuilds the string with `s.push(b as char)` over raw bytes, which garbles multi-byte UTF-8 on that rare branch.
- The project-references extends loop in `extend_tsconfig` skips the `with_extended_file` circular-extend guard that `load_tsconfig` applies.