### PR TITLE
perf: store canonicalization state only where it differs from the path

### DIFF
--- a/src/cache/cache_impl.rs
+++ b/src/cache/cache_impl.rs
@@ -5,7 +5,7 @@ use std::{
     hash::{BuildHasherDefault, Hash, Hasher},
     io,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Weak},
 };
 
 use dashmap::{DashMap, mapref::entry::Entry};
@@ -17,8 +17,13 @@ use super::cached_path::{CachedPath, CachedPathImpl};
 use super::hasher::IdentityHasher;
 use crate::{
     FileMetadata, FileSystem, PackageJson, ResolveError, ResolveOptions, TsConfig,
-    context::ResolveContext as Ctx, path::PathUtil,
+    context::ResolveContext as Ctx,
+    path::{PathUtil, push_normalized_component},
 };
+
+/// Hashes of the symlink nodes currently being resolved in one canonicalization call, for
+/// circular-symlink detection.
+type VisitedLinks = StdHashSet<u64, BuildHasherDefault<IdentityHasher>>;
 
 /// Cache implementation used for caching filesystem access.
 pub struct Cache {
@@ -95,8 +100,11 @@ impl Cache {
     }
 
     pub(crate) fn canonicalize(&self, path: &CachedPath) -> Result<PathBuf, ResolveError> {
-        let cached_path = self.canonicalize_impl(path)?;
-        let path = cached_path.to_path_buf();
+        let path = self.canonicalize_buf(path, &mut None).or_else(|err| {
+            // Fallback: if the cached walk fails (e.g. after a cache clear), try the
+            // filesystem's own canonicalize before reporting the original error.
+            self.fs.canonicalize(path.path()).map_err(|_| err)
+        })?;
         cfg_select! {
             target_os = "windows" => crate::windows::strip_windows_prefix(path),
             _ => Ok(path),
@@ -138,7 +146,17 @@ impl Cache {
         path.meta.followed_or_init(|| match path.link_metadata(self.fs()) {
             Some(meta) if meta.is_symlink() => {
                 let followed = if symlinks {
-                    self.canonicalize_impl(path).ok().and_then(|c| c.link_metadata(self.fs()))
+                    self.resolve_symlink_node(path, &mut None)
+                        .or_else(|err| {
+                            // Same fallback the canonicalize entry point applies: try the
+                            // filesystem's own canonicalize before giving up.
+                            self.fs
+                                .canonicalize(path.path())
+                                .map(|canonical| self.value(&canonical))
+                                .map_err(|_| err)
+                        })
+                        .ok()
+                        .and_then(|c| c.link_metadata(self.fs()))
                 } else {
                     None
                 };
@@ -364,109 +382,177 @@ impl Cache {
         }
     }
 
-    /// Returns the canonical path, resolving all symbolic links.
+    /// Returns the canonical form of `path` as a freshly built `PathBuf`, resolving all
+    /// symbolic links.
     ///
-    /// <https://github.com/parcel-bundler/parcel/blob/4d27ec8b8bd1792f536811fef86e74a31fa0e704/crates/parcel-resolver/src/cache.rs#L232>
-    pub(crate) fn canonicalize_impl(&self, path: &CachedPath) -> Result<CachedPath, ResolveError> {
-        // Each canonicalization chain gets its own visited set for circular symlink detection
-        let mut visited = StdHashSet::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
+    /// Canonicalization state is kept only where it is not redundant: a path that is its own
+    /// canonical form (no ancestor is a symlink — the large majority) carries a one-bit
+    /// `canonical_is_self` flag and no heap, while a symlink or a path below one caches its
+    /// canonical form in `canonicalized`. The previous design instead stored a `(Weak, Box<Path>)`
+    /// on *every* level and interned the whole canonical-side chain alongside the logical one,
+    /// which dominated the cache in symlink-heavy layouts.
+    fn canonicalize_buf(
+        &self,
+        path: &CachedPath,
+        visited: &mut Option<VisitedLinks>,
+    ) -> Result<PathBuf, ResolveError> {
+        // Hot path (warm cache): this exact spelling was already proven canonical, so it is its
+        // own answer — one exact-capacity allocation, no scan.
+        if path.canonical_is_self() {
+            return Ok(path.to_path_buf());
+        }
+        // Hot path (warm cache): a symlink whose target is cached, or a path below a symlink whose
+        // derived canonical form was cached on a previous call. Either way the answer is stored —
+        // no scan, no re-derivation.
+        if let Some((_, canonical)) = path.canonicalized.get() {
+            return Ok(canonical.to_path_buf());
+        }
 
-        // canonicalize_with_visited now handles caching at every recursion level
-        self.canonicalize_with_visited(path, &mut visited).or_else(|err| {
-            // Fallback: if canonicalization fails and path's cache was cleared,
-            // try direct FS canonicalize without caching the result
-            self.fs
-                .canonicalize(path.path())
-                .map(|canonical| self.value(&canonical))
-                .map_err(|_| err)
+        // Scan bottom-up for the nearest ancestor-or-self (`stop`) whose canonical form
+        // (`prefix`) is known, verifying via the cached `lstat` bit that every node below the
+        // stop is not a symlink.
+        let mut node = path.clone();
+        let (prefix, stop) = loop {
+            // Proven canonical already: its own spelling is the prefix.
+            if node.canonical_is_self() {
+                break (node.clone(), node);
+            }
+            // A node with a cached canonical form (a symlink's target, or an already-derived
+            // path below one): use it as the prefix. Consult the cache before `lstat` so a
+            // resolved node costs no syscall.
+            if let Some(prefix) = self.cached_canonical(&node) {
+                break (prefix, node);
+            }
+            // The root is its own canonical form; roots are never `lstat`'d.
+            let Some(parent) = node.parent(self) else {
+                break (node.normalize_root(self), node);
+            };
+            // An unresolved symlink: resolve it (caching the mapping on the node) and use the
+            // target as the prefix.
+            if node.link_metadata(self.fs()).is_some_and(|m| m.is_symlink) {
+                break (self.resolve_symlink_node(&node, visited)?, node);
+            }
+            node = parent;
+        };
+
+        // The scan stopped at `path` itself (a resolved symlink leaf, or the root): the prefix is
+        // already the whole answer.
+        if Arc::ptr_eq(&stop.0, &path.0) {
+            return Ok(prefix.to_path_buf());
+        }
+
+        // Rebuild: fold the suffix below the stop node onto the prefix, in one exact-capacity
+        // allocation. The suffix is relative (the stop node is a textual ancestor), so
+        // `Prefix`/`RootDir` components cannot occur.
+        let suffix = path.path().strip_prefix(stop.path()).unwrap();
+        let prefix_bytes = prefix.path().as_os_str();
+        let extra = path.path().as_os_str().len() - stop.path().as_os_str().len();
+        let mut buf = std::ffi::OsString::with_capacity(prefix_bytes.len() + extra);
+        buf.push(prefix_bytes);
+        let mut result = PathBuf::from(buf);
+        for component in suffix.components() {
+            push_normalized_component(&mut result, component);
+        }
+
+        if result.as_os_str() == path.path().as_os_str() {
+            // The rebuild reproduced the key byte-for-byte: no ancestor was a symlink and every
+            // joint was already normalized, so this spelling *is* canonical, and so is every
+            // prefix of it. Mark the scanned chain so later scans stop immediately — one bit, no
+            // heap.
+            let mut current = path.clone();
+            loop {
+                current.set_canonical_is_self();
+                if Arc::ptr_eq(&current.0, &stop.0) {
+                    break;
+                }
+                let Some(parent) = current.parent(self) else { break };
+                current = parent;
+            }
+        } else {
+            // A path below a symlink: cache its derived canonical form so re-resolving it is O(1)
+            // (matching a per-leaf cache) instead of re-scanning to the symlink and re-folding.
+            // The `Weak` is left dangling: the canonical target is not interned (no twin entry),
+            // and a non-symlink leaf never routes through `resolve_symlink_node`, which is the
+            // only reader of the `Weak`. A symlink leaf already had its mapping set during the
+            // scan, so this `set` is a no-op for it.
+            let _ = path.canonicalized.set((Weak::new(), result.clone().into_boxed_path()));
+        }
+
+        Ok(result)
+    }
+
+    /// The stored canonical form of `node` as an interned [`CachedPath`], or `None` if the node
+    /// has no mapping (it is self-canonical, or not yet resolved).
+    ///
+    /// A mapping's `Weak` is live for a symlink target and dangling for a derived below-symlink
+    /// path; either way, a failed upgrade (a live target evicted from the cache, or the dangling
+    /// sentinel) falls back to re-interning the stored canonical bytes.
+    fn cached_canonical(&self, node: &CachedPath) -> Option<CachedPath> {
+        node.canonicalized.get().map(|(weak, canonical)| {
+            weak.upgrade().map_or_else(|| self.value(canonical), CachedPath)
         })
     }
 
-    /// Internal helper for canonicalization with circular symlink detection.
-    fn canonicalize_with_visited(
+    /// Resolve a symlink node to its canonical target, caching the mapping on the node.
+    ///
+    /// `node` must have `lstat`'d as a symlink (or already hold a stored mapping).
+    fn resolve_symlink_node(
         &self,
-        path: &CachedPath,
-        visited: &mut StdHashSet<u64, BuildHasherDefault<IdentityHasher>>,
+        node: &CachedPath,
+        visited: &mut Option<VisitedLinks>,
     ) -> Result<CachedPath, ResolveError> {
-        // Check cache first - if this path was already canonicalized, return the cached result
-        if let Some((weak, path_box)) = path.canonicalized.get() {
-            return weak
-                .upgrade()
-                .map(CachedPath)
-                .or_else(|| {
-                    // Weak pointer upgrade failed - recreate from the stored canonical path
-                    Some(self.value(path_box))
-                })
-                .ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::NotFound, "Cached path no longer exists").into()
-                });
+        if let Some(canonical) = self.cached_canonical(node) {
+            return Ok(canonical);
         }
 
-        // Check for circular symlink by tracking visited paths in the current canonicalization chain
-        if !visited.insert(path.hash) {
+        // A chain that re-enters a symlink still being resolved is circular. The set is
+        // allocated lazily: most canonicalize calls never meet a symlink.
+        if !visited.get_or_insert_default().insert(node.hash) {
             return Err(io::Error::new(io::ErrorKind::NotFound, "Circular symlink").into());
         }
 
-        let res = path.parent(self).map_or_else(
-            || Ok(path.normalize_root(self)),
-            |parent| {
-                let parent_canonical = self.canonicalize_with_visited(&parent, visited)?;
-                // When no ancestor is a symlink — the common case — the parent
-                // canonicalizes to itself, so `parent_canonical` is `parent`'s own interned
-                // Arc and the rebuild below would just re-derive `path`'s existing key.
-                // Skip it (the strip_prefix, scratch-buffer copy, hash, and shard probe)
-                // and return this entry directly. That is only sound when the key is
-                // spelled exactly `<parent><MAIN_SEPARATOR><file_name>`: spellings the
-                // rebuild would fold — `.`/`..` tails, trailing or doubled separators, a
-                // `/` joint on Windows — fail the shape check and rebuild as before. The
-                // byte before the joint must be a non-separator because a root parent
-                // already ends with the separator (the rebuild appends none), so with
-                // `//x` or `C:\\x` the `+ 1` would count the doubled separator itself.
-                // Wasm always rebuilds: component normalization trims uvwasi's trailing
-                // NULs, which reuse would keep.
-                let path_bytes = path.path().as_os_str().as_encoded_bytes();
-                let parent_len = parent.path().as_os_str().len();
-                let normalized = if cfg!(not(target_family = "wasm"))
-                    && Arc::ptr_eq(&parent_canonical.0, &parent.0)
-                    && path.path().file_name().is_some_and(|name| {
-                        parent_len + 1 + name.len() == path_bytes.len()
-                            && path_bytes[parent_len] == std::path::MAIN_SEPARATOR as u8
-                            && path_bytes[parent_len - 1] != std::path::MAIN_SEPARATOR as u8
-                    }) {
-                    path.clone()
-                } else {
-                    parent_canonical
-                        .normalize_with(path.path().strip_prefix(parent.path()).unwrap(), self)
-                };
+        // Read the link through its canonical parent spelling. A symlink's last component is
+        // always a plain name: the OS resolves `.`/`..`/trailing-separator spellings before
+        // classifying, so those never `lstat` as symlinks.
+        let mut link_path = match node.parent(self) {
+            Some(parent) => {
+                let mut link_path = self.canonicalize_buf(&parent, visited)?;
+                node.path().file_name().map_or_else(
+                    || node.to_path_buf(),
+                    |name| {
+                        link_path.push(name);
+                        link_path
+                    },
+                )
+            }
+            None => node.to_path_buf(),
+        };
+        let link = self.fs.read_link(&link_path)?;
 
-                if path.link_metadata(self.fs()).is_some_and(|m| m.is_symlink) {
-                    let link = self.fs.read_link(normalized.path())?;
-                    if link.is_absolute() {
-                        return self
-                            .canonicalize_with_visited(&self.value(&link.normalize()), visited);
-                    } else if let Some(dir) = normalized.parent(self) {
-                        // Symlink is relative `../../foo.js`, use the path directory
-                        // to resolve this symlink.
-                        return self
-                            .canonicalize_with_visited(&dir.normalize_with(&link, self), visited);
-                    }
-                    debug_assert!(
-                        false,
-                        "Failed to get path parent for {}.",
-                        normalized.path().display()
-                    );
-                }
+        let target = if link.is_absolute() {
+            link.normalize()
+        } else {
+            // Resolve the relative target against the canonical parent directory. `normalize_with`
+            // folds `.`/`..` and escapes a rooted-but-not-absolute head (`\dir`, `C:rel` on
+            // Windows) or an empty link verbatim.
+            link_path.pop();
+            link_path.normalize_with(&link)
+        };
 
-                Ok(normalized)
-            },
-        )?;
+        // The target chain may itself contain symlinks. Only the target and its canonical form
+        // are interned — the mapping needs a durable entry to point at.
+        let target = self.value(&target);
+        let canonical_buf = self.canonicalize_buf(&target, visited)?;
+        let canonical = if canonical_buf.as_os_str() == target.path().as_os_str() {
+            target
+        } else {
+            self.value(&canonical_buf)
+        };
 
-        // Cache the result before removing from visited set
-        // This ensures parent canonicalization results are cached and reused
-        let _ = path.canonicalized.set((Arc::downgrade(&res.0), res.0.path.clone()));
-
-        // Remove from visited set when unwinding the recursion
-        visited.remove(&path.hash);
-        Ok(res)
+        let _ = node.canonicalized.set((Arc::downgrade(&canonical.0), canonical.0.path.clone()));
+        if let Some(visited) = visited.as_mut() {
+            visited.remove(&node.hash);
+        }
+        Ok(canonical)
     }
 }

--- a/src/cache/cached_path.rs
+++ b/src/cache/cached_path.rs
@@ -4,7 +4,10 @@ use std::{
     hash::{Hash, Hasher},
     ops::Deref,
     path::{Component, Path, PathBuf},
-    sync::{Arc, Weak},
+    sync::{
+        Arc, Weak,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use once_cell::sync::OnceCell as OnceLock;
@@ -29,6 +32,15 @@ pub struct CachedPathImpl {
     /// Cached `(is_file, is_dir)` filesystem metadata packed into one byte. See
     /// [`CachedMeta`] for the encoding and the rationale for skipping `OnceLock`.
     pub meta: CachedMeta,
+    /// This path's spelling was proven to be its own canonical form: no ancestor (or self) is a
+    /// symlink and the key needs no normalization. Lets a canonicalization scan stop here
+    /// instead of re-walking to the root. A lost update under a race only costs a re-derivation.
+    pub canonical_is_self: AtomicBool,
+    /// The canonical form of this path, set only where it differs from the path itself: a symlink
+    /// (target, with a live `Weak` used by `followed_metadata`) or a path below a symlink (its
+    /// derived canonical form, with a dangling `Weak`). A path that is its own canonical form uses
+    /// the [`Self::canonical_is_self`] bit instead, storing no heap — the common case, which
+    /// otherwise pinned a `(Weak, Box<Path>)` byte-copy of its own spelling on every cached path.
     /// Stored as `Box<Path>` (not `PathBuf`) to save 8 bytes per cached path entry —
     /// the canonical path is set once and never mutated.
     pub canonicalized: OnceLock<(Weak<Self>, Box<Path>)>,
@@ -55,6 +67,7 @@ impl CachedPathImpl {
             is_node_modules,
             inside_node_modules,
             meta: CachedMeta::new(),
+            canonical_is_self: AtomicBool::new(false),
             canonicalized: OnceLock::new(),
             node_modules: OnceLock::new(),
             package_json: OnceLock::new(),
@@ -231,6 +244,14 @@ impl CachedPath {
     /// whether to follow a symlink — so the two share a single `lstat` syscall per path.
     pub(crate) fn link_metadata(&self, fs: &dyn FileSystem) -> Option<FileMetadata> {
         self.meta.link_or_init(|| fs.symlink_metadata(&self.path).ok())
+    }
+
+    pub(crate) fn canonical_is_self(&self) -> bool {
+        self.canonical_is_self.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn set_canonical_is_self(&self) {
+        self.canonical_is_self.store(true, Ordering::Relaxed);
     }
 }
 

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -315,6 +315,7 @@ fn canonicalize_matches_os_for_all_node_modules() {
 fn canonicalize_dirty_cache_keys() {
     let f = super::fixture();
     let sep = std::path::MAIN_SEPARATOR;
+    let m1 = f.join("node_modules").join("m1");
     let mut dirty = vec![
         f.join(".."),
         f.join("lib").join(".."),
@@ -322,7 +323,20 @@ fn canonicalize_dirty_cache_keys() {
         f.join("lib").join(".").join("complex1.js"),
         PathBuf::from(format!("{}{sep}", f.join("lib").display())),
         PathBuf::from(format!("{}{sep}{sep}complex1.js", f.join("lib").display())),
+        m1.join(".").join("a.js"),
+        m1.join("..").join("m1").join("a.js"),
+        PathBuf::from(format!("{}{sep}", m1.display())),
+        PathBuf::from(format!("{}{sep}{sep}a.js", m1.display())),
     ];
+    let anchor = fixture_root()
+        .join("node_modules-canonicalize")
+        .join("symlinked-workspace")
+        .join("node_modules")
+        .join("pkg");
+    if fs::symlink_metadata(&anchor).is_ok_and(|m| m.is_symlink()) {
+        dirty.push(anchor.join(".").join("real").join("file.js"));
+        dirty.push(PathBuf::from(format!("{}{sep}{sep}real{sep}file.js", anchor.display())));
+    }
     #[cfg(unix)]
     {
         dirty.push(PathBuf::from(format!("{sep}{}", f.display())));
@@ -442,4 +456,52 @@ fn nested_monorepo_canonicalize_matches_os() {
         resolve(&root.join("node_modules/dep/index.js")),
         root.join("node_modules/.pnpm/dep@2.0.0/node_modules/dep/index.js")
     );
+}
+
+#[test]
+fn canonicalize_stores_no_self_referential_mappings() {
+    // Native separators throughout: canonicalization rebuilds with `MAIN_SEPARATOR`, so a key that
+    // mixed `/` and `\` would not be recognized as its own canonical form on Windows.
+    let root = fixture_root().join("node_modules-canonicalize").join("nested-monorepo");
+    let anchor = root.join("node_modules").join("dep");
+    if !fs::symlink_metadata(&anchor).is_ok_and(|m| m.is_symlink()) {
+        eprintln!("skip canonicalize_stores_no_self_referential_mappings: symlinks unavailable");
+        return;
+    }
+
+    let resolver = Resolver::new(ResolveOptions::default());
+    let logical = anchor.join("index.js");
+    let store_dir =
+        root.join("node_modules").join(".pnpm").join("dep@2.0.0").join("node_modules").join("dep");
+    let store = store_dir.join("index.js");
+    let canonical = resolver.cache.canonicalize(&resolver.cache.value(&logical)).unwrap();
+    assert_eq!(canonical, store);
+
+    // A path that is its own canonical form (the real store file) stores no per-node canonical:
+    // it is marked with the one-bit `canonical_is_self` flag instead. This is the #852 win — the
+    // majority of cache entries are self-canonical and previously each pinned a `(Weak, Box)`.
+    let store_entry = resolver.cache.canonicalize(&resolver.cache.value(&store)).unwrap();
+    assert_eq!(store_entry, store);
+    let store_cached = resolver.cache.value(&store);
+    assert!(store_cached.canonical_is_self());
+    assert!(store_cached.canonicalized.get().is_none());
+
+    // No cache entry carries a self-referential mapping (a canonical form equal to its own key).
+    for entry in &resolver.cache.paths {
+        let key = entry.key();
+        if let Some((_, canonical)) = key.canonicalized.get() {
+            assert_ne!(
+                canonical.as_os_str(),
+                key.path().as_os_str(),
+                "a path equal to its own canonical form must use the bit, not a stored mapping: {}",
+                key.path().display()
+            );
+        }
+    }
+
+    // The symlink node keeps a live mapping to its interned target (needed by `followed_metadata`).
+    let anchor_cached = resolver.cache.value(&anchor);
+    let (weak, target) = anchor_cached.canonicalized.get().expect("symlink node stores a mapping");
+    assert!(weak.upgrade().is_some(), "the symlink node's mapping target stays interned");
+    assert_eq!(target.as_os_str(), store_dir.as_os_str());
 }


### PR DESCRIPTION
## Problem

Canonicalization cached a `(Weak, Box<Path>)` result on **every** path level and interned the whole canonical-side chain alongside the logical one. For a single pnpm package both `node_modules/pkg/*` and `node_modules/.pnpm/pkg@x/node_modules/pkg/*` were fully interned, and every node of both chains stored a canonical mapping — on a path that is its own canonical form (the large majority) that is a self-referential `Weak` plus a byte-copy of the node's own spelling. #852 measured 63% of cache entries carrying such a mapping.

## Change

Keep canonicalization state only where it is **not** redundant, in three states:

- A path that is its own canonical form (no ancestor is a symlink) carries a one-bit `canonical_is_self` flag and no heap.
- A symlink stores its resolved target (live `Weak`, used by `followed_metadata`).
- A path below a symlink caches its derived canonical form so re-resolving it stays O(1).

`Cache::canonicalize` first tries two O(1) warm-cache checks (the bit, then the stored mapping); on a miss it scans the cached parent chain bottom-up to the nearest node whose canonical form is known, verifies via the cached `lstat` bits that the suffix contains no symlink, then folds the suffix onto the prefix in one exact-capacity allocation. Results are never interned; only symlink targets are (the mapping needs a durable entry). The pnpm anchor mapping (`node_modules/pkg -> .pnpm/...`) emerges naturally as the symlink node's mapping — no `node_modules` special-casing.

## Measurements

bench-pm workload (16 requests × 8 layouts), deterministic metrics:

| combo | entries (before → after) | entries w/ canonical mapping | key + mapping heap bytes |
|---|---|---|---|
| npm-flat | 67 → 64 | 50 → 5 | −40% |
| pnpm-isolated | 103 → 83 | 71 → 21 | −41% |
| yarn-isolated | 96 → 76 | 64 → 21 | −40% |
| bun-isolated | 103 → 83 | 71 → 21 | −41% |

- **Cold allocations:** −6 to −9% (npm-flat 1086 → 1020, pnpm-isolated 1211 → 1127).
- **Filesystem syscalls:** byte-identical before/after (per-op-type and total, 822 cold). The per-suffix `lstat`s are required — an in-package symlink below a package anchor must still be followed, which the `canonicalize_matches_os_for_all_node_modules` OS-equality test pins.
- **Warm resolution:** at parity. Warm allocations identical (22 = 22, all combos); wall time within noise on `resolver_memory` / `resolver_real` single-thread and `resolve from symlinks` (measured with isolated interleaved binaries: single-thread ~22.0µs both; symlinks ~3.25ms both). CodSpeed reports NEUTRAL.

> First iteration dropped per-leaf caching entirely (as #852 literally describes) and regressed warm resolution ~5%, because paths below a symlink re-derived each call. The shipped design keeps the `canonical_is_self` bit for the self-canonical majority (the real waste) **and** caches through-symlink leaves, so it captures the memory win with no warm regression.

## Tests

- Extended `canonicalize_dirty_cache_keys` with node_modules-internal dirty spellings (including under a symlinked anchor) and a Windows separator case.
- `canonicalize_stores_no_self_referential_mappings`, pinning that a self-canonical path stores no mapping (uses the bit) and that the symlink node keeps a live mapping to its interned target.

Closes #852. Refs #1202 — this removes the per-level canonical result caching and canonical-side interning that issue targets; the remaining per-component `lstat`s are required by the OS-equality contract, so syscall counts are unchanged (they were already minimized by the earlier lstat-unification work).