### PR TITLE
feat: add `ResolveError::TsconfigLoadFailed` for tsconfig read and parse failures

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -287,15 +287,22 @@ impl Cache {
             if err.kind() == io::ErrorKind::NotFound {
                 ResolveError::TsconfigNotFound(path.to_path_buf())
             } else {
-                ResolveError::from(err)
+                ResolveError::TsconfigLoadFailed {
+                    path: tsconfig_path.to_path_buf(),
+                    source: Box::new(ResolveError::from(err)),
+                }
             }
         })?;
         let canonical_path = self
             .canonicalize(&self.value(&tsconfig_path))
             .unwrap_or_else(|_| tsconfig_path.to_path_buf());
         let mut tsconfig = TsConfig::parse(root, &tsconfig_path, &canonical_path, tsconfig_string)
-            .map_err(|error| {
-                ResolveError::from_serde_json_error(tsconfig_path.to_path_buf(), &error)
+            .map_err(|error| ResolveError::TsconfigLoadFailed {
+                path: tsconfig_path.to_path_buf(),
+                source: Box::new(ResolveError::from_serde_json_error(
+                    tsconfig_path.to_path_buf(),
+                    &error,
+                )),
             })?;
 
         // Run callback (extends/references processing)

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,13 @@ pub enum ResolveError {
     #[error("Tsconfig extends configs circularly: {0}")]
     TsconfigCircularExtend(CircularPathBufs),
 
+    /// Failed to read or parse a tsconfig file.
+    ///
+    /// Keeps tsconfig load failures distinguishable from package.json ones,
+    /// which also surface as [ResolveError::Json] and [ResolveError::IOError].
+    #[error("Failed to load tsconfig {path:?}: {source}")]
+    TsconfigLoadFailed { path: PathBuf, source: Box<Self> },
+
     #[error("{0}")]
     IOError(IOError),
 

--- a/src/tests/tsconfig_extends.rs
+++ b/src/tests/tsconfig_extends.rs
@@ -298,7 +298,8 @@ impl crate::FileSystem for UnreadableFs {
 }
 
 /// When a tsconfig's `extends` target exists but is not readable (e.g. permission denied),
-/// `resolve_tsconfig` should return an `IOError` (not silently skip it).
+/// `resolve_tsconfig` should return a `TsconfigLoadFailed` wrapping an `IOError`
+/// (not silently skip it).
 #[test]
 fn test_extend_tsconfig_unreadable_file() {
     use crate::ResolveError;
@@ -319,13 +320,17 @@ fn test_extend_tsconfig_unreadable_file() {
 
     let result = resolver.resolve_tsconfig(&f);
     assert!(
-        matches!(&result, Err(ResolveError::IOError(_))),
-        "expected IOError for unreadable extends target, got {result:?}",
+        matches!(
+            &result,
+            Err(ResolveError::TsconfigLoadFailed { source, .. })
+                if matches!(source.as_ref(), ResolveError::IOError(_))
+        ),
+        "expected TsconfigLoadFailed wrapping IOError for unreadable extends target, got {result:?}",
     );
 }
 
 /// When a tsconfig's `references` target exists but is not readable (e.g. permission denied),
-/// `resolve_tsconfig` should return an `IOError`.
+/// `resolve_tsconfig` should return a `TsconfigLoadFailed` wrapping an `IOError`.
 #[test]
 fn test_references_unreadable_file() {
     use crate::ResolveError;
@@ -346,8 +351,12 @@ fn test_references_unreadable_file() {
 
     let result = resolver.resolve_tsconfig(&f);
     assert!(
-        matches!(&result, Err(ResolveError::IOError(_))),
-        "expected IOError for unreadable references target, got {result:?}",
+        matches!(
+            &result,
+            Err(ResolveError::TsconfigLoadFailed { source, .. })
+                if matches!(source.as_ref(), ResolveError::IOError(_))
+        ),
+        "expected TsconfigLoadFailed wrapping IOError for unreadable references target, got {result:?}",
     );
 }
 

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -159,12 +159,15 @@ fn broken() {
     });
 
     let resolved_path = resolver.resolve_file(&f, "/");
-    let error = ResolveError::Json(JSONError {
+    let error = ResolveError::TsconfigLoadFailed {
         path: f.join("tsconfig_broken.json"),
-        message: String::from("EOF while parsing an object at line 2 column 0"),
-        line: 2,
-        column: 0,
-    });
+        source: Box::new(ResolveError::Json(JSONError {
+            path: f.join("tsconfig_broken.json"),
+            message: String::from("EOF while parsing an object at line 2 column 0"),
+            line: 2,
+            column: 0,
+        })),
+    };
     assert_eq!(resolved_path, Err(error));
 }
 

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -92,7 +92,7 @@ impl ResolverImpl {
     ///
     /// # Errors
     ///
-    /// * [ResolveError::Json]
+    /// * [ResolveError::TsconfigLoadFailed]
     fn find_tsconfig_impl(
         &self,
         cached_path: &CachedPath,
@@ -119,7 +119,11 @@ impl ResolverImpl {
                         Ok(tsconfig) => Ok(Some(tsconfig)),
                         // Skip unreadable tsconfig files (e.g. permission denied)
                         // and continue walking parent directories
-                        Err(ResolveError::IOError(_)) => Ok(None),
+                        Err(ResolveError::TsconfigLoadFailed { ref source, .. })
+                            if matches!(source.as_ref(), ResolveError::IOError(_)) =>
+                        {
+                            Ok(None)
+                        }
                         Err(e) => Err(e),
                     }
                 } else {


### PR DESCRIPTION
Tsconfig files are loaded lazily during resolution, and when the load fails with anything other than "not found", the error surfaces as the generic `ResolveError::Json` or `ResolveError::IOError`. Both variants are also used for package.json failures, so callers cannot tell which file actually failed to load. Rolldown hit this while trying to report a broken tsconfig as a proper `TSCONFIG_ERROR` diagnostic instead of an internal error, see the discussion in rolldown/rolldown#10200 (https://github.com/rolldown/rolldown/pull/10200#discussion_r3556704803).

This PR adds a dedicated variant that wraps the original error instead of replacing it, so the JSON details (path, line, column) stay reachable through `source`:

```rust
/// Failed to read or parse a tsconfig file.
#[error("Failed to load tsconfig {path:?}: {source}")]
TsconfigLoadFailed { path: PathBuf, source: Box<Self> },
```

The wrapping happens in `Cache::get_tsconfig`, the single entry point for tsconfig loading, so manual mode, auto discovery, the `extends` chain and project references are all covered at once. `TsconfigNotFound` keeps its dedicated variant, and package.json failures keep surfacing as plain `Json` / `IOError`. The auto discovery walk used to skip unreadable tsconfig files by matching `IOError` directly and now matches the wrapped form, keeping the same behavior.

Since `ResolveError` is `#[non_exhaustive]`, adding the variant is not a breaking change for downstream matches. The existing `broken`, `test_extend_tsconfig_unreadable_file` and `test_references_unreadable_file` tests are updated to assert the new shape.