### PR TITLE
feat: expose tsconfig paths resolve method without file existence check

### DIFF
--- a/src/tests/tsconfig_lookup.rs
+++ b/src/tests/tsconfig_lookup.rs
@@ -311,6 +311,61 @@ fn paths_no_base_url_anchors_at_config_dir() {
 }
 
 #[test]
+fn resolve_path_alias_or_base_url_maps_without_file_check() {
+    // `@/*` -> `./src/*`. The mapping must be applied even when the target does not point at a real file,
+    // so glob-like specifiers (e.g. `import.meta.glob` patterns) can be aliased.
+    let f = super::fixture_root().join("tsconfig/cases/paths-no-base-url");
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        extensions: vec![".ts".into()],
+        ..ResolveOptions::default()
+    });
+
+    let map = |importer: &std::path::Path, specifier: &str| {
+        resolver
+            .find_tsconfig(importer)
+            .unwrap()
+            .map(|tsconfig| tsconfig.resolve_path_alias_or_base_url(specifier))
+            .unwrap_or_default()
+    };
+
+    let importer = f.join("src/foo.ts");
+
+    assert_eq!(map(&importer, "@/assets/**/*"), vec![f.join("src/assets/**/*")]);
+    assert_eq!(map(&importer, "@/foo"), vec![f.join("src/foo")]);
+    assert_eq!(map(&importer, "unmatched/bar"), Vec::<std::path::PathBuf>::new());
+    assert_eq!(map(&importer, "./assets/**/*"), Vec::<std::path::PathBuf>::new());
+    assert_eq!(
+        map(&f.join("node_modules/pkg/index.ts"), "@/assets/**/*"),
+        Vec::<std::path::PathBuf>::new()
+    );
+}
+
+#[test]
+fn resolve_path_alias_or_base_url_maps_without_file_check_falls_back_to_base_url() {
+    // `baseUrl: "./src"` with no `paths`, so a non-relative specifier resolves under `./src` even for a glob-like specifier.
+    let f = super::fixture_root().join("tsconfig/cases/base-url");
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        extensions: vec![".ts".into()],
+        ..ResolveOptions::default()
+    });
+
+    let map = |importer: &std::path::Path, specifier: &str| {
+        resolver
+            .find_tsconfig(importer)
+            .unwrap()
+            .map(|tsconfig| tsconfig.resolve_path_alias_or_base_url(specifier))
+            .unwrap_or_default()
+    };
+
+    let importer = f.join("index.ts");
+
+    assert_eq!(map(&importer, "assets/**/*"), vec![f.join("src/assets/**/*")]);
+    assert_eq!(map(&importer, "foo.js"), vec![f.join("src/foo.js")]);
+}
+
+#[test]
 fn paths_explicit_extension_target() {
     let f = super::fixture_root().join("tsconfig/cases/paths-explicit-extension");
     let resolver =

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -518,6 +518,29 @@ impl TsConfig {
             .is_some()
             .then(|| self.compiler_options.paths_base.normalize_with(specifier))
     }
+
+    /// Maps a non-relative module `specifier` through this tsconfig's `compilerOptions.paths`
+    /// and `baseUrl` configuration, returning the mapped absolute path candidates without
+    /// checking whether they exist on disk.
+    ///
+    /// Unlike normal resolution (e.g. [`crate::ResolverImpl::resolve_file`]), which discards
+    /// a `paths`/`baseUrl` mapping when the mapped path does not point at a real file, this
+    /// keeps the mapping. It is intended for callers that need the alias mapping for a specifier
+    /// that is not expected to resolve to a real file, such as glob patterns used by
+    /// `import.meta.glob` (e.g. `@/foo/**/*`).
+    ///
+    /// Discover the tsconfig for an importing file with [`crate::ResolverImpl::find_tsconfig`],
+    /// which resolves project references so the returned config is the one that owns the file.
+    #[must_use]
+    pub fn resolve_path_alias_or_base_url(&self, specifier: &str) -> Vec<PathBuf> {
+        let mut paths = self.resolve_path_alias(specifier);
+        if paths.is_empty()
+            && let Some(base_url_path) = self.resolve_base_url(specifier)
+        {
+            paths.push(base_url_path);
+        }
+        paths
+    }
 }
 
 /// Compiler Options


### PR DESCRIPTION
Adds `resolve_path_alias_or_base_url` method to `TsConfig` struct. This method resolves a specifier with tsconfig paths / baseUrl without checking the file existence. This is needed for https://github.com/rolldown/rolldown/pull/10167.
