### PR TITLE
perf(napi): shrink release binaries (path remap + build-std without backtrace)

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -43,11 +43,6 @@ jobs:
   build:
     needs: check
     if: needs.check.outputs.version_changed == 'true'
-    env:
-      # Rebuild std without its backtrace symbolizer for smaller shipped binaries.
-      # The gate (RUSTC_BOOTSTRAP + -Z build-std for the release profile's panic=abort)
-      # lives in napi/build.mjs and only fires on release builds with an explicit --target.
-      OXC_RESOLVER_BUILD_STD: "1"
     strategy:
       fail-fast: false
       matrix:
@@ -125,7 +120,8 @@ jobs:
 
       - run: rustup target add ${{ matrix.target }}
 
-      # std sources for `-Z build-std` (OXC_RESOLVER_BUILD_STD, see napi/build.mjs)
+      # std sources for `-Z build-std`: release builds with an explicit --target rebuild std
+      # without its backtrace symbolizer (see napi/build.mjs); missing rust-src fails the job.
       - run: rustup component add rust-src
 
       - name: Setup OpenHarmony SDK
@@ -156,8 +152,9 @@ jobs:
     needs: check
     if: needs.check.outputs.version_changed == 'true'
     name: Build FreeBSD
-    # Deliberately does not set OXC_RESOLVER_BUILD_STD: provisioning rust-src inside the VM
-    # isn't worth it for this niche target, so its binary keeps the prebuilt std.
+    # OXC_RESOLVER_BUILD_STD=0 keeps the prebuilt std: provisioning rust-src inside the VM
+    # isn't worth it for this niche target, and CI leaks into the VM, so without the opt-out
+    # the missing-rust-src guard in napi/build.mjs would fail the job instead of falling back.
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
@@ -167,12 +164,13 @@ jobs:
         env:
           DEBUG: napi:*
           RUSTUP_IO_THREADS: 1
+          OXC_RESOLVER_BUILD_STD: "0"
         with:
           operating_system: freebsd
           version: 14.2
           memory: 8G
           cpu_count: 3
-          environment_variables: DEBUG RUSTUP_IO_THREADS
+          environment_variables: DEBUG RUSTUP_IO_THREADS OXC_RESOLVER_BUILD_STD
           shell: bash
           run: |
             sudo pkg install -y -f curl libnghttp2 node22 npm cmake

--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -120,8 +120,8 @@ jobs:
 
       - run: rustup target add ${{ matrix.target }}
 
-      # std sources for `-Z build-std`: release builds with an explicit --target rebuild std
-      # without its backtrace symbolizer (see napi/build.mjs); missing rust-src fails the job.
+      # std sources for `-Z build-std`: CI release builds with an explicit --target rebuild
+      # std without its backtrace symbolizer (see napi/build.mjs); missing rust-src fails the job.
       - run: rustup component add rust-src
 
       - name: Setup OpenHarmony SDK
@@ -154,7 +154,7 @@ jobs:
     name: Build FreeBSD
     # OXC_RESOLVER_BUILD_STD=0 keeps the prebuilt std: provisioning rust-src inside the VM
     # isn't worth it for this niche target, and CI leaks into the VM, so without the opt-out
-    # the missing-rust-src guard in napi/build.mjs would fail the job instead of falling back.
+    # the missing-rust-src guard in napi/build.mjs would fail the job.
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2

--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -43,6 +43,11 @@ jobs:
   build:
     needs: check
     if: needs.check.outputs.version_changed == 'true'
+    env:
+      # Rebuild std without its backtrace symbolizer for smaller shipped binaries.
+      # The gate (RUSTC_BOOTSTRAP + -Z build-std for the release profile's panic=abort)
+      # lives in napi/build.mjs and only fires on release builds with an explicit --target.
+      OXC_RESOLVER_BUILD_STD: "1"
     strategy:
       fail-fast: false
       matrix:
@@ -120,6 +125,9 @@ jobs:
 
       - run: rustup target add ${{ matrix.target }}
 
+      # std sources for `-Z build-std` (OXC_RESOLVER_BUILD_STD, see napi/build.mjs)
+      - run: rustup component add rust-src
+
       - name: Setup OpenHarmony SDK
         if: ${{ contains(matrix.target, 'ohos') }}
         uses: Boshen/setup-ohos-sdk@edb865a89a712f1f15dbad932dfa9cfce849d95c # v1.0.0
@@ -148,6 +156,8 @@ jobs:
     needs: check
     if: needs.check.outputs.version_changed == 'true'
     name: Build FreeBSD
+    # Deliberately does not set OXC_RESOLVER_BUILD_STD: provisioning rust-src inside the VM
+    # isn't worth it for this niche target, so its binary keeps the prebuilt std.
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
@@ -180,9 +190,9 @@ jobs:
             export COREPACK_INTEGRITY_KEYS=0
             sudo corepack enable
             pnpm install
-            # Call napi directly: vite-plus has no freebsd-x64 native binding,
+            # Call the build script directly: vite-plus has no freebsd-x64 native binding,
             # so the `vp run`-based `pnpm build` script can't be loaded here.
-            pnpm exec napi build --platform --manifest-path napi/Cargo.toml --features allocator --release --target x86_64-unknown-freebsd
+            node napi/build.mjs --features allocator --release --target x86_64-unknown-freebsd
             node napi/patch.mjs
             rm -rf node_modules
             rm -rf target

--- a/napi/build.mjs
+++ b/napi/build.mjs
@@ -1,7 +1,7 @@
 // Wrapper around `napi build` (the `build:debug` script) so release builds can
 // inject cargo configuration the napi CLI does not expose as flags.
 import { spawnSync } from "node:child_process";
-import { readdirSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -35,6 +35,9 @@ const isRelease = argsOptions.release === true || argsOptions.profile === "relea
 // which suppresses config-level rustflags there — musl artifacts keep unremapped paths. The
 // durable fix is upstream in napi-rs.
 let remapConfig;
+// `<sysroot>/lib/rustlib/src/rust` — std sources from the rust-src component. Computed on
+// release builds; feeds both the path remap and the build-std gate (which checks it exists).
+let rustSrc;
 if (isRelease) {
   const cargoHome = process.env.CARGO_HOME ?? resolve(homedir(), ".cargo");
   const rustupHome = process.env.RUSTUP_HOME ?? resolve(homedir(), ".rustup");
@@ -68,7 +71,7 @@ if (isRelease) {
   // dependencies → `/deps/<crate>` to match the registry mapping.
   const sysroot = spawnSync("rustc", ["--print", "sysroot"], { encoding: "utf8" });
   if (sysroot.status === 0) {
-    const rustSrc = resolve(sysroot.stdout.trim(), "lib", "rustlib", "src", "rust");
+    rustSrc = resolve(sysroot.stdout.trim(), "lib", "rustlib", "src", "rust");
     remaps.push(
       `--remap-path-prefix=${resolve(rustSrc, "vendor")}=/deps`,
       `--remap-path-prefix=${resolve(rustSrc, "library")}=/std`,
@@ -93,21 +96,39 @@ if (isRelease) {
 // `panic = "abort"` selects that runtime; std keeps its default `panic-unwind` feature so
 // the rebuilt std differs from the prebuilt one only by the dropped `backtrace` feature.
 //
-// Opt-in via the release workflow because it needs `RUSTC_BOOTSTRAP=1` to unlock
-// `-Z build-std` on the pinned stable toolchain, the `rust-src` component (installed by the
-// release workflow), and an explicit `--target`. wasm targets keep the prebuilt std (it
-// bundles the toolchain's self-contained wasi-libc); windows-msvc keeps the prebuilt std (a
-// matched A/B in rolldown#10177 measured build-std as a small size loss there) — both still
-// get the path remap.
-if (process.env.OXC_RESOLVER_BUILD_STD === "1" && isRelease) {
-  if (!argsOptions.target) {
-    console.warn(
-      "OXC_RESOLVER_BUILD_STD=1 requires an explicit --target; building with prebuilt std instead",
-    );
-  } else if (!argsOptions.target.startsWith("wasm") && !argsOptions.target.includes("windows")) {
+// Automatic on release builds with an explicit --target — i.e. the shipped binaries
+// (`RUSTC_BOOTSTRAP=1` unlocks `-Z build-std` on the pinned stable toolchain). Local dev
+// builds never rebuild std: debug builds skip this entirely, and a release build without
+// the `rust-src` component falls back to the prebuilt std — except in CI, where silently
+// shipping the ~200 KiB backtrace machinery again would be worse than a failed job.
+// `OXC_RESOLVER_BUILD_STD=0` opts a build out (the FreeBSD release VM). wasm targets keep
+// the prebuilt std (it bundles the toolchain's self-contained wasi-libc); windows-msvc
+// keeps the prebuilt std (a matched A/B in rolldown#10177 measured build-std as a small
+// size loss there) — all of these still get the path remap.
+const target = argsOptions.target;
+if (
+  isRelease &&
+  target &&
+  process.env.OXC_RESOLVER_BUILD_STD !== "0" &&
+  !target.startsWith("wasm") &&
+  !target.includes("windows")
+) {
+  if (rustSrc && existsSync(resolve(rustSrc, "library", "std"))) {
+    console.info("build-std: rebuilding std without the backtrace feature");
     process.env.RUSTC_BOOTSTRAP = "1";
     process.env.CARGO_UNSTABLE_BUILD_STD = "std,panic_abort";
     process.env.CARGO_UNSTABLE_BUILD_STD_FEATURES = "panic-unwind";
+  } else if (process.env.CI) {
+    console.error(
+      "release build without the rust-src component would ship std's backtrace symbolizer: " +
+        "run `rustup component add rust-src` (or set OXC_RESOLVER_BUILD_STD=0 to keep the prebuilt std)",
+    );
+    process.exit(1);
+  } else {
+    console.warn(
+      "rust-src component not installed: using the prebuilt std, which keeps the backtrace " +
+        "symbolizer released binaries drop (`rustup component add rust-src` to match)",
+    );
   }
 }
 

--- a/napi/build.mjs
+++ b/napi/build.mjs
@@ -14,6 +14,9 @@ const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 // `--use-napi-cross` behave identically.
 const buildCommand = createBuildCommand(process.argv.slice(2));
 const argsOptions = buildCommand.getOptions();
+// `getOptions()` does not surface args after `--`; the CLI's BuildCommand forwards those
+// separately as `cargoOptions`, so read the same field to keep the passthrough working.
+const restCargoOptions = buildCommand.cargoOptions ?? [];
 
 const isRelease = argsOptions.release === true || argsOptions.profile === "release";
 
@@ -96,10 +99,13 @@ if (process.env.OXC_RESOLVER_BUILD_STD === "1" && isRelease) {
   }
 }
 
+// Injected config first: cargo applies later `--config` values with higher precedence,
+// so a caller-passed `--config` can still override the remap entry.
+const cargoOptions = [...(remapConfig ? ["--config", remapConfig] : []), ...restCargoOptions];
+
 const napiArgs = {
   ...argsOptions,
-  // `getOptions()` doesn't surface CLI rest args, so this doesn't overwrite anything.
-  ...(remapConfig ? { cargoOptions: ["--config", remapConfig] } : {}),
+  ...(cargoOptions.length > 0 ? { cargoOptions } : {}),
   cwd: workspaceRoot,
   manifestPath: "napi/Cargo.toml",
   platform: true,

--- a/napi/build.mjs
+++ b/napi/build.mjs
@@ -1,4 +1,4 @@
-// Wrapper around `napi build` (the `build:debug` script) so release builds can
+// Wrapper around `napi build` (the `build:debug` script) so CI release builds can
 // inject cargo configuration the napi CLI does not expose as flags.
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
@@ -19,11 +19,15 @@ const argsOptions = buildCommand.getOptions();
 const restCargoOptions = buildCommand.cargoOptions ?? [];
 
 const isRelease = argsOptions.release === true || argsOptions.profile === "release";
+// Shipped binaries are built only by CI release jobs; local builds — debug or release —
+// skip the remap and build-std machinery entirely.
+const isCiRelease = isRelease && Boolean(process.env.CI);
 
 // For published binaries, remap the absolute build-machine paths (cargo/rustup homes and
 // the workspace root) that rustc embeds into panic locations and tracing callsite metadata.
 // This shrinks the binary's string tables and keeps the build machine's filesystem layout
-// out of the shipped artifact. Release-only so local dev backtraces keep clickable paths.
+// out of the shipped artifact. CI-release-only so local backtraces keep clickable paths
+// (and local builds skip the `cargo fetch`).
 // Replace with cargo `-Ztrim-paths` once it stabilizes (rust-lang/cargo#12137).
 //
 // The flags are injected as a cargo `--config target.'cfg(all())'.rustflags=[…]` entry, NOT
@@ -36,9 +40,9 @@ const isRelease = argsOptions.release === true || argsOptions.profile === "relea
 // durable fix is upstream in napi-rs.
 let remapConfig;
 // `<sysroot>/lib/rustlib/src/rust` — std sources from the rust-src component. Computed on
-// release builds; feeds both the path remap and the build-std gate (which checks it exists).
+// CI release builds; feeds both the path remap and the build-std gate (which checks it exists).
 let rustSrc;
-if (isRelease) {
+if (isCiRelease) {
   const cargoHome = process.env.CARGO_HOME ?? resolve(homedir(), ".cargo");
   const rustupHome = process.env.RUSTUP_HOME ?? resolve(homedir(), ".rustup");
   const remaps = [
@@ -108,9 +112,8 @@ if (isRelease) {
 // these still get the path remap.
 const target = argsOptions.target;
 if (
-  isRelease &&
+  isCiRelease &&
   target &&
-  process.env.CI &&
   process.env.OXC_RESOLVER_BUILD_STD !== "0" &&
   !target.startsWith("wasm") &&
   !target.includes("windows")

--- a/napi/build.mjs
+++ b/napi/build.mjs
@@ -96,19 +96,21 @@ if (isRelease) {
 // `panic = "abort"` selects that runtime; std keeps its default `panic-unwind` feature so
 // the rebuilt std differs from the prebuilt one only by the dropped `backtrace` feature.
 //
-// Automatic on release builds with an explicit --target — i.e. the shipped binaries
-// (`RUSTC_BOOTSTRAP=1` unlocks `-Z build-std` on the pinned stable toolchain). Local dev
-// builds never rebuild std: debug builds skip this entirely, and a release build without
-// the `rust-src` component falls back to the prebuilt std — except in CI, where silently
-// shipping the ~200 KiB backtrace machinery again would be worse than a failed job.
-// `OXC_RESOLVER_BUILD_STD=0` opts a build out (the FreeBSD release VM). wasm targets keep
-// the prebuilt std (it bundles the toolchain's self-contained wasi-libc); windows-msvc
-// keeps the prebuilt std (a matched A/B in rolldown#10177 measured build-std as a small
-// size loss there) — all of these still get the path remap.
+// Only on CI release builds with an explicit --target — i.e. the shipped binaries
+// (`RUSTC_BOOTSTRAP=1` unlocks `-Z build-std` on the pinned stable toolchain; the release
+// workflow installs the required `rust-src` component). Local builds, debug or release,
+// never rebuild std — set CI=1 to reproduce a shipped binary. A CI release build without
+// rust-src fails outright: silently shipping the ~200 KiB backtrace machinery again would
+// be worse than a red job. `OXC_RESOLVER_BUILD_STD=0` opts a build out (the FreeBSD release
+// VM, where provisioning rust-src isn't worth it). wasm targets keep the prebuilt std (it
+// bundles the toolchain's self-contained wasi-libc); windows-msvc keeps the prebuilt std (a
+// matched A/B in rolldown#10177 measured build-std as a small size loss there) — all of
+// these still get the path remap.
 const target = argsOptions.target;
 if (
   isRelease &&
   target &&
+  process.env.CI &&
   process.env.OXC_RESOLVER_BUILD_STD !== "0" &&
   !target.startsWith("wasm") &&
   !target.includes("windows")
@@ -118,17 +120,12 @@ if (
     process.env.RUSTC_BOOTSTRAP = "1";
     process.env.CARGO_UNSTABLE_BUILD_STD = "std,panic_abort";
     process.env.CARGO_UNSTABLE_BUILD_STD_FEATURES = "panic-unwind";
-  } else if (process.env.CI) {
+  } else {
     console.error(
       "release build without the rust-src component would ship std's backtrace symbolizer: " +
         "run `rustup component add rust-src` (or set OXC_RESOLVER_BUILD_STD=0 to keep the prebuilt std)",
     );
     process.exit(1);
-  } else {
-    console.warn(
-      "rust-src component not installed: using the prebuilt std, which keeps the backtrace " +
-        "symbolizer released binaries drop (`rustup component add rust-src` to match)",
-    );
   }
 }
 

--- a/napi/build.mjs
+++ b/napi/build.mjs
@@ -62,6 +62,18 @@ if (isRelease) {
   } catch {
     // no registry dir (e.g. vendored deps) — nothing to collapse
   }
+  // `-Z build-std` compiles std from the sysroot's rust-src, so the `/rustup` mapping
+  // alone still leaves `toolchains/<tc>/lib/rustlib/src/rust/…` in panic locations.
+  // Collapse that tree too: `…/library/alloc/…` → `/std/alloc/…`, and std's vendored
+  // dependencies → `/deps/<crate>` to match the registry mapping.
+  const sysroot = spawnSync("rustc", ["--print", "sysroot"], { encoding: "utf8" });
+  if (sysroot.status === 0) {
+    const rustSrc = resolve(sysroot.stdout.trim(), "lib", "rustlib", "src", "rust");
+    remaps.push(
+      `--remap-path-prefix=${resolve(rustSrc, "vendor")}=/deps`,
+      `--remap-path-prefix=${resolve(rustSrc, "library")}=/std`,
+    );
+  }
   // TOML literal strings cannot contain single quotes; such paths just skip the remap.
   if (remaps.every((flag) => !flag.includes("'"))) {
     remapConfig = `target.'cfg(all())'.rustflags=[${remaps.map((flag) => `'${flag}'`).join(",")}]`;

--- a/napi/build.mjs
+++ b/napi/build.mjs
@@ -1,0 +1,111 @@
+// Wrapper around `napi build` (the `build:debug` script) so release builds can
+// inject cargo configuration the napi CLI does not expose as flags.
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createBuildCommand, NapiCli } from "@napi-rs/cli";
+
+const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+// The same clipanion parser as the `napi build` CLI, so flags like `-x` and
+// `--use-napi-cross` behave identically.
+const buildCommand = createBuildCommand(process.argv.slice(2));
+const argsOptions = buildCommand.getOptions();
+
+const isRelease = argsOptions.release === true || argsOptions.profile === "release";
+
+// For published binaries, remap the absolute build-machine paths (cargo/rustup homes and
+// the workspace root) that rustc embeds into panic locations and tracing callsite metadata.
+// This shrinks the binary's string tables and keeps the build machine's filesystem layout
+// out of the shipped artifact. Release-only so local dev backtraces keep clickable paths.
+// Replace with cargo `-Ztrim-paths` once it stabilizes (rust-lang/cargo#12137).
+//
+// The flags are injected as a cargo `--config target.'cfg(all())'.rustflags=[…]` entry, NOT
+// via RUSTFLAGS/CARGO_BUILD_RUSTFLAGS: config-level target rustflags are joined with the
+// `.cargo/config.toml` target entries (the gnu `nodelete` link-args, the wasi stack size),
+// whereas the napi CLI promotes CARGO_BUILD_RUSTFLAGS to RUSTFLAGS, which suppresses all
+// config-level target rustflags.
+// Known gap: napi-cli always sets RUSTFLAGS for musl targets (`-C target-feature=-crt-static`),
+// which suppresses config-level rustflags there — musl artifacts keep unremapped paths. The
+// durable fix is upstream in napi-rs.
+let remapConfig;
+if (isRelease) {
+  const cargoHome = process.env.CARGO_HOME ?? resolve(homedir(), ".cargo");
+  const rustupHome = process.env.RUSTUP_HOME ?? resolve(homedir(), ".rustup");
+  const remaps = [
+    `--remap-path-prefix=${cargoHome}=/cargo`,
+    `--remap-path-prefix=${rustupHome}=/rustup`,
+    `--remap-path-prefix=${workspaceRoot}=/oxc-resolver`,
+  ];
+  // Collapse the long per-registry hash directory (`registry/src/index.crates.io-<hash>`)
+  // too: rustc uses the last matching prefix, so these more-specific mappings go last.
+  // The registry extraction dirs only exist after dependencies are fetched, and this script
+  // runs before napi invokes cargo — on a cold CI runner the directory would be empty. Fetch
+  // first (cheap: the same download cargo would do anyway), then enumerate sorted so the
+  // resulting flag set is deterministic.
+  spawnSync(
+    "cargo",
+    ["fetch", "--locked", ...(argsOptions.target ? ["--target", argsOptions.target] : [])],
+    { cwd: workspaceRoot, stdio: "inherit" },
+  );
+  const registrySrc = resolve(cargoHome, "registry", "src");
+  try {
+    for (const dir of readdirSync(registrySrc).sort()) {
+      remaps.push(`--remap-path-prefix=${resolve(registrySrc, dir)}=/deps`);
+    }
+  } catch {
+    // no registry dir (e.g. vendored deps) — nothing to collapse
+  }
+  // TOML literal strings cannot contain single quotes; such paths just skip the remap.
+  if (remaps.every((flag) => !flag.includes("'"))) {
+    remapConfig = `target.'cfg(all())'.rustflags=[${remaps.map((flag) => `'${flag}'`).join(",")}]`;
+  }
+}
+
+// Rebuild std without its `backtrace` feature: the DWARF symbolizer (gimli/object/addr2line,
+// hundreds of KiB) exists so RUST_BACKTRACE=1 can print symbolized panic traces — dead
+// weight in the shipped addon, which is built with `panic = "abort"` and can only print the
+// panic message + source location before aborting.
+//
+// Accepted behavior change in shipped binaries: RUST_BACKTRACE=1 prints NO stack frames at
+// all — the panic message and source location survive (which is what issue reports contain
+// in practice).
+//
+// `panic_abort` must be in the build-std crate list because the release profile's
+// `panic = "abort"` selects that runtime; std keeps its default `panic-unwind` feature so
+// the rebuilt std differs from the prebuilt one only by the dropped `backtrace` feature.
+//
+// Opt-in via the release workflow because it needs `RUSTC_BOOTSTRAP=1` to unlock
+// `-Z build-std` on the pinned stable toolchain, the `rust-src` component (installed by the
+// release workflow), and an explicit `--target`. wasm targets keep the prebuilt std (it
+// bundles the toolchain's self-contained wasi-libc); windows-msvc keeps the prebuilt std (a
+// matched A/B in rolldown#10177 measured build-std as a small size loss there) — both still
+// get the path remap.
+if (process.env.OXC_RESOLVER_BUILD_STD === "1" && isRelease) {
+  if (!argsOptions.target) {
+    console.warn(
+      "OXC_RESOLVER_BUILD_STD=1 requires an explicit --target; building with prebuilt std instead",
+    );
+  } else if (!argsOptions.target.startsWith("wasm") && !argsOptions.target.includes("windows")) {
+    process.env.RUSTC_BOOTSTRAP = "1";
+    process.env.CARGO_UNSTABLE_BUILD_STD = "std,panic_abort";
+    process.env.CARGO_UNSTABLE_BUILD_STD_FEATURES = "panic-unwind";
+  }
+}
+
+const napiArgs = {
+  ...argsOptions,
+  // `getOptions()` doesn't surface CLI rest args, so this doesn't overwrite anything.
+  ...(remapConfig ? { cargoOptions: ["--config", remapConfig] } : {}),
+  cwd: workspaceRoot,
+  manifestPath: "napi/Cargo.toml",
+  platform: true,
+};
+
+console.info("napi build args:", napiArgs);
+
+const { task } = await new NapiCli().build(napiArgs);
+await task;

--- a/napi/build.mjs
+++ b/napi/build.mjs
@@ -111,6 +111,7 @@ if (isCiRelease) {
 // matched A/B in rolldown#10177 measured build-std as a small size loss there) — all of
 // these still get the path remap.
 const target = argsOptions.target;
+let buildStdFlags = [];
 if (
   isCiRelease &&
   target &&
@@ -120,9 +121,12 @@ if (
 ) {
   if (rustSrc && existsSync(resolve(rustSrc, "library", "std"))) {
     console.info("build-std: rebuilding std without the backtrace feature");
+    // As CLI flags rather than CARGO_UNSTABLE_* env config: stable cargo silently ignores
+    // nightly-only env config but hard-errors on `-Z` flags, so if the RUSTC_BOOTSTRAP
+    // channel unlock (cargo reports "nightly" whenever it is set) ever stops working, the
+    // release job fails instead of quietly shipping the prebuilt std again.
     process.env.RUSTC_BOOTSTRAP = "1";
-    process.env.CARGO_UNSTABLE_BUILD_STD = "std,panic_abort";
-    process.env.CARGO_UNSTABLE_BUILD_STD_FEATURES = "panic-unwind";
+    buildStdFlags = ["-Zbuild-std=std,panic_abort", "-Zbuild-std-features=panic-unwind"];
   } else {
     console.error(
       "release build without the rust-src component would ship std's backtrace symbolizer: " +
@@ -134,7 +138,11 @@ if (
 
 // Injected config first: cargo applies later `--config` values with higher precedence,
 // so a caller-passed `--config` can still override the remap entry.
-const cargoOptions = [...(remapConfig ? ["--config", remapConfig] : []), ...restCargoOptions];
+const cargoOptions = [
+  ...(remapConfig ? ["--config", remapConfig] : []),
+  ...buildStdFlags,
+  ...restCargoOptions,
+];
 
 const napiArgs = {
   ...argsOptions,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepare": "vp config",
     "fmt": "vp fmt",
     "test": "vp test run -r ./napi",
-    "build:debug": "napi build --platform --manifest-path napi/Cargo.toml",
+    "build:debug": "node napi/build.mjs",
     "build": "vp run build:debug --features allocator --release",
     "postbuild:debug": "node napi/patch.mjs"
   },


### PR DESCRIPTION
Shrink the shipped `.node` binaries, ported from rolldown/rolldown#10177. Measured on a matched pair of release runs ([baseline](https://github.com/oxc-project/oxc-resolver/actions/runs/28878899374) vs [this branch](https://github.com/oxc-project/oxc-resolver/actions/runs/28878896916)): **−8 to −12%** on build-std targets (darwin-arm64 1,738.8 → 1,543.7 KiB, linux-x64-gnu 2,303.2 → 2,104.7 KiB), −0.2 to −0.3% on the remap-only targets (windows, wasm, freebsd).

`napi/build.mjs` wraps `napi build` (same clipanion arg parsing, `--` passthrough) and, **only on CI release builds with an explicit `--target`**, injects:

1. **Path remap** — `--remap-path-prefix` for cargo home → `/cargo`, rustup home → `/rustup`, workspace → `/oxc-resolver`, registry dirs → `/deps`, std sources → `/std`, injected as a cargo `--config` rustflags entry so the `.cargo/config.toml` target rustflags (gnu `nodelete`, wasi stack size) still apply. Panic locations read `/deps/sharded-slab-0.1.7/…` / `/std/alloc/…` instead of build-machine paths. Migrate to `-Ztrim-paths` once it stabilizes (rust-lang/cargo#12137).
2. **build-std without std's `backtrace` feature** — drops the ~200 KiB DWARF symbolizer (gimli/object/addr2line), dead weight under `panic = "abort"` + `strip = "symbols"`. `RUSTC_BOOTSTRAP=1` + `-Zbuild-std=std,panic_abort` CLI flags on the pinned stable toolchain (CLI flags hard-error if the unlock ever breaks; env config would be silently ignored). Excluded: wasm, windows-msvc, FreeBSD (`OXC_RESOLVER_BUILD_STD=0`).

Local builds — debug or release — are untouched: real clickable paths, prebuilt std, no `cargo fetch`. `CI=1 pnpm build --target <t>` reproduces a shipped binary byte-for-byte. A CI release build missing `rust-src` fails the job instead of silently shipping the prebuilt std.

Accepted behavior change: `RUST_BACKTRACE=1` on shipped binaries prints no stack frames — panic message + source location survive. Today's stripped binaries already can't symbolize (`=1` prints zero frames, `=full` mislabels every frame).

Known gap: musl artifacts keep unremapped paths — napi-cli force-sets `RUSTFLAGS` for musl, which suppresses config-level rustflags; the fix belongs upstream. build-std still applies there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
