### PR TITLE
ci: publish with pnpm so workspace catalog: specifiers are resolved

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -205,7 +205,7 @@ jobs:
     name: Publish NAPI
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # for `npm publish --provenance`
+      id-token: write # for `pnpm publish --provenance`
     needs:
       - build
       - build-freebsd
@@ -247,4 +247,14 @@ jobs:
           # Publish root package
           cp package.json napi/package.json
           cp README.md napi/README.md
-          npm publish napi/ --tag latest --provenance --access public
+
+          # Guard: fail if a workspace-only specifier would leak into the published manifest.
+          pnpm -C napi pack --out "$RUNNER_TEMP/pack-check.tgz"
+          if tar -xzOf "$RUNNER_TEMP/pack-check.tgz" package/package.json | grep -nE '"(catalog|workspace):'; then
+            echo "::error::catalog:/workspace: specifier leaked into the packed package.json"
+            exit 1
+          fi
+
+          # pnpm publish (unlike npm publish) resolves `catalog:` specifiers
+          # to concrete versions when packing.
+          pnpm publish napi/ --tag latest --provenance --access public --no-git-checks


### PR DESCRIPTION
Fixes #1292

Since the Vite+ migration, the repo-root `package.json` (which is the published `oxc-resolver` manifest) contains `"vite-plus": "catalog:"` in `devDependencies`. The publish step copies it to `napi/` and publishes with `npm publish`, which does not understand pnpm's workspace-only `catalog:` protocol, so the raw specifier shipped verbatim in 11.20.0, 11.21.2, 11.21.3, 11.22.0, and 11.23.0. Consumers whose pnpm resolves manifests without a lockfile (e.g. legacy `pnpm deploy`) then fail with `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC`.

Changes to the publish job, mirroring oxc's `reusable_release_napi.yml`:

- Publish the root package with `pnpm publish` instead of `npm publish`. pnpm replaces `catalog:`/`workspace:` specifiers with concrete versions at pack time (verified locally: the packed manifest contains `"vite-plus": "^0.2.0"`). `--no-git-checks` is needed because the tree is dirty at publish time (copied `napi/package.json`, downloaded artifacts).
- Add a guard that packs the package and fails the job if any `catalog:`/`workspace:` specifier remains in the packed `package.json`, so this class of bug can't ship silently again (it went unnoticed for 5 releases).

Side effect: `pnpm pack` includes the workspace-root `LICENSE` in the tarball, which the npm package currently lacks.

The platform sub-packages (`@oxc-resolver/binding-*`) are unaffected — their manifests are generated by the napi CLI with concrete versions, and `napi pre-publish` is unchanged.

The already-published affected versions are immutable; the fix takes effect with the next release.