### PR TITLE
chore: reduce Rust dev debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,9 @@ codspeed = ["criterion2/codspeed"]
 # and we don't rely on it for debugging that much.
 debug = false
 
+[profile.dev.package."*"]
+debug = false
+
 [profile.test]
 # Disabling debug info speeds up local and CI builds,
 # and we don't rely on it for debugging that much.


### PR DESCRIPTION
Reduces debug information for local Rust builds and disables debug information for dependencies.