### PR TITLE
chore(deps): bump regress and pnp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,9 +876,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pnp"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57281b9cdf635e68b57fc347e213b413f099d57cdd708182d5e759418d41485"
+checksum = "5a0e591607db15df65036bd424bd57782296da9963d823da5a139ed451f615b5"
 dependencies = [
  "byteorder",
  "concurrent_lru",
@@ -984,11 +984,10 @@ dependencies = [
 
 [[package]]
 name = "regress"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
+checksum = "32eef8b209c3c1c15dbad02c1f30f9539f00dc7253e0cbcdaae442a50a09d7c1"
 dependencies = [
- "hashbrown 0.16.1",
  "memchr",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ thiserror = "2"
 tracing = "0.1"
 
 percent-encoding = "2"
-pnp = { version = "0.12.10", optional = true }
+pnp = { version = "0.12.12", optional = true }
 
 document-features = { version = "0.2.12", optional = true }
 
@@ -135,7 +135,7 @@ criterion2 = { version = "3.0.3", default-features = false }
 dirs = { version = "6.0.0" }
 pico-args = "0.5.0"
 rayon = { version = "1.12.0" }
-regress = { version = "0.11" } # ECMAScript regex engine for testing `Restriction::Fn`
+regress = { version = "0.12" } # ECMAScript regex engine for testing `Restriction::Fn`
 vfs = "0.13.0" # for testing with in memory file system
 walkdir = "2" # for loading benchmark fixtures
 

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -24,7 +24,7 @@ oxc_resolver = { workspace = true }
 
 napi = { version = "3.8", default-features = false, features = ["napi3", "serde-json"] }
 napi-derive = { version = "3" }
-regress = { version = "0.11" } # ECMAScript regex engine for `Restriction` regex
+regress = { version = "0.12" } # ECMAScript regex engine for `Restriction` regex
 tracing-subscriber = { version = "0.3.23", optional = true, default-features = false, features = [
   "std",
   "fmt",


### PR DESCRIPTION
Updates regress to 0.12.0 and pnp to 0.12.12.

NAPI darwin-arm64 release size: 1,797,392 → 1,714,720 bytes (-82,672 bytes, -4.60%).