### PR TITLE
fix(tsconfig): resolve dot-prefixed path aliases

### DIFF
--- a/fixtures/tsconfig/cases/dot-prefixed-paths/.base-url.ts
+++ b/fixtures/tsconfig/cases/dot-prefixed-paths/.base-url.ts
@@ -1,0 +1,1 @@
+export const baseUrl = {};

--- a/fixtures/tsconfig/cases/dot-prefixed-paths/.storybook/preview.ts
+++ b/fixtures/tsconfig/cases/dot-prefixed-paths/.storybook/preview.ts
@@ -1,0 +1,1 @@
+export const preview = {};

--- a/fixtures/tsconfig/cases/dot-prefixed-paths/alias/module.ts
+++ b/fixtures/tsconfig/cases/dot-prefixed-paths/alias/module.ts
@@ -1,0 +1,1 @@
+export const module = {};

--- a/fixtures/tsconfig/cases/dot-prefixed-paths/exact.ts
+++ b/fixtures/tsconfig/cases/dot-prefixed-paths/exact.ts
@@ -1,0 +1,1 @@
+export const exact = {};

--- a/fixtures/tsconfig/cases/dot-prefixed-paths/index.ts
+++ b/fixtures/tsconfig/cases/dot-prefixed-paths/index.ts
@@ -1,0 +1,4 @@
+import ".exact";
+import ".storybook/preview";
+import "..alias/module";
+import ".base-url";

--- a/fixtures/tsconfig/cases/dot-prefixed-paths/tsconfig.json
+++ b/fixtures/tsconfig/cases/dot-prefixed-paths/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      ".exact": ["./exact.ts"],
+      ".storybook/*": ["./.storybook/*"],
+      "..alias/*": ["./alias/*"]
+    }
+  }
+}

--- a/src/dts_resolver.rs
+++ b/src/dts_resolver.rs
@@ -16,6 +16,7 @@ use std::{borrow::Cow, path::Path};
 use crate::{
     CachedPath, PackageJson, ResolveError, ResolverImpl,
     context::ResolveContext as Ctx,
+    path::is_path_relative,
     resolution::{ModuleType, Resolution},
     specifier::Specifier,
 };
@@ -115,7 +116,7 @@ impl ResolverImpl {
         let specifier = parsed.path();
 
         // 1. tsconfig paths (non-relative only)
-        if !specifier.starts_with('.')
+        if !is_path_relative(specifier)
             && !specifier.starts_with('/')
             && let Some(path) = self.dts_resolve_tsconfig_paths(specifier, &mut ctx)?
         {
@@ -123,7 +124,7 @@ impl ResolverImpl {
         }
 
         // 2. Route by specifier type
-        let result = if specifier.starts_with('.') || specifier.starts_with('/') {
+        let result = if is_path_relative(specifier) || specifier.starts_with('/') {
             // Relative or absolute
             let candidate = cached_dir.normalize_with(specifier, &self.cache);
             self.dts_resolve_relative(extensions, &candidate, &mut ctx)?

--- a/src/path.rs
+++ b/src/path.rs
@@ -10,6 +10,22 @@ use std::{
 
 pub const SLASH_START: &[char; 2] = &['/', '\\'];
 
+/// Whether a path starts with a relative path component (`.` or `..`).
+///
+/// Matches TypeScript's `pathIsRelative` helper.
+#[inline]
+pub fn is_path_relative(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    if bytes.first() != Some(&b'.') {
+        return false;
+    }
+    match bytes.get(1) {
+        None | Some(b'/' | b'\\') => true,
+        Some(b'.') => matches!(bytes.get(2), None | Some(b'/' | b'\\')),
+        _ => false,
+    }
+}
+
 /// Extension trait to add path normalization to std's [`Path`].
 pub trait PathUtil {
     /// Normalize this path without performing I/O.
@@ -166,6 +182,16 @@ fn is_invalid_exports_target() {
 
     assert!(!Path::new("C:").is_invalid_exports_target());
     assert!(!Path::new("/").is_invalid_exports_target());
+}
+
+#[test]
+fn path_relative() {
+    for path in [".", "..", "./foo", ".\\foo", "../foo", "..\\foo"] {
+        assert!(is_path_relative(path), "{path}");
+    }
+    for path in ["", "foo", ".storybook", "..alias", ".../foo"] {
+        assert!(!is_path_relative(path), "{path}");
+    }
 }
 
 #[test]

--- a/src/tests/dts_resolver.rs
+++ b/src/tests/dts_resolver.rs
@@ -1,4 +1,6 @@
-use crate::{ResolveError, ResolveOptions, Resolver, TsconfigDiscovery, TsconfigOptions};
+use crate::{
+    Resolution, ResolveError, ResolveOptions, Resolver, TsconfigDiscovery, TsconfigOptions,
+};
 
 fn dts_fixture() -> std::path::PathBuf {
     super::fixture_root().join("dts-resolver")
@@ -254,6 +256,31 @@ fn tsconfig_paths_in_dts() {
     let containing = dts_fixture().join("with-tsconfig/index.ts");
     let result = r.resolve_dts(containing, "@lib/utils").unwrap();
     assert_eq!(result.path(), dts_fixture().join("with-tsconfig/lib/utils.ts"));
+}
+
+#[test]
+fn dot_prefixed_tsconfig_paths_in_dts() {
+    let f = super::fixture_root().join("tsconfig/cases/dot-prefixed-paths");
+    let r = Resolver::new(ResolveOptions {
+        condition_names: vec!["import".into(), "types".into()],
+        tsconfig: Some(TsconfigDiscovery::Manual(TsconfigOptions {
+            config_file: f.join("tsconfig.json"),
+            references: crate::TsconfigReferences::Disabled,
+        })),
+        ..ResolveOptions::default()
+    });
+
+    #[rustfmt::skip]
+    let pass = [
+        (".exact", f.join("exact.ts")),
+        (".storybook/preview", f.join(".storybook/preview.ts")),
+        ("..alias/module", f.join("alias/module.ts")),
+        (".base-url", f.join(".base-url.ts")),
+    ];
+    for (request, expected) in pass {
+        let result = r.resolve_dts(f.join("index.ts"), request).map(Resolution::into_path_buf);
+        assert_eq!(result, Ok(expected), "{request}");
+    }
 }
 
 // -------- Extension substitution: .mjs → .mts priority --------

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -300,6 +300,39 @@ fn test_parent_base_url() {
 }
 
 #[test]
+fn test_dot_prefixed_non_relative_specifiers() {
+    let f = super::fixture_root().join("tsconfig/cases/dot-prefixed-paths");
+
+    #[rustfmt::skip]
+    let pass = [
+        (".exact", f.join("exact.ts")),
+        (".storybook/preview", f.join(".storybook/preview.ts")),
+        ("..alias/module", f.join("alias/module.ts")),
+        (".base-url", f.join(".base-url.ts")),
+    ];
+
+    for tsconfig_discovery in [false, true] {
+        let resolver = Resolver::new(ResolveOptions {
+            tsconfig: Some(if tsconfig_discovery {
+                TsconfigDiscovery::Auto
+            } else {
+                TsconfigDiscovery::Manual(TsconfigOptions {
+                    config_file: f.join("tsconfig.json"),
+                    references: TsconfigReferences::Auto,
+                })
+            }),
+            ..ResolveOptions::default().with_extension(String::from(".ts"))
+        });
+
+        for (request, expected) in &pass {
+            let resolved_path =
+                resolver.resolve_file(f.join("index.ts"), request).map(|f| f.full_path());
+            assert_eq!(resolved_path, Ok(expected.clone()), "{request} {tsconfig_discovery}");
+        }
+    }
+}
+
+#[test]
 fn test_tsconfig_mixed_root_non_root_cache() {
     let f = super::fixture_root().join("tsconfig");
     let f2 = f.join("cases").join("simple-paths");

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -11,7 +11,11 @@ use indexmap::IndexMap;
 use rustc_hash::FxHasher;
 use serde::Deserialize;
 
-use crate::{TsconfigReferences, path::PathUtil, replace_bom_with_whitespace};
+use crate::{
+    TsconfigReferences,
+    path::{PathUtil, is_path_relative},
+    replace_bom_with_whitespace,
+};
 
 /// Template variable `${configDir}` for substitution of config files
 /// directory path.
@@ -490,7 +494,7 @@ impl TsConfig {
     // <https://github.com/parcel-bundler/parcel/blob/b6224fd519f95e68d8b93ba90376fd94c8b76e69/packages/utils/node-resolver-rs/src/tsconfig.rs#L93>
     #[must_use]
     pub(crate) fn resolve_path_alias(&self, specifier: &str) -> Vec<PathBuf> {
-        if specifier.starts_with('.') {
+        if is_path_relative(specifier) {
             return Vec::new();
         }
 

--- a/src/tsconfig_resolver.rs
+++ b/src/tsconfig_resolver.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::{
     CachedPath, Ctx, ResolveError, ResolveOptions, ResolveResult, ResolverImpl, Specifier,
     SpecifierError, TsConfig, TsconfigDiscovery, TsconfigOptions, TsconfigReferences,
-    path::PathUtil,
+    path::{PathUtil, is_path_relative},
 };
 
 #[derive(Default)]
@@ -294,8 +294,8 @@ impl ResolverImpl {
 
     /// Resolves
     /// * `compilerOptions.paths`
-    /// * `compilerOptions.rootDirs` (if specifier starts with `.`)
-    /// * `compilerOptions.baseUrl` (if specifier does not start with `.`)
+    /// * `compilerOptions.rootDirs` (if specifier is relative)
+    /// * `compilerOptions.baseUrl` (if specifier is non-relative)
     // <https://github.com/microsoft/TypeScript/blob/v5.9.3/src/compiler/moduleNameResolver.ts#L1550>
     pub(crate) fn resolve_tsconfig_compiler_options(
         &self,
@@ -338,7 +338,7 @@ impl ResolverImpl {
                 return Ok(Some(resolution));
             }
         }
-        if specifier.starts_with('.') {
+        if is_path_relative(specifier) {
             if let Some(path) =
                 self.load_tsconfig_root_dirs(cached_path, specifier, tsconfig, ctx)?
             {
@@ -362,7 +362,7 @@ impl ResolverImpl {
         tsconfig: &TsConfig,
         ctx: &mut Ctx,
     ) -> ResolveResult {
-        debug_assert!(specifier.starts_with('.'));
+        debug_assert!(is_path_relative(specifier));
         debug_assert!(!cached_path.inside_node_modules());
         let Some(root_dirs) = &tsconfig.compiler_options.root_dirs else { return Ok(None) };
 


### PR DESCRIPTION
TypeScript treats dot-prefixed names such as `.storybook/preview` and `..alias/module` as non-relative, but oxc-resolver rejected them before consulting `compilerOptions.paths` and routed them away from `baseUrl`. This follows the TypeScript `pathIsRelative` behavior in normal and DTS resolution, with fixtures for exact and wildcard paths plus `baseUrl` fallback; reported in aleclarson/vite-tsconfig-paths#217.