### PR TITLE
ci: remove npm install -g npm@latest from release job

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -228,8 +228,6 @@ jobs:
         with:
           path: artifacts
 
-      - run: npm install -g npm@latest # For trusted publishing support
-
       - name: Prepare dirs and artifacts
         # Invoke napi directly. Going through `pnpm napi ...` triggers pnpm 11's
         # verify-deps-before-run check, which fails after `cp package.json


### PR DESCRIPTION
The `npm install -g npm@latest` step broke the v11.24.0 release (https://github.com/oxc-project/oxc-resolver/actions/runs/29189931751/job/86642999426): npm@latest is now npm 12.0.1, which requires node `^22.22.2 || ^24.15.0 || >=26.0.0`, failing the engines check against the pinned node 24.14.0 and aborting the publish job before anything was published.

The step was added in d5c79bb for trusted publishing support, when `.node-version` was 22.17.0 and the bundled npm predated OIDC trusted publishing (requires npm >= 11.5.1). Node 24.14.0 bundles npm 11.9.0, which supports it, so the upgrade step is obsolete — both publish paths (`napi pre-publish` and `pnpm publish`) still invoke the npm CLI under the hood, and the bundled version is now sufficient.

This also removes the one unpinned package install from a workflow where everything else is SHA-pinned.

After merge, the release will be re-triggered via workflow_dispatch (the version check against unpkg still sees 11.24.0 as unpublished).