### PR TITLE
refactor(alias): compile fallback aliases once at construction

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -140,18 +140,6 @@ impl CompiledAliasEntry {
 }
 
 impl ResolverImpl {
-    pub(super) fn load_alias_by_options(
-        &self,
-        cached_path: &CachedPath,
-        specifier: &str,
-        aliases: &Alias,
-        tsconfig: Option<&TsConfig>,
-        ctx: &mut Ctx,
-    ) -> Result<Option<CachedPath>, ResolveError> {
-        let compiled_aliases = compile_alias(aliases);
-        self.load_alias(cached_path, specifier, &compiled_aliases, tsconfig, ctx)
-    }
-
     /// enhanced-resolve: AliasPlugin for [crate::ResolveOptions::alias] and [crate::ResolveOptions::fallback].
     pub(super) fn load_alias(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ pub struct ResolverImpl {
     options: ResolveOptions,
     cache: Arc<Cache>,
     alias: CompiledAlias,
+    fallback: CompiledAlias,
 }
 
 /// Generic implementation of the resolver, can be configured by the [Cache] trait
@@ -161,6 +162,7 @@ impl<Fs: FileSystem + 'static> ResolverGeneric<Fs> {
     pub fn new(options: ResolveOptions) -> Self {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
+        let fallback = compile_alias(&options.fallback);
         cfg_if::cfg_if! {
             if #[cfg(feature = "yarn_pnp")] {
                 let fs = Fs::new(options.yarn_pnp);
@@ -169,38 +171,37 @@ impl<Fs: FileSystem + 'static> ResolverGeneric<Fs> {
             }
         }
         let cache = Arc::new(Cache::new(Arc::new(fs) as Arc<dyn FileSystem>));
-        let inner = ResolverImpl { options, cache, alias };
+        let inner = ResolverImpl { options, cache, alias, fallback };
         Self { inner, _marker: std::marker::PhantomData }
     }
 
     pub fn new_with_file_system(file_system: Fs, options: ResolveOptions) -> Self {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
+        let fallback = compile_alias(&options.fallback);
         let cache = Arc::new(Cache::new(Arc::new(file_system) as Arc<dyn FileSystem>));
-        let inner = ResolverImpl { options, cache, alias };
+        let inner = ResolverImpl { options, cache, alias, fallback };
         Self { inner, _marker: std::marker::PhantomData }
     }
 
     /// Clone the resolver using the same underlying cache.
-    #[allow(clippy::unused_self)]
     #[must_use]
     pub fn clone_with_options(&self, options: ResolveOptions) -> Self {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
+        let fallback = compile_alias(&options.fallback);
         cfg_if::cfg_if! {
             if #[cfg(feature = "yarn_pnp")] {
-                let cache = if (options.yarn_pnp && !self.inner.options.yarn_pnp)
-                    || (!options.yarn_pnp && self.inner.options.yarn_pnp)
-                {
-                    Arc::new(Cache::new(Arc::new(Fs::new(options.yarn_pnp)) as Arc<dyn FileSystem>))
-                } else {
+                let cache = if options.yarn_pnp == self.inner.options.yarn_pnp {
                     Arc::clone(&self.inner.cache)
+                } else {
+                    Arc::new(Cache::new(Arc::new(Fs::new(options.yarn_pnp)) as Arc<dyn FileSystem>))
                 };
             } else {
                 let cache = Arc::clone(&self.inner.cache);
             }
         }
-        let inner = ResolverImpl { options, cache, alias };
+        let inner = ResolverImpl { options, cache, alias, fallback };
         Self { inner, _marker: std::marker::PhantomData }
     }
 }
@@ -496,14 +497,8 @@ impl ResolverImpl {
                 return Err(err);
             }
             // enhanced-resolve: try fallback
-            self.load_alias_by_options(
-                cached_path,
-                specifier,
-                &self.options.fallback,
-                tsconfig,
-                ctx,
-            )
-            .and_then(|value| value.ok_or(err))
+            self.load_alias(cached_path, specifier, &self.fallback, tsconfig, ctx)
+                .and_then(|value| value.ok_or(err))
         })
     }
 

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -415,9 +415,10 @@ impl ResolverImpl {
         }
         .sanitize();
         let alias = crate::alias::compile_alias(&options.alias);
+        let fallback = crate::alias::compile_alias(&options.fallback);
         // Extends-resolution never toggles `yarn_pnp`, so reuse the same cache (and thus the
         // same underlying filesystem) rather than rebuilding it.
-        Self { options, cache: Arc::clone(&self.cache), alias }
+        Self { options, cache: Arc::clone(&self.cache), alias, fallback }
     }
 
     fn get_extended_tsconfig_path(


### PR DESCRIPTION
`load_alias_by_options` re-ran `compile_alias` (allocating and cloning every `AliasValue`) on **every failed resolution**, while the primary `alias` list is compiled once at construction. This compiles `fallback` once into a `ResolverImpl.fallback` field, uses `load_alias` directly at the fallback call site, and deletes `load_alias_by_options` (its only caller). `compile_alias` is pure over the post-`sanitize` options, so behavior is identical; with an empty fallback list the new field is an empty box + 32 zero bytes.

Also tidies `clone_with_options` while touching it: the `(a && !b) || (!a && b)` yarn_pnp cache check becomes a plain `==` comparison, and the stale `#[allow(clippy::unused_self)]` is removed (both cfg branches use `self`).

Split out of #1263.