### PR TITLE
feat: record tsconfig files loaded through the `extends` chain

### DIFF
--- a/src/tests/tsconfig_extends.rs
+++ b/src/tests/tsconfig_extends.rs
@@ -144,6 +144,34 @@ fn test_extend_tsconfig_multiple_inheritance() {
 }
 
 #[test]
+fn test_extended_paths() {
+    let resolve = |case: &str| {
+        let f = super::fixture_root().join("tsconfig/cases").join(case);
+        let resolver = Resolver::new(ResolveOptions {
+            tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
+                config_file: f.join("tsconfig.json"),
+                references: TsconfigReferences::Auto,
+            })),
+            ..ResolveOptions::default()
+        });
+        let resolution = resolver.resolve_tsconfig(&f).expect("resolved");
+        (f, resolution)
+    };
+
+    // Transitive chain: tsconfig.json -> intermediate-tsconfig.json -> base-tsconfig.json
+    let (f, resolution) = resolve("extends-chain");
+    assert_eq!(
+        resolution.extended_paths(),
+        [f.join("base-tsconfig.json"), f.join("intermediate-tsconfig.json")]
+    );
+
+    // Diamond: tsconfig.json -> [b.json, c.json], both extend d.json.
+    // Each file is recorded exactly once.
+    let (f, resolution) = resolve("extends-diamond");
+    assert_eq!(resolution.extended_paths(), [f.join("d.json"), f.join("c.json"), f.join("b.json")]);
+}
+
+#[test]
 fn test_extend_tsconfig_preserves_child_settings() {
     let f = super::fixture_root().join("tsconfig/cases/extends-preserve-child");
 

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -62,6 +62,10 @@ pub struct TsConfig {
     #[serde(default)]
     pub extends: Option<ExtendsField>,
 
+    /// Tsconfig files loaded transitively through the `extends` chain.
+    #[serde(skip)]
+    pub extended_paths: Vec<PathBuf>,
+
     #[serde(default)]
     pub compiler_options: CompilerOptions,
 
@@ -173,6 +177,12 @@ impl TsConfig {
     pub fn directory(&self) -> &Path {
         debug_assert!(self.path.file_name().is_some());
         self.path.parent().unwrap()
+    }
+
+    /// Tsconfig files loaded transitively through the `extends` chain.
+    #[must_use]
+    pub fn extended_paths(&self) -> &[PathBuf] {
+        &self.extended_paths
     }
 
     /// Returns any paths to tsconfigs that should be extended by this tsconfig.

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -233,6 +233,18 @@ impl ResolverImpl {
                             TsconfigReferences::Disabled,
                             ctx,
                         )?;
+                        // Record the loaded base and its own extends chain,
+                        // deduplicated for diamond-shaped chains.
+                        for base_path in extended_tsconfig
+                            .extended_paths
+                            .iter()
+                            .cloned()
+                            .chain(std::iter::once(extended_tsconfig.path().to_path_buf()))
+                        {
+                            if !tsconfig.extended_paths.contains(&base_path) {
+                                tsconfig.extended_paths.push(base_path);
+                            }
+                        }
                         tsconfig.extend_tsconfig(&extended_tsconfig);
                     }
                     Result::Ok::<(), ResolveError>(())


### PR DESCRIPTION
This adds an `extended_paths` field to `TsConfig` that records every tsconfig file loaded transitively through the `extends` chain, together with an `extended_paths()` accessor.

The motivation is bundler watch mode. Rolldown registers the discovered tsconfig as a watch file so that editing it triggers a rebuild. But when part of the effective options comes from a base config via `extends`, editing that base file changes the build output without touching any watched file, so no rebuild happens. To watch the whole chain the caller needs to know which files were actually loaded, and only the resolver knows that. See rolldown/rolldown#9598.

Implementation notes:

- Recording happens in `load_tsconfig` while processing `extends`, before the config enters the cache, so cache hits carry the paths as well.
- Each loaded base contributes its own transitive chain, and entries are deduplicated, so a diamond-shaped chain (`tsconfig.json` extends `b` and `c`, both extend `d`) lists each file exactly once.
- The field is `pub` with `#[serde(skip)]`, mirroring `references_resolved`.
