### PR TITLE
refactor: replace cfg-if dependency with std cfg_select! macro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ oxc-resolver is a Rust port of webpack's enhanced-resolve, providing ESM and Com
 
 ### Key Technologies
 
-- **Rust**: Core implementation using Rust 2024 edition (MSRV: 1.85.0)
+- **Rust**: Core implementation using Rust 2024 edition (MSRV: 1.95.0)
 - **NAPI**: Node.js bindings for JavaScript/TypeScript usage
 - **WebAssembly**: Browser support
 - **GitHub Actions**: CI/CD workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,6 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 name = "oxc_resolver"
 version = "11.23.0"
 dependencies = [
- "cfg-if",
  "compact_str",
  "criterion2",
  "dashmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["node", "resolve", "cjs", "esm", "enhanced-resolve"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/oxc-project/oxc-resolver"
-rust-version = "1.88.0"
+rust-version = "1.95.0"
 description = "ESM / CJS module resolution"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ missing_const_for_fn = "allow"
 name = "dir"
 
 [dependencies]
-cfg-if = "1"
 compact_str = "0.9"
 fast-glob = "1"
 indexmap = { version = "2", features = ["serde"] }

--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Cow,
+    cfg_select,
     collections::HashSet as StdHashSet,
     hash::{BuildHasherDefault, Hash, Hasher},
     io,
@@ -7,7 +8,6 @@ use std::{
     sync::Arc,
 };
 
-use cfg_if::cfg_if;
 use dashmap::{DashMap, mapref::entry::Entry};
 #[cfg(feature = "yarn_pnp")]
 use once_cell::sync::OnceCell;
@@ -94,12 +94,9 @@ impl Cache {
     pub(crate) fn canonicalize(&self, path: &CachedPath) -> Result<PathBuf, ResolveError> {
         let cached_path = self.canonicalize_impl(path)?;
         let path = cached_path.to_path_buf();
-        cfg_if! {
-            if #[cfg(target_os = "windows")] {
-                crate::windows::strip_windows_prefix(path)
-            } else {
-                Ok(path)
-            }
+        cfg_select! {
+            target_os = "windows" => crate::windows::strip_windows_prefix(path),
+            _ => Ok(path),
         }
     }
 

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -1,9 +1,8 @@
 use std::{
-    fs, io,
+    cfg_select, fs, io,
     path::{Path, PathBuf},
 };
 
-use cfg_if::cfg_if;
 #[cfg(feature = "yarn_pnp")]
 use pnp::fs::{LruZipCache, VPath, VPathInfo, ZipCache};
 #[cfg(feature = "yarn_pnp")]
@@ -179,14 +178,15 @@ impl FileSystemOs {
     /// See [std::fs::metadata]
     #[inline]
     pub fn metadata(path: &Path) -> io::Result<FileMetadata> {
-        cfg_if! {
-            if #[cfg(target_os = "windows")] {
+        cfg_select! {
+            target_os = "windows" => {
                 let result = crate::windows::symlink_metadata(path)?;
                 if result.is_symlink {
                     return fs::metadata(path).map(FileMetadata::from);
                 }
                 Ok(result.into())
-            } else if #[cfg(target_os = "linux")] {
+            }
+            target_os = "linux" => {
                 use rustix::fs::{AtFlags, CWD, FileType, StatxFlags};
                 match rustix::fs::statx(CWD, path, AtFlags::STATX_DONT_SYNC, StatxFlags::TYPE) {
                     Ok(statx) => {
@@ -199,7 +199,8 @@ impl FileSystemOs {
                     }
                     Err(err) => Err(err.into()),
                 }
-            } else {
+            }
+            _ => {
                 fs::metadata(path).map(FileMetadata::from)
             }
         }
@@ -210,10 +211,11 @@ impl FileSystemOs {
     /// See [std::fs::symlink_metadata]
     #[inline]
     pub fn symlink_metadata(path: &Path) -> io::Result<FileMetadata> {
-        cfg_if! {
-            if #[cfg(target_os = "windows")] {
+        cfg_select! {
+            target_os = "windows" => {
                 Ok(crate::windows::symlink_metadata(path)?.into())
-            } else if #[cfg(target_os = "linux")] {
+            }
+            target_os = "linux" => {
                 use rustix::fs::{AtFlags, CWD, FileType, StatxFlags};
                 match rustix::fs::statx(CWD, path, AtFlags::SYMLINK_NOFOLLOW, StatxFlags::TYPE) {
                     Ok(statx) => {
@@ -226,7 +228,8 @@ impl FileSystemOs {
                     }
                     Err(err) => Err(err.into()),
                 }
-            } else {
+            }
+            _ => {
                 fs::symlink_metadata(path).map(FileMetadata::from)
             }
         }
@@ -238,12 +241,9 @@ impl FileSystemOs {
     #[inline]
     pub fn read_link(path: &Path) -> Result<PathBuf, ResolveError> {
         let path = fs::read_link(path)?;
-        cfg_if! {
-            if #[cfg(target_os = "windows")] {
-                crate::windows::strip_windows_prefix(path)
-            } else {
-                Ok(path)
-            }
+        cfg_select! {
+            target_os = "windows" => crate::windows::strip_windows_prefix(path),
+            _ => Ok(path),
         }
     }
 
@@ -268,18 +268,13 @@ impl FileSystem for FileSystemOs {
     }
 
     fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
-        cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                if self.yarn_pnp {
-                    return match VPath::from(path)? {
-                        VPath::Zip(info) => {
-                            self.pnp_lru.read(info.physical_base_path(), info.zip_path)
-                        }
-                        VPath::Virtual(info) => fs::read(info.physical_base_path()),
-                        VPath::Native(path) => fs::read(path),
-                    }
-                }
-            }
+        #[cfg(feature = "yarn_pnp")]
+        if self.yarn_pnp {
+            return match VPath::from(path)? {
+                VPath::Zip(info) => self.pnp_lru.read(info.physical_base_path(), info.zip_path),
+                VPath::Virtual(info) => fs::read(info.physical_base_path()),
+                VPath::Native(path) => fs::read(path),
+            };
         }
         fs::read(path)
     }
@@ -290,75 +285,61 @@ impl FileSystem for FileSystemOs {
     }
 
     fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-        cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                if self.yarn_pnp {
-                    return match VPath::from(path)? {
-                        VPath::Zip(info) => self
-                            .pnp_lru
-                            .file_type(info.physical_base_path(), info.zip_path)
-                            .map(FileMetadata::from),
-                        VPath::Virtual(info) => {
-                            Self::metadata(&info.physical_base_path())
-                        }
-                        VPath::Native(path) => Self::metadata(&path),
-                    }
-                }
-            }
+        #[cfg(feature = "yarn_pnp")]
+        if self.yarn_pnp {
+            return match VPath::from(path)? {
+                VPath::Zip(info) => self
+                    .pnp_lru
+                    .file_type(info.physical_base_path(), info.zip_path)
+                    .map(FileMetadata::from),
+                VPath::Virtual(info) => Self::metadata(&info.physical_base_path()),
+                VPath::Native(path) => Self::metadata(&path),
+            };
         }
         Self::metadata(path)
     }
 
     fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-        cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                if self.yarn_pnp {
-                    // Mirror `metadata`'s virtual-path translation. Without it, `lstat`-ing a
-                    // virtual or zip path directly stats a path that may not physically exist, so
-                    // canonicalization cannot detect symlinks correctly under Yarn PnP. Zip entries
-                    // are never symlinks, so reuse the same file-type lookup as `metadata`.
-                    return match VPath::from(path)? {
-                        VPath::Zip(info) => self
-                            .pnp_lru
-                            .file_type(info.physical_base_path(), info.zip_path)
-                            .map(FileMetadata::from),
-                        VPath::Virtual(info) => {
-                            Self::symlink_metadata(&info.physical_base_path())
-                        }
-                        VPath::Native(path) => Self::symlink_metadata(&path),
-                    }
-                }
-            }
+        // Mirror `metadata`'s virtual-path translation. Without it, `lstat`-ing a
+        // virtual or zip path directly stats a path that may not physically exist, so
+        // canonicalization cannot detect symlinks correctly under Yarn PnP. Zip entries
+        // are never symlinks, so reuse the same file-type lookup as `metadata`.
+        #[cfg(feature = "yarn_pnp")]
+        if self.yarn_pnp {
+            return match VPath::from(path)? {
+                VPath::Zip(info) => self
+                    .pnp_lru
+                    .file_type(info.physical_base_path(), info.zip_path)
+                    .map(FileMetadata::from),
+                VPath::Virtual(info) => Self::symlink_metadata(&info.physical_base_path()),
+                VPath::Native(path) => Self::symlink_metadata(&path),
+            };
         }
         Self::symlink_metadata(path)
     }
 
     fn read_link(&self, path: &Path) -> Result<PathBuf, ResolveError> {
-        cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                if self.yarn_pnp {
-                    return match VPath::from(path)? {
-                        VPath::Zip(info) => Self::read_link(&info.physical_base_path().join(info.zip_path)),
-                        VPath::Virtual(info) => Self::read_link(&info.physical_base_path()),
-                        VPath::Native(path) => Self::read_link(&path),
-                    }
-                }
-            }
+        #[cfg(feature = "yarn_pnp")]
+        if self.yarn_pnp {
+            return match VPath::from(path)? {
+                VPath::Zip(info) => Self::read_link(&info.physical_base_path().join(info.zip_path)),
+                VPath::Virtual(info) => Self::read_link(&info.physical_base_path()),
+                VPath::Native(path) => Self::read_link(&path),
+            };
         }
         Self::read_link(path)
     }
 
     fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
-        cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                if self.yarn_pnp {
-                    return match VPath::from(path)? {
-                        VPath::Zip(info) => Self::canonicalize(&info.physical_base_path().join(info.zip_path)),
-                        VPath::Virtual(info) => Self::canonicalize(&info.physical_base_path()),
-                        VPath::Native(path) => Self::canonicalize(&path),
-                    }
+        #[cfg(feature = "yarn_pnp")]
+        if self.yarn_pnp {
+            return match VPath::from(path)? {
+                VPath::Zip(info) => {
+                    Self::canonicalize(&info.physical_base_path().join(info.zip_path))
                 }
-            }
+                VPath::Virtual(info) => Self::canonicalize(&info.physical_base_path()),
+                VPath::Native(path) => Self::canonicalize(&path),
+            };
         }
         Self::canonicalize(path)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub use crate::{
 
 use std::{
     borrow::Cow,
+    cfg_select,
     cmp::Ordering,
     ffi::OsStr,
     fmt,
@@ -163,13 +164,10 @@ impl<Fs: FileSystem + 'static> ResolverGeneric<Fs> {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
         let fallback = compile_alias(&options.fallback);
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                let fs = Fs::new(options.yarn_pnp);
-            } else {
-                let fs = Fs::new();
-            }
-        }
+        let fs = cfg_select! {
+            feature = "yarn_pnp" => Fs::new(options.yarn_pnp),
+            _ => Fs::new(),
+        };
         let cache = Arc::new(Cache::new(Arc::new(fs) as Arc<dyn FileSystem>));
         let inner = ResolverImpl { options, cache, alias, fallback };
         Self { inner, _marker: std::marker::PhantomData }
@@ -190,17 +188,16 @@ impl<Fs: FileSystem + 'static> ResolverGeneric<Fs> {
         let options = options.sanitize();
         let alias = compile_alias(&options.alias);
         let fallback = compile_alias(&options.fallback);
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "yarn_pnp")] {
-                let cache = if options.yarn_pnp == self.inner.options.yarn_pnp {
+        let cache = cfg_select! {
+            feature = "yarn_pnp" => {
+                if options.yarn_pnp == self.inner.options.yarn_pnp {
                     Arc::clone(&self.inner.cache)
                 } else {
                     Arc::new(Cache::new(Arc::new(Fs::new(options.yarn_pnp)) as Arc<dyn FileSystem>))
-                };
-            } else {
-                let cache = Arc::clone(&self.inner.cache);
+                }
             }
-        }
+            _ => Arc::clone(&self.inner.cache),
+        };
         let inner = ResolverImpl { options, cache, alias, fallback };
         Self { inner, _marker: std::marker::PhantomData }
     }
@@ -456,12 +453,10 @@ impl ResolverImpl {
             return Ok(path);
         }
 
-        cfg_if::cfg_if! {
-            if #[cfg(not(target_arch = "wasm32"))] {
-                let specifier = file_url::resolve_file_protocol(specifier)?;
-                let specifier = specifier.as_ref();
-            }
-        };
+        #[cfg(not(target_arch = "wasm32"))]
+        let specifier = file_url::resolve_file_protocol(specifier)?;
+        #[cfg(not(target_arch = "wasm32"))]
+        let specifier = specifier.as_ref();
 
         let result = match Path::new(&specifier).components().next() {
             // 2. If X begins with '/'

--- a/src/path.rs
+++ b/src/path.rs
@@ -3,9 +3,10 @@
 //! Code adapted from the following libraries
 //! * [path-absolutize](https://docs.rs/path-absolutize)
 //! * [normalize_path](https://docs.rs/normalize-path)
-use std::path::{Component, Path, PathBuf};
-
-use cfg_if::cfg_if;
+use std::{
+    cfg_select,
+    path::{Component, Path, PathBuf},
+};
 
 pub const SLASH_START: &[char; 2] = &['/', '\\'];
 
@@ -130,11 +131,12 @@ pub fn push_normalized_component(ret: &mut PathBuf, component: Component<'_>) {
             ret.pop();
         }
         Component::Normal(c) => {
-            cfg_if! {
-                if #[cfg(target_family = "wasm")] {
+            cfg_select! {
+                target_family = "wasm" => {
                     // Need to trim the extra \0 introduces by https://github.com/nodejs/uvwasi/issues/262
                     ret.push(c.to_string_lossy().trim_end_matches('\0'));
-                } else {
+                }
+                _ => {
                     ret.push(c);
                 }
             }


### PR DESCRIPTION
Replaces the `cfg-if` crate with `std::cfg_select!`, which was stabilized in Rust 1.95 (its rustdoc even carries `doc(alias = "cfg-if")` as the intended replacement). This drops one dependency.

- Sites with real platform/feature branching (`metadata`, `symlink_metadata`, `read_link`, `Cache::canonicalize`, `normalize_with` wasm handling, `ResolverGeneric::new`/`clone_with_options`) become `cfg_select!` arms; the two `let` sites use it in expression position, which `cfg_if!` could not do.
- The five Yarn-PnP early-return guards in `FileSystemOs` and the non-wasm specifier shadowing in `require_impl` had no else branch, so they become plain `#[cfg]` attributes instead of a macro with an empty fallback arm.

Verified with `just ready` (fmt, typos, check incl. s390x target, tests for default and `--all-features`, napi build + node tests, pnp tests, clippy `--deny warnings`, doc). Windows and wasm arms are token-identical to before and are covered by CI.

Stacked on #1289 (MSRV 1.95.0 bump); retargets to `main` once that merges.