### PR TITLE
chore: remove test and JS-side leftovers

### DIFF
--- a/napi/test.mjs
+++ b/napi/test.mjs
@@ -25,5 +25,4 @@ const resolver2 = new ResolverFactory({
   extensions: [".mjs"],
 });
 
-// After add `.ts` extension, resolver can resolve `ts` as `ts.ts` now
 assert.deepStrictEqual(resolver2.sync(dir, "./test.mjs").path, path.join(dir, "test.mjs"));

--- a/napi/webcontainer-fallback.js
+++ b/napi/webcontainer-fallback.js
@@ -12,7 +12,6 @@ if (!fs.existsSync(bindingEntry)) {
   fs.rmSync(baseDir, { recursive: true, force: true });
   fs.mkdirSync(baseDir, { recursive: true });
   const bindingPkg = `@oxc-resolver/binding-wasm32-wasi@${version}`;
-  // eslint-disable-next-line: no-console
   console.log(`[oxc-resolver] Downloading ${bindingPkg} on WebContainer...`);
   childProcess.execFileSync('pnpm', ['i', bindingPkg], {
     cwd: baseDir,

--- a/src/tests/alias.rs
+++ b/src/tests/alias.rs
@@ -6,7 +6,6 @@ use crate::{
     AliasValue, PathUtil, Resolution, ResolveContext, ResolveError, ResolveOptions, Resolver,
 };
 
-#[allow(clippy::too_many_lines)]
 #[test]
 #[cfg(not(target_os = "windows"))] // MemoryFS's path separator is always `/` so the test will not pass in windows.
 fn alias() {

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -42,7 +42,6 @@ fn resolve() {
         ("file in module with fragment", f.clone(), "m1/a#fragment", f.join("node_modules/m1/a.js#fragment")),
         ("file in module with fragment and query", f.clone(), "m1/a#fragment?query", f.join("node_modules/m1/a.js#fragment?query")),
         ("file in module with query and fragment", f.clone(), "m1/a?#fragment", f.join("node_modules/m1/a.js?#fragment")),
-        ("file in module with query and fragment", f.clone(), "m1/a?#fragment", f.join("node_modules/m1/a.js?#fragment")),
         ("differ between directory and file, resolve file", f.clone(), "./dirOrFile", f.join("dirOrFile.js")),
         ("differ between directory and file, resolve directory", f.clone(), "./dirOrFile/", f.join("dirOrFile/index.js")),
         ("find node_modules outside of node_modules", f.join("browser-module/node_modules"), "m1/a", f.join("node_modules/m1/a.js")),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
       "CHANGELOG.md",
       "fixtures",
       "napi/browser.js",
-      "napi/browser.js",
       "napi/index.d.ts",
       "napi/index.js",
       "napi/resolver.wasi-browser.js",


### PR DESCRIPTION
Small leftovers found while sweeping the test suite and the JS side:

- `src/tests/resolve.rs`: the "file in module with query and fragment" table row appeared twice, byte-identical — the upstream enhanced-resolve `resolve.test.js` has the case exactly once, so the second row was a copy-paste in the port. The loop just ran the same assertion twice.
- `src/tests/alias.rs`: `#[allow(clippy::too_many_lines)]` no longer suppresses anything (verified by removing it and running the CI clippy command). The same allow in `imports_field.rs` is still load-bearing (1191/100) and stays.
- `vite.config.ts`: `"napi/browser.js"` was listed twice in `fmt.ignorePatterns`.
- `napi/test.mjs`: removed a stale comment about a `.ts` extension next to code that adds `.mjs` and resolves an already-suffixed specifier.
- `napi/webcontainer-fallback.js`: removed an inert lint directive (`// eslint-disable-next-line: no-console`) — the project lints with oxlint, the syntax is invalid even for ESLint, and `no-console` isn't enabled.

Part of a second cleanup pass; follows #1264–#1268.