### PR TITLE
chore: standardize rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,17 +1,6 @@
 style_edition = "2024"
-
-# Make Rust more readable given most people have wide screens nowadays.
-# This is also the setting used by [rustc](https://github.com/rust-lang/rust/blob/master/rustfmt.toml)
 use_small_heuristics = "Max"
-
-# Use field initialize shorthand if possible
 use_field_init_shorthand = true
-
 reorder_modules = true
-
-# For `cargo +nightly fmt`
-# unstable_features = true
-# style_edition = '2024'
-# reorder_impl_items = true
-# group_imports = "StdExternalCrate"
-# imports_granularity = "Crate"
+merge_derives = true
+remove_nested_parens = true


### PR DESCRIPTION
Standardizes the Rustfmt config filename and options, then applies cargo fmt.
