### PR TITLE
chore: miscellaneous small cleanups

### DIFF
--- a/napi/src/options.rs
+++ b/napi/src/options.rs
@@ -180,20 +180,6 @@ pub enum EnforceExtension {
     Disabled,
 }
 
-impl EnforceExtension {
-    pub fn is_auto(&self) -> bool {
-        *self == Self::Auto
-    }
-
-    pub fn is_enabled(&self) -> bool {
-        *self == Self::Enabled
-    }
-
-    pub fn is_disabled(&self) -> bool {
-        *self == Self::Disabled
-    }
-}
-
 /// Alias Value for [ResolveOptions::alias] and [ResolveOptions::fallback].
 /// Use struct because napi don't support structured union now
 #[napi(object)]

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -67,7 +67,7 @@ impl Cache {
             }
         }
         let parent = path.parent().map(|p| self.value(p));
-        let is_node_modules = path.file_name().as_ref().is_some_and(|&name| name == "node_modules");
+        let is_node_modules = path.file_name().is_some_and(|name| name == "node_modules");
         let inside_node_modules =
             is_node_modules || parent.as_ref().is_some_and(|parent| parent.inside_node_modules);
         let parent_weak = parent.as_ref().map(|p| Arc::downgrade(&p.0));

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -371,7 +371,6 @@ fn metadata() {
         format!("{meta:?}"),
         "FileMetadata { is_file: true, is_dir: true, is_symlink: true }"
     );
-    let _ = meta;
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -598,7 +598,7 @@ impl ResolverImpl {
         debug_assert_eq!(specifier.chars().next(), Some('#'));
         // a. LOAD_PACKAGE_IMPORTS(X, dirname(Y))
         self.load_package_imports(cached_path, specifier, tsconfig, ctx)?
-            .map_or_else(|| Err(ResolveError::NotFound(specifier.to_string())), Ok)
+            .ok_or_else(|| ResolveError::NotFound(specifier.to_string()))
     }
 
     fn require_bare(
@@ -683,21 +683,18 @@ impl ResolverImpl {
         // it's kind of bug feature
         if specifier.contains("/../..") || specifier.contains("../../") {
             let path = Path::new(specifier).normalize_relative();
-            let mut owned = path.to_string_lossy().into_owned();
+            let mut normalized_specifier = path.to_string_lossy().into_owned();
 
             if specifier.ends_with('/') {
-                owned += "/";
+                normalized_specifier += "/";
             }
 
-            let specifier_owned = Some(owned);
-            let normalized_specifier = specifier_owned.as_deref().unwrap();
-
-            let (package_name, subpath) = Self::parse_package_specifier(normalized_specifier);
+            let (package_name, subpath) = Self::parse_package_specifier(&normalized_specifier);
 
             if package_name == ".."
                 && let Some(path) = self.load_node_modules(
                     cached_path,
-                    normalized_specifier,
+                    &normalized_specifier,
                     package_name,
                     subpath,
                     tsconfig,

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -16,6 +16,7 @@ pub enum ModuleType {
 }
 
 /// The final path resolution with optional `?query` and `#fragment`
+#[derive(Clone)]
 pub struct Resolution {
     pub(crate) path: PathBuf,
 
@@ -36,18 +37,6 @@ pub struct Resolution {
     ///
     ///  The algorithm uses the file extension or finds the closest `package.json` with the `type` field.
     pub(crate) module_type: Option<ModuleType>,
-}
-
-impl Clone for Resolution {
-    fn clone(&self) -> Self {
-        Self {
-            path: self.path.clone(),
-            query: self.query.clone(),
-            fragment: self.fragment.clone(),
-            package_json: self.package_json.clone(),
-            module_type: self.module_type,
-        }
-    }
 }
 
 impl fmt::Debug for Resolution {

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -15,12 +15,12 @@ impl<'a> Specifier<'a> {
     }
 
     pub fn parse(specifier: &'a str) -> Result<Self, SpecifierError> {
+        #[cold]
+        fn empty_error(specifier: &str) -> SpecifierError {
+            SpecifierError::Empty(specifier.to_string())
+        }
         if specifier.is_empty() {
-            #[cold]
-            fn empty_specifier_error(specifier: &str) -> SpecifierError {
-                SpecifierError::Empty(specifier.to_string())
-            }
-            return Err(empty_specifier_error(specifier));
+            return Err(empty_error(specifier));
         }
         let offset = match specifier.as_bytes()[0] {
             b'/' | b'.' | b'#' => 1,
@@ -28,11 +28,7 @@ impl<'a> Specifier<'a> {
         };
         let (path, query, fragment) = Self::parse_query_fragment(specifier, offset);
         if path.is_empty() {
-            #[cold]
-            fn empty_path_error(specifier: &str) -> SpecifierError {
-                SpecifierError::Empty(specifier.to_string())
-            }
-            return Err(empty_path_error(specifier));
+            return Err(empty_error(specifier));
         }
         Ok(Self { path, query, fragment })
     }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -37,7 +37,7 @@ pub struct ProjectReference {
 #[serde(rename_all = "camelCase")]
 pub struct TsConfig {
     /// Whether this is the caller tsconfig.
-    /// Used for final template variable substitution when all configs are extended and merged.
+    /// `false` for configs loaded through `extends`.
     #[serde(skip)]
     pub root: bool,
 
@@ -139,7 +139,7 @@ impl TsConfig {
     }
 
     /// Whether this is the caller tsconfig.
-    /// Used for final template variable substitution when all configs are extended and merged.
+    /// `false` for configs loaded through `extends`.
     #[must_use]
     pub fn root(&self) -> bool {
         self.root


### PR DESCRIPTION
A batch of tiny, independent cleanups:

- Derive `Clone` for `Resolution` — the manual impl was field-for-field identical to what the derive produces (`Debug`/`PartialEq` stay manual, they're genuinely custom).
- Merge the two byte-identical `#[cold]` empty-error constructors in `Specifier::parse` into one.
- `require_hash`: `.ok_or_else(..)` instead of `.map_or_else(|| Err(..), Ok)`.
- Remove a pointless `Some(owned).as_deref().unwrap()` dance in the legacy `jest-runner-../..` fallback path.
- Drop a redundant `.as_ref()` on `file_name()` in `Cache::value` (`&OsStr == &str` already works via `OsStr: PartialEq<str>`).
- Remove the napi `EnforceExtension::{is_auto,is_enabled,is_disabled}` helpers — zero callers anywhere in the repo and not `#[napi]`-exported, so they never reached JS.
- Remove a no-op `let _ = meta;` in the `metadata` test.
- Fix the stale doc comment on `TsConfig::root` / `root()": it claimed the field drives final template-variable substitution, but that's keyed off `should_build` now; `root` just records whether the config is the caller's (vs loaded through `extends`).

Split out of #1263.