### PR TITLE
chore(bench): move specifier allocation out of the timed symlink loop

### DIFF
--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -180,13 +180,13 @@ fn bench_resolver_memory(c: &mut Criterion) {
         );
     }
 
-    let symlinks_range = 0u32..10000;
+    let symlink_specifiers = (0u32..10000).map(|i| format!("./file{i}")).collect::<Vec<_>>();
 
-    for i in symlinks_range.clone() {
-        assert!(
-            oxc_resolver_memory().resolve(&symlink_test_dir, &format!("./file{i}")).is_ok(),
-            "file{i}.js"
-        );
+    {
+        let oxc_resolver = oxc_resolver_memory();
+        for specifier in &symlink_specifiers {
+            assert!(oxc_resolver.resolve(&symlink_test_dir, specifier).is_ok(), "{specifier}");
+        }
     }
 
     let mut group = c.benchmark_group("resolver_memory");
@@ -220,15 +220,12 @@ fn bench_resolver_memory(c: &mut Criterion) {
 
     group.bench_with_input(
         BenchmarkId::from_parameter("resolve from symlinks"),
-        &symlinks_range,
-        |b, data| {
+        &symlink_specifiers,
+        |b, specifiers| {
             let oxc_resolver = oxc_resolver_memory();
             b.iter(|| {
-                for i in data.clone() {
-                    assert!(
-                        oxc_resolver.resolve(&symlink_test_dir, &format!("./file{i}")).is_ok(),
-                        "file{i}.js"
-                    );
+                for specifier in specifiers {
+                    _ = oxc_resolver.resolve(&symlink_test_dir, specifier);
                 }
             });
         },
@@ -258,13 +255,13 @@ fn bench_resolver_real(c: &mut Criterion) {
         assert!(oxc_resolver_real().resolve(path, request).is_ok(), "{} {request}", path.display());
     }
 
-    let symlinks_range = 0u32..10000;
+    let symlink_specifiers = (0u32..10000).map(|i| format!("./file{i}")).collect::<Vec<_>>();
 
-    for i in symlinks_range.clone() {
-        assert!(
-            oxc_resolver_real().resolve(&symlink_test_dir, &format!("./file{i}")).is_ok(),
-            "file{i}.js"
-        );
+    {
+        let oxc_resolver = oxc_resolver_real();
+        for specifier in &symlink_specifiers {
+            assert!(oxc_resolver.resolve(&symlink_test_dir, specifier).is_ok(), "{specifier}");
+        }
     }
 
     let mut group = c.benchmark_group("resolver_real");
@@ -289,15 +286,12 @@ fn bench_resolver_real(c: &mut Criterion) {
 
     group.bench_with_input(
         BenchmarkId::from_parameter("resolve from symlinks"),
-        &symlinks_range,
-        |b, data| {
+        &symlink_specifiers,
+        |b, specifiers| {
             let oxc_resolver = oxc_resolver_real();
             b.iter(|| {
-                for i in data.clone() {
-                    assert!(
-                        oxc_resolver.resolve(&symlink_test_dir, &format!("./file{i}")).is_ok(),
-                        "file{i}.js"
-                    );
+                for specifier in specifiers {
+                    _ = oxc_resolver.resolve(&symlink_test_dir, specifier);
                 }
             });
         },


### PR DESCRIPTION
The two "resolve from symlinks" benches did, per timed iteration, 10,000 eager `format!("./file{i}")` allocations plus an `assert!(.. .is_ok())` branch — unlike every sibling bench in the file, which iterates precomputed data and discards results with `_ =`. The asserts also re-checked an invariant already validated once before the benchmark group runs.

This precomputes the specifiers once (mirroring the `find tsconfig` bench's hoisting pattern) and drops the in-loop asserts, so the benches measure symlink resolution rather than resolution + allocation noise. The validation pass also now constructs one resolver instead of 10,000.

**Heads-up:** this will step-change the CodSpeed series for `resolver_memory/resolve from symlinks` and `resolver_real/resolve from symlinks` downward — that's the removed allocation/assert overhead, not a resolver perf change.

Part of a second cleanup pass; follows #1264–#1268.