### PR TITLE
refactor: deduplicate cross-file helpers, drop stale lint allows

### DIFF
--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -7,13 +7,15 @@ use std::{
     sync::{Arc, Weak},
 };
 
-use cfg_if::cfg_if;
 use once_cell::sync::OnceCell as OnceLock;
 
 use super::cache_impl::Cache;
 use super::cached_meta::CachedMeta;
 use super::thread_local::SCRATCH_PATH;
-use crate::{FileMetadata, FileSystem, PackageJson, TsConfig, context::ResolveContext as Ctx};
+use crate::{
+    FileMetadata, FileSystem, PackageJson, TsConfig, context::ResolveContext as Ctx,
+    path::push_normalized_component,
+};
 
 #[derive(Clone)]
 pub struct CachedPath(pub Arc<CachedPathImpl>);
@@ -220,29 +222,6 @@ impl CachedPath {
     #[cfg(not(windows))]
     pub(crate) fn normalize_root(&self, _cache: &Cache) -> Self {
         self.clone()
-    }
-}
-
-/// `Prefix`/`RootDir` can only be a `Components` iterator's first item, which the caller consumes
-/// before reaching here, so those arms are unreachable.
-#[inline]
-fn push_normalized_component(path: &mut PathBuf, component: Component<'_>) {
-    match component {
-        Component::CurDir => {}
-        Component::ParentDir => {
-            path.pop();
-        }
-        Component::Normal(c) => {
-            cfg_if! {
-                if #[cfg(target_family = "wasm")] {
-                    // Need to trim the extra \0 introduces by https://github.com/nodejs/uvwasi/issues/262
-                    path.push(c.to_string_lossy().trim_end_matches('\0'));
-                } else {
-                    path.push(c);
-                }
-            }
-        }
-        Component::Prefix(..) | Component::RootDir => unreachable!(),
     }
 }
 

--- a/src/dts_resolver.rs
+++ b/src/dts_resolver.rs
@@ -250,7 +250,6 @@ impl ResolverImpl {
     }
 
     /// TS: `tryAddingExtensions`
-    #[allow(clippy::too_many_lines)]
     fn dts_try_extensions(
         &self,
         base: &CachedPath,
@@ -693,10 +692,7 @@ impl ResolverImpl {
 
     fn dts_resolve_tsconfig_paths(&self, specifier: &str, ctx: &mut Ctx) -> ResolveResult {
         // Reuse the existing tsconfig resolution
-        let tsconfig = match &self.options.tsconfig {
-            Some(crate::TsconfigDiscovery::Manual(o)) => self.find_tsconfig_manual(o)?,
-            _ => None,
-        };
+        let tsconfig = self.manual_tsconfig()?;
 
         let Some(tsconfig) = tsconfig.as_deref() else {
             return Ok(None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,10 +247,7 @@ impl ResolverImpl {
     ) -> Result<Resolution, ResolveError> {
         let mut ctx = Ctx::default();
         let path = directory.as_ref();
-        let tsconfig = match &self.options.tsconfig {
-            Some(TsconfigDiscovery::Manual(o)) => self.find_tsconfig_manual(o)?,
-            _ => None,
-        };
+        let tsconfig = self.manual_tsconfig()?;
         self.resolve_tracing(path, specifier, tsconfig.as_deref(), &mut ctx)
     }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -5,6 +5,8 @@
 //! * [normalize_path](https://docs.rs/normalize-path)
 use std::path::{Component, Path, PathBuf};
 
+use cfg_if::cfg_if;
+
 pub const SLASH_START: &[char; 2] = &['/', '\\'];
 
 /// Extension trait to add path normalization to std's [`Path`].
@@ -121,14 +123,21 @@ fn normalize_with_impl(base: &Path, subpath: &Path) -> PathBuf {
 /// `Prefix`/`RootDir` can only be a `Components` iterator's first item, which callers consume
 /// before reaching here, so those arms are unreachable.
 #[inline]
-fn push_normalized_component(ret: &mut PathBuf, component: Component<'_>) {
+pub fn push_normalized_component(ret: &mut PathBuf, component: Component<'_>) {
     match component {
         Component::CurDir => {}
         Component::ParentDir => {
             ret.pop();
         }
         Component::Normal(c) => {
-            ret.push(c);
+            cfg_if! {
+                if #[cfg(target_family = "wasm")] {
+                    // Need to trim the extra \0 introduces by https://github.com/nodejs/uvwasi/issues/262
+                    ret.push(c.to_string_lossy().trim_end_matches('\0'));
+                } else {
+                    ret.push(c);
+                }
+            }
         }
         Component::Prefix(..) | Component::RootDir => unreachable!(),
     }

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -203,7 +203,7 @@ impl TsConfig {
     }
 
     /// Inherits settings from the given tsconfig into `self`.
-    #[allow(clippy::cognitive_complexity, clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines)]
     pub(crate) fn extend_tsconfig(&mut self, tsconfig: &Self) {
         if self.files.is_none()
             && let Some(files) = &tsconfig.files

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -141,7 +141,16 @@ impl ResolverImpl {
         Ok(None)
     }
 
-    pub(crate) fn find_tsconfig_manual(
+    /// The manually configured tsconfig ([`TsconfigDiscovery::Manual`]); `Auto` discovery is
+    /// deliberately skipped.
+    pub(crate) fn manual_tsconfig(&self) -> Result<Option<Arc<TsConfig>>, ResolveError> {
+        match &self.options.tsconfig {
+            Some(TsconfigDiscovery::Manual(o)) => self.find_tsconfig_manual(o),
+            _ => Ok(None),
+        }
+    }
+
+    fn find_tsconfig_manual(
         &self,
         tsconfig_options: &TsconfigOptions,
     ) -> Result<Option<Arc<TsConfig>>, ResolveError> {


### PR DESCRIPTION
Two cross-file dedups plus stale-allow removal:

- **`push_normalized_component`** existed twice — `path.rs` and `cache/cached_path.rs` — identical except the cached-path copy trims the trailing `\0` that uvwasi appends to directory entries on wasm ([nodejs/uvwasi#262](https://github.com/nodejs/uvwasi/issues/262)). This keeps one `pub` wasm-aware version in `path.rs`. Note this means `path.rs` callers (tsconfig path joins) now also get the `\0`-trim on wasm; on native targets the generated code is unchanged, and the helper stays `#[inline]` so the hot `normalize_with` path keeps its codegen.
- **`manual_tsconfig()`**: the "manually configured tsconfig, deliberately skipping `Auto` discovery" match block was duplicated verbatim in `lib.rs` (`resolve`) and `dts_resolver.rs` (`dts_resolve_tsconfig_paths`). One helper in `tsconfig_resolver.rs` now owns it, and `find_tsconfig_manual` drops its `pub(crate)`.
- **Stale allows**: `clippy::cognitive_complexity` on `extend_tsconfig` and `clippy::too_many_lines` on `dts_try_extensions`' neighbor no longer suppress anything (verified by removing them and running the CI clippy command); `extend_tsconfig` keeps `too_many_lines` (139/100).

Part of a second cleanup pass; follows #1264–#1268.