### PR TITLE
perf(cache): reuse the child path when its parent canonicalizes to itself

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -411,8 +411,24 @@ impl Cache {
             || Ok(path.normalize_root(self)),
             |parent| {
                 self.canonicalize_with_visited(&parent, visited).and_then(|parent_canonical| {
-                    let normalized = parent_canonical
-                        .normalize_with(path.path().strip_prefix(parent.path()).unwrap(), self);
+                    // When no ancestor was rewritten (`parent_canonical` is `parent` itself) and
+                    // this key is exactly `<parent><MAIN_SEPARATOR><file_name>`, re-joining the
+                    // tail would rebuild `path`'s own key — reuse it and skip the strip_prefix,
+                    // scratch-buffer copy, hash, and shard probe. Keys with `.`/`..` tails,
+                    // trailing/doubled separators, or (on Windows) a `/` joint fail the check
+                    // and take the rebuild path, which folds them.
+                    let path_bytes = path.path().as_os_str().as_encoded_bytes();
+                    let parent_len = parent.path().as_os_str().len();
+                    let normalized = if Arc::ptr_eq(&parent_canonical.0, &parent.0)
+                        && path.path().file_name().is_some_and(|name| {
+                            parent_len + 1 + name.len() == path_bytes.len()
+                                && path_bytes[parent_len] == std::path::MAIN_SEPARATOR as u8
+                        }) {
+                        path.clone()
+                    } else {
+                        parent_canonical
+                            .normalize_with(path.path().strip_prefix(parent.path()).unwrap(), self)
+                    };
 
                     if path.link_metadata(self.fs()).is_some_and(|m| m.is_symlink) {
                         let link = self.fs.read_link(normalized.path())?;

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -416,13 +416,17 @@ impl Cache {
                     // tail would rebuild `path`'s own key — reuse it and skip the strip_prefix,
                     // scratch-buffer copy, hash, and shard probe. Keys with `.`/`..` tails,
                     // trailing/doubled separators, or (on Windows) a `/` joint fail the check
-                    // and take the rebuild path, which folds them.
+                    // and take the rebuild path, which folds them. A root parent already ends
+                    // with the separator, so the rebuild adds none and the `+ 1` would instead
+                    // count a doubled separator after the root (`//x`, `C:\\x`) — the byte
+                    // before the joint must therefore be a non-separator.
                     let path_bytes = path.path().as_os_str().as_encoded_bytes();
                     let parent_len = parent.path().as_os_str().len();
                     let normalized = if Arc::ptr_eq(&parent_canonical.0, &parent.0)
                         && path.path().file_name().is_some_and(|name| {
                             parent_len + 1 + name.len() == path_bytes.len()
                                 && path_bytes[parent_len] == std::path::MAIN_SEPARATOR as u8
+                                && path_bytes[parent_len - 1] != std::path::MAIN_SEPARATOR as u8
                         }) {
                         path.clone()
                     } else {

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -411,19 +411,19 @@ impl Cache {
             || Ok(path.normalize_root(self)),
             |parent| {
                 self.canonicalize_with_visited(&parent, visited).and_then(|parent_canonical| {
-                    // This step appends the tail to whatever `parent` canonicalized into. The
-                    // cache interns one Arc per key, so a pointer-equal `parent_canonical` means
-                    // no ancestor was rewritten by a symlink — and when this key is exactly
-                    // `<parent><MAIN_SEPARATOR><file_name>`, the rebuild below could only
-                    // reproduce `path`'s own key and hand back this very entry. Return it
-                    // directly, skipping the strip_prefix, scratch-buffer copy, hash, and shard
-                    // probe. Spellings the rebuild would fold rather than reproduce — `.`/`..`
-                    // tails, trailing or doubled separators, a `/` joint on Windows — fail the
-                    // shape check and take the rebuild path. A root parent already ends with the
-                    // separator (the rebuild appends none), so the `+ 1` would instead count a
-                    // doubled separator after the root (`//x`, `C:\\x`) — the byte before the
-                    // joint must be a non-separator. Wasm always rebuilds: component
-                    // normalization trims uvwasi's trailing NULs, which reuse would keep.
+                    // When no ancestor is a symlink — the common case — the parent
+                    // canonicalizes to itself, so `parent_canonical` is `parent`'s own interned
+                    // Arc and the rebuild below would just re-derive `path`'s existing key.
+                    // Skip it (the strip_prefix, scratch-buffer copy, hash, and shard probe)
+                    // and return this entry directly. That is only sound when the key is
+                    // spelled exactly `<parent><MAIN_SEPARATOR><file_name>`: spellings the
+                    // rebuild would fold — `.`/`..` tails, trailing or doubled separators, a
+                    // `/` joint on Windows — fail the shape check and rebuild as before. The
+                    // byte before the joint must be a non-separator because a root parent
+                    // already ends with the separator (the rebuild appends none), so with
+                    // `//x` or `C:\\x` the `+ 1` would count the doubled separator itself.
+                    // Wasm always rebuilds: component normalization trims uvwasi's trailing
+                    // NULs, which reuse would keep.
                     let path_bytes = path.path().as_os_str().as_encoded_bytes();
                     let parent_len = parent.path().as_os_str().len();
                     let normalized = if cfg!(not(target_family = "wasm"))

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -411,18 +411,23 @@ impl Cache {
             || Ok(path.normalize_root(self)),
             |parent| {
                 self.canonicalize_with_visited(&parent, visited).and_then(|parent_canonical| {
-                    // When no ancestor was rewritten (`parent_canonical` is `parent` itself) and
-                    // this key is exactly `<parent><MAIN_SEPARATOR><file_name>`, re-joining the
-                    // tail would rebuild `path`'s own key — reuse it and skip the strip_prefix,
-                    // scratch-buffer copy, hash, and shard probe. Keys with `.`/`..` tails,
-                    // trailing/doubled separators, or (on Windows) a `/` joint fail the check
-                    // and take the rebuild path, which folds them. A root parent already ends
-                    // with the separator, so the rebuild adds none and the `+ 1` would instead
-                    // count a doubled separator after the root (`//x`, `C:\\x`) — the byte
-                    // before the joint must therefore be a non-separator.
+                    // This step appends the tail to whatever `parent` canonicalized into. The
+                    // cache interns one Arc per key, so a pointer-equal `parent_canonical` means
+                    // no ancestor was rewritten by a symlink — and when this key is exactly
+                    // `<parent><MAIN_SEPARATOR><file_name>`, the rebuild below could only
+                    // reproduce `path`'s own key and hand back this very entry. Return it
+                    // directly, skipping the strip_prefix, scratch-buffer copy, hash, and shard
+                    // probe. Spellings the rebuild would fold rather than reproduce — `.`/`..`
+                    // tails, trailing or doubled separators, a `/` joint on Windows — fail the
+                    // shape check and take the rebuild path. A root parent already ends with the
+                    // separator (the rebuild appends none), so the `+ 1` would instead count a
+                    // doubled separator after the root (`//x`, `C:\\x`) — the byte before the
+                    // joint must be a non-separator. Wasm always rebuilds: component
+                    // normalization trims uvwasi's trailing NULs, which reuse would keep.
                     let path_bytes = path.path().as_os_str().as_encoded_bytes();
                     let parent_len = parent.path().as_os_str().len();
-                    let normalized = if Arc::ptr_eq(&parent_canonical.0, &parent.0)
+                    let normalized = if cfg!(not(target_family = "wasm"))
+                        && Arc::ptr_eq(&parent_canonical.0, &parent.0)
                         && path.path().file_name().is_some_and(|name| {
                             parent_len + 1 + name.len() == path_bytes.len()
                                 && path_bytes[parent_len] == std::path::MAIN_SEPARATOR as u8

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -312,7 +312,7 @@ fn canonicalize_matches_os_for_all_node_modules() {
 fn canonicalize_dirty_cache_keys() {
     let f = super::fixture();
     let sep = std::path::MAIN_SEPARATOR;
-    let dirty = [
+    let mut dirty = vec![
         f.join(".."),
         f.join("lib").join(".."),
         f.join("lib").join("..").join("lib").join("complex1.js"),
@@ -320,6 +320,15 @@ fn canonicalize_dirty_cache_keys() {
         PathBuf::from(format!("{}{sep}", f.join("lib").display())),
         PathBuf::from(format!("{}{sep}{sep}complex1.js", f.join("lib").display())),
     ];
+    #[cfg(unix)]
+    {
+        dirty.push(PathBuf::from(format!("{sep}{}", f.display())));
+        dirty.push(PathBuf::from(format!("{sep}{sep}{}", f.display())));
+    }
+    #[cfg(target_os = "windows")]
+    {
+        dirty.push(PathBuf::from(f.display().to_string().replacen(":\\", ":\\\\", 1)));
+    }
     let resolver = Resolver::new(ResolveOptions::default());
     for path in dirty {
         let expected = fs::canonicalize(&path).unwrap();
@@ -327,7 +336,7 @@ fn canonicalize_dirty_cache_keys() {
         let expected = crate::windows::strip_windows_prefix(expected).unwrap();
         let cached = resolver.cache.value(&path);
         let actual = resolver.cache.canonicalize(&cached).unwrap();
-        assert_eq!(actual, expected, "{}", path.display());
+        assert_eq!(actual.as_os_str(), expected.as_os_str(), "{}", path.display());
     }
 }
 

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -308,6 +308,29 @@ fn canonicalize_matches_os_for_all_node_modules() {
     eprintln!("checked {paths_checked} paths across {combos_checked} bench-pm combos");
 }
 
+#[test]
+fn canonicalize_dirty_cache_keys() {
+    let f = super::fixture();
+    let sep = std::path::MAIN_SEPARATOR;
+    let dirty = [
+        f.join(".."),
+        f.join("lib").join(".."),
+        f.join("lib").join("..").join("lib").join("complex1.js"),
+        f.join("lib").join(".").join("complex1.js"),
+        PathBuf::from(format!("{}{sep}", f.join("lib").display())),
+        PathBuf::from(format!("{}{sep}{sep}complex1.js", f.join("lib").display())),
+    ];
+    let resolver = Resolver::new(ResolveOptions::default());
+    for path in dirty {
+        let expected = fs::canonicalize(&path).unwrap();
+        #[cfg(target_os = "windows")]
+        let expected = crate::windows::strip_windows_prefix(expected).unwrap();
+        let cached = resolver.cache.value(&path);
+        let actual = resolver.cache.canonicalize(&cached).unwrap();
+        assert_eq!(actual, expected, "{}", path.display());
+    }
+}
+
 /// A symlinked workspace package anchor with a symlink in the suffix below it: canonicalization must
 /// follow both the anchor link and the inner link.
 #[test]


### PR DESCRIPTION
## Summary

Each level of `canonicalize_with_visited` does one job: **append the path's last component to whatever its parent canonicalized into** — today via `strip_prefix` (O(len) component walk) + `normalize_with` (scratch-buffer copy of the whole path, full-path FxHash, dashmap shard probe).

When no ancestor is a symlink — the common case — the parent canonicalizes to *itself*, so that append can only rebuild the child's own key, and the shard probe is guaranteed to hand back the entry we already hold: four O(len) operations computing the identity function. This PR detects that case and returns the entry directly, per non-symlink level of every first-time canonicalization.

## Example

pnpm project, `node_modules/lodash → .pnpm/lodash@4.17.21/node_modules/lodash`; canonicalize `/app/node_modules/lodash/index.js` (parent-first recursion):

- `/app/node_modules`: parent `/app` canonicalized to itself → the rebuild could only reproduce `/app/node_modules` → **fast path** returns the entry as-is. Most levels of most paths look like this.
- `/app/node_modules/lodash`: fast path for the string, then the (unchanged) symlink check lstats it, follows the link, and its canonical becomes the `.pnpm` entry.
- `/app/node_modules/lodash/index.js`: the parent's canonical is now a *different* entry → `ptr_eq` fails → the rebuild does real work, appending `index.js` to the `.pnpm` parent. The rebuild runs exactly where its output differs from its input.

## Why the guard is sound

The cache interns paths — one `Arc<CachedPathImpl>` per byte string — so `Arc::ptr_eq(&parent_canonical.0, &parent.0)` ⟺ canonicalizing the parent changed nothing ⟺ no ancestor was rewritten by a symlink. Under that precondition the rebuild returns `path`'s own Arc **iff** the rebuilt string is byte-identical to `path`'s key. `PathBuf::push` of one normal component appends `MAIN_SEPARATOR` + name, except it appends *no* separator when the base already ends with one (a root). So the fast path is restricted to keys shaped exactly `<parent><one native separator><file_name>`, checked in O(1):

- `file_name().is_some()` — excludes `.`/`..` tails, where the rebuild folds (`/a/b/..` → `/a`);
- `parent_len + 1 + name.len() == path_len` — excludes trailing slashes and doubled separators mid-path;
- `path_bytes[parent_len] == MAIN_SEPARATOR` — excludes mixed joints on Windows (`C:\proj/src`, where push would emit `\`);
- `path_bytes[parent_len − 1] != MAIN_SEPARATOR` — excludes root-adjacent doubled separators (`//x`, `C:\\x`), where push appends no joint separator and the `+ 1` would otherwise count the doubled separator itself (caught in review; clean root children like `/usr` already failed the length check, so no fast-path coverage is lost);
- wasm always takes the rebuild: component normalization is what trims the trailing NULs uvwasi can leave in directory entries, and reusing the key verbatim would keep them.

Keys failing the guard are exactly the spellings the rebuild would **fold** rather than reproduce — they take the rebuild path as before. The symlink check on the resulting entry is unchanged; only the string computation is skipped.

## Correctness

- `canonicalize_matches_os_for_all_node_modules`: 12,441 paths across 7 installed bench-pm combos (npm/pnpm/yarn/bun × flat/isolated/hoisted) match `std::fs::canonicalize` byte-for-byte.
- New `canonicalize_dirty_cache_keys` test covers every guard exclusion (`.`/`..` tails and mid-chain, trailing, doubled, and root-adjacent doubled separators on Unix and Windows) against the OS oracle. It compares `OsStr` bytes, because `Path`'s component-based `PartialEq` treats `//x` and `/x` as equal and would mask separator-level differences; the root-adjacent cases fail on the unfixed fast path and pass with the guard.
- Full suite: 276 unit + 15 integration + 4 dependencies + 8 resolve_package + 13 doctests, clippy `--deny warnings`, fmt, on all CI platforms including Windows and big-endian.

## Benchmarks

CodSpeed (instrumented instruction count, cold-cache pm workloads that exercise this path):

| bench | base | head | efficiency |
|---|---|---|---|
| pm/yarn-isolated | 1,052.5 µs | 851.1 µs | +23.7% |
| pm/pnpm-isolated | 1,050.8 µs | 853.7 µs | +23.1% |
| pm/pnpm-hoisted | 1,070.9 µs | 887.7 µs | +20.7% |
| pm/npm-flat | 968.8 µs | 817.1 µs | +18.6% |
| pm/bun-isolated | 1,035.1 µs | 897.3 µs | +15.4% |
| pm/bun-flat | 970.6 µs | 844.2 µs | +15.0% |
| pm/yarn-flat | 944.6 µs | 876.6 µs | +7.8% |

The flagged `resolver_real[multi-thread]` −6.2% is measurement slop: that bench reuses one resolver across iterations, so its steady state never reaches the changed code (the `canonicalized` OnceLock returns before the guard), and the same bench was untouched on e201289, which contains the identical fast path. Local wall-clock A/B (interleaved fixed binaries on a quiet machine, change measured first) agreed in direction: −1% to −3% on 7/8 pm combos, yarn-pnp neutral (dominated by `.pnp.cjs` parsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
