### PR TITLE
chore: bump MSRV to 1.95.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ oxc-resolver is a Rust port of webpack's enhanced-resolve, providing ESM and Com
 
 ### Key Technologies
 
-- **Rust**: Core implementation using Rust 2024 edition (MSRV: 1.85.0)
+- **Rust**: Core implementation using Rust 2024 edition (MSRV: 1.95.0)
 - **NAPI**: Node.js bindings for JavaScript/TypeScript usage
 - **WebAssembly**: Browser support
 - **GitHub Actions**: CI/CD workflows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["node", "resolve", "cjs", "esm", "enhanced-resolve"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/oxc-project/oxc-resolver"
-rust-version = "1.88.0"
+rust-version = "1.95.0"
 description = "ESM / CJS module resolution"
 
 [workspace.dependencies]


### PR DESCRIPTION
Bumps `rust-version` from 1.88.0 to 1.95.0 and updates the stale MSRV note in AGENTS.md (which still said 1.85.0).

The toolchain in CI is already 1.97.0, and `cargo clippy --all-features --all-targets` is clean under the new `rust-version`.

This unlocks APIs stabilized in 1.89–1.95; a follow-up PR replaces the `cfg-if` dependency with `std::cfg_select!` (stabilized in 1.95).