### PR TITLE
ci(release-napi): support `loongarch64-unknown-linux-gnu`    

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -79,6 +79,14 @@ jobs:
             target: armv7-unknown-linux-musleabihf
             build: pnpm build -x
           - os: ubuntu-latest
+            target: loongarch64-unknown-linux-gnu
+            build: |-
+              sudo apt-get update &&
+              sudo apt-get install gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu -y &&
+              export TARGET_CC=loongarch64-linux-gnu-gcc-14 &&
+              export CXX=loongarch64-linux-gnu-g++-14 &&
+              pnpm build
+          - os: ubuntu-latest
             target: powerpc64le-unknown-linux-gnu
             build: pnpm build --use-napi-cross
           - os: ubuntu-latest

--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -82,9 +82,9 @@ jobs:
             target: loongarch64-unknown-linux-gnu
             build: |-
               sudo apt-get update &&
-              sudo apt-get install gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu -y &&
-              export TARGET_CC=loongarch64-linux-gnu-gcc-14 &&
-              export CXX=loongarch64-linux-gnu-g++-14 &&
+              sudo apt-get install gcc-13-loongarch64-linux-gnu g++-13-loongarch64-linux-gnu -y &&
+              export TARGET_CC=loongarch64-linux-gnu-gcc-13 &&
+              export CXX=loongarch64-linux-gnu-g++-13 &&
               pnpm build
           - os: ubuntu-latest
             target: powerpc64le-unknown-linux-gnu

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
+      "loongarch64-unknown-linux-gnu",
       "powerpc64le-unknown-linux-gnu",
       "riscv64gc-unknown-linux-gnu",
       "riscv64gc-unknown-linux-musl",


### PR DESCRIPTION
 ## Summary

  - add `loongarch64-unknown-linux-gnu` to the N-API release targets
  - build the binding with Ubuntu's GCC 13 LoongArch cross toolchain
  - keep LoongArch musl support out of scope

  The generated N-API loader already supports `process.arch === "loong64"`
  and loads `@oxc-resolver/binding-linux-loong64-gnu`, so no generated loader
  changes are required.

  ## Motivation

  This enables publishing a prebuilt GNU/Linux LoongArch64 binding for
  `oxc-resolver`, which is required by downstream projects such as Rolldown.

  ## Validation

  Tested on a native LoongArch64 GNU/Linux system:

  - `cargo +stable fmt --all -- --check`
  - `cargo +stable check --all-features --all-targets --locked`
  - `cargo +stable clippy --all-features --all-targets --locked -- --deny warnings`
  - `cargo +stable build -p oxc_resolver_napi --features allocator --release --locked`
  - verified the resulting shared object is a LoongArch ELF
  - verified automatic native binding loading with Node.js
  - verified resolving `package.json` through the native binding
  - cross-built `loongarch64-unknown-linux-gnu` with GCC 13 on GitHub Actions
  - verified the generated artifact is a LoongArch ELF
  - [fork CI smoke build](https://github.com/cheungxi/oxc-resolver/actions/runs/31081962038)

  ## Notes

  This PR intentionally supports GNU/Linux only. LoongArch musl support is
  not included.

  The full `just ready` workflow cannot currently run on native LoongArch
  because Vite+ does not publish a LoongArch binding. The Rust checks,
  native N-API build, and Node.js loading smoke test passed locally.
