### PR TITLE
fix(exports): propagate the last error in array target resolution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1714,6 +1714,7 @@ impl ResolverImpl {
     }
 
     /// PACKAGE_TARGET_RESOLVE(packageURL, target, patternMatch, isImports, conditions)
+    #[allow(clippy::too_many_lines)]
     fn package_target_resolve(
         &self,
         package_url: &CachedPath,
@@ -1849,7 +1850,13 @@ impl ResolverImpl {
                     ctx,
                 );
 
-                if resolved.is_err() && i == targets.len() {
+                // `NotFound` is exempt: it comes from re-resolving a bare `imports` target
+                // through the module system, which enhanced-resolve lets fall through to the
+                // next array entry / a soft failure rather than a hard error.
+                if i + 1 == targets.len()
+                    && let Err(err) = &resolved
+                    && !matches!(err, ResolveError::NotFound(_))
+                {
                     return resolved;
                 }
 
@@ -1860,7 +1867,7 @@ impl ResolverImpl {
                 }
             }
             // 3. Return or throw the last fallback resolution null return or error.
-            // Note: see `resolved.is_err() && i == targets.len()`
+            // Note: see `i + 1 == targets.len()`
         }
         // 4. Otherwise, if target is null, return null.
         Ok(None)

--- a/src/tests/imports_field.rs
+++ b/src/tests/imports_field.rs
@@ -748,6 +748,24 @@ fn test_cases() {
             condition_names: vec!["import", "require"],
         },
         TestCase {
+            name: "invalid target in last array entry",
+            expect: None,
+            imports_field: imports_field(&json!({
+              "#a": ["../invalid.js"]
+            })),
+            request: "#a",
+            condition_names: vec![],
+        },
+        TestCase {
+            name: "invalid target in non-last array entry",
+            expect: Some(vec!["./ok.js"]),
+            imports_field: imports_field(&json!({
+              "#a": ["../invalid.js", "./ok.js"]
+            })),
+            request: "#a",
+            condition_names: vec![],
+        },
+        TestCase {
             name: "mapping to a folder root #1",
             expect: Some(vec![]),
             imports_field: imports_field(&json!({


### PR DESCRIPTION
The "return the last array entry's error" branch in `package_target_resolve` was dead code: `i` comes from `enumerate()`, so `i == targets.len()` could never be true. Errors from array entries were always swallowed like `undefined`, so an invalid target in the last fallback entry surfaced as a generic `PackagePathNotExported` instead of the specific error — despite the comment right below claiming "Return or throw the last fallback resolution null return or error".

This fixes the off-by-one (`i + 1 == targets.len()`) so the last entry's error now propagates, matching the documented intent and Node's `lastException` behavior for arrays.

One deliberate exemption: `ResolveError::NotFound` still falls through. It only arises from re-resolving a bare `imports` target (e.g. `\"#a\": [{\"import\": [\"#b/import.js\"]}]`) through the module system, and enhanced-resolve treats an unresolvable candidate there as a soft failure, not a hard error — the ported "Direct and conditional mapping #4" test pins that behavior. Node would actually throw immediately on any non-`ERR_INVALID_PACKAGE_TARGET` error inside the array loop, which is stricter than enhanced-resolve; the exemption keeps us compatible with the latter.

Adds two imports-field tests: an invalid target in the **last** array entry now errors (previously `Ok(None)`), and an invalid target in a **non-last** entry still falls through to the next entry.

Split out of #1263.