### PR TITLE
chore(deps): update crossbeam-epoch to v0.9.20 to fix RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
RUSTSEC-2026-0204 (invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared`) was published against `crossbeam-epoch` 0.9.18, a transitive dev-dependency via `rayon`. It currently fails the Security Analysis job on every PR and the Cargo Deny job on any PR that touches Cargo.lock.

`cargo update crossbeam-epoch` → v0.9.20, per the advisory's recommended fix.