### PR TITLE
refactor(tsconfig): skip TsConfig deep clone for non-root configs

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -303,10 +303,8 @@ impl Cache {
 
         // Cache raw version (callback applied, not built)
         tsconfig.set_should_build(false);
-        let raw_tsconfig = Arc::new(tsconfig.clone());
-        self.tsconfigs_raw.insert(path.to_path_buf(), Arc::clone(&raw_tsconfig));
-
         if root {
+            self.tsconfigs_raw.insert(path.to_path_buf(), Arc::new(tsconfig.clone()));
             // Build and cache built version
             tsconfig.set_should_build(true);
             let tsconfig = Arc::new(tsconfig.build());
@@ -314,7 +312,9 @@ impl Cache {
             Ok(tsconfig)
         } else {
             // Return unbuilt version
-            Ok(raw_tsconfig)
+            let tsconfig = Arc::new(tsconfig);
+            self.tsconfigs_raw.insert(path.to_path_buf(), Arc::clone(&tsconfig));
+            Ok(tsconfig)
         }
     }
 


### PR DESCRIPTION
`Cache::get_tsconfig` deep-cloned every parsed `TsConfig` before branching on `root`, but the clone only matters in the root branch, where `TsConfig::build(mut self)` consumes the value after the raw version is cached. On the non-root path — taken once per `extends` entry — the original local was dropped unused, so the clone (`CompilerOptions`, three `Option<Vec<PathBuf>>`s, references, paths) was pure waste.

The raw cache still stores the `should_build = false` version and the built cache still stores the built version; returned `Arc`s share the cached instances exactly as before.

Split out of #1263.