### PR TITLE
chore(napi): widen napi req for rolldown 3.12.0-alpha testing

### DIFF
--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -22,8 +22,8 @@ doctest = false
 [dependencies]
 oxc_resolver = { workspace = true }
 
-napi = { version = "3.8", default-features = false, features = ["napi3", "serde-json"] }
-napi-derive = { version = "3" }
+napi = { version = ">=3.12.0-alpha.0, <4", default-features = false, features = ["napi3", "serde-json"] }
+napi-derive = { version = ">=3.7.0-alpha.0, <4" }
 regress = { version = "0.11" } # ECMAScript regex engine for `Restriction` regex
 tracing-subscriber = { version = "0.3.23", optional = true, default-features = false, features = [
   "std",


### PR DESCRIPTION
**Draft — not for merge.** Temporary patch branch consumed via rolldown's `[patch.crates-io]` so that rolldown/rolldown#10350 (tokio-free custom async runtime) can build against the published napi `3.12.0-alpha.0` / napi-derive `3.7.0-alpha.0` prerelease bundle.

Cargo's SemVer rule only lets a prerelease satisfy a comparator naming the same `major.minor.patch` with a prerelease tag, so a plain `^3.x` (here `napi = "3.8"`) excludes `3.12.0-alpha.0`. This branch widens `oxc_resolver_napi`'s `napi` / `napi-derive` requirement to `>=3.12.0-alpha.0, <4` / `>=3.7.0-alpha.0, <4`. Branched off the released **v11.24.2** tag; crate content is otherwise unchanged.

Kept as a draft while the napi alphas are validated in rolldown CI. Close once the napi bundle ships a normal release (or re-touch on each alpha bump).
