### PR TITLE
fix(napi): add explicit "types" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "main": "index.js",
   "browser": "browser.js",
+  "types": "index.d.ts",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
It was reported that the published version has "TypeScript types removed". The types were never removed from the package itself: the 11.24.1 tarball ships a complete `index.d.ts`, and `tsc` resolves it fine under `bundler`/`node16`/`nodenext` (TypeScript falls back to the `.d.ts` next to `main`). What disappeared is the `types` field in the **registry manifest** — every version through 11.23.0 had `"types": "./index.d.ts"`, 11.24.1 has none — so npmjs.com no longer shows the "TypeScript" badge and tools that read types from the manifest (e.g. esm.sh's `X-TypeScript-Types`) lose type discovery.

Root cause: the root `package.json` never declared `types`. It looked fine for years because `npm publish` runs `@npmcli/package-json`'s normalize step, which infers `types` from `main` when a matching `.d.ts` exists on disk and injects `"types": "./index.d.ts"` into the manifest it uploads — while the tarball's `package.json` stays without it (manifest ≠ tarball). #1293 switched the root-package publish to `pnpm publish` to resolve `catalog:` specifiers, and pnpm does no such inference, so the silently-inferred field vanished. (`gitHead`, `bugs`, and `packageManager` dropped out of the manifest for the same reason; those are cosmetic.)

Fix: declare `"types": "index.d.ts"` explicitly so the manifest no longer depends on publish-client behavior. Verified by replicating the CI pack step (`cp package.json napi/ && pnpm -C napi pack`): the packed manifest — which is what `pnpm publish` uploads — now contains `"types": "index.d.ts"`. As a side effect the field now also lands in the tarball's `package.json`, which it never did before.

11.24.1 is immutable; the fix takes effect with the next release.